### PR TITLE
fix(client): propagate header errors instead of panicking

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -19,17 +19,19 @@ impl AlpacaClient {
         }
     }
 
-    fn auth_headers(&self) -> HeaderMap {
+    fn auth_headers(&self) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "APCA-API-KEY-ID",
-            HeaderValue::from_str(&self.config.key).unwrap(),
+            HeaderValue::from_str(&self.config.key)
+                .context("API key contains invalid header characters")?,
         );
         headers.insert(
             "APCA-API-SECRET-KEY",
-            HeaderValue::from_str(&self.config.secret).unwrap(),
+            HeaderValue::from_str(&self.config.secret)
+                .context("API secret contains invalid header characters")?,
         );
-        headers
+        Ok(headers)
     }
 
     fn url(&self, path: &str) -> String {
@@ -39,7 +41,7 @@ impl AlpacaClient {
     pub async fn get_account(&self) -> Result<AccountInfo> {
         self.http
             .get(self.url("/account"))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("GET /account request failed")?
@@ -51,7 +53,7 @@ impl AlpacaClient {
     pub async fn get_positions(&self) -> Result<Vec<Position>> {
         self.http
             .get(self.url("/positions"))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("GET /positions request failed")?
@@ -64,7 +66,7 @@ impl AlpacaClient {
         self.http
             .get(self.url("/orders"))
             .query(&[("status", status), ("limit", "100")])
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("GET /orders request failed")?
@@ -76,7 +78,7 @@ impl AlpacaClient {
     pub async fn submit_order(&self, req: &OrderRequest) -> Result<Order> {
         self.http
             .post(self.url("/orders"))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .json(req)
             .send()
             .await
@@ -89,7 +91,7 @@ impl AlpacaClient {
     pub async fn cancel_order(&self, id: &str) -> Result<()> {
         self.http
             .delete(self.url(&format!("/orders/{}", id)))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("DELETE /orders/{id} request failed")?;
@@ -99,7 +101,7 @@ impl AlpacaClient {
     pub async fn get_clock(&self) -> Result<MarketClock> {
         self.http
             .get(self.url("/clock"))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("GET /clock request failed")?
@@ -111,7 +113,7 @@ impl AlpacaClient {
     pub async fn list_watchlists(&self) -> Result<Vec<WatchlistSummary>> {
         self.http
             .get(self.url("/watchlists"))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("GET /watchlists request failed")?
@@ -123,7 +125,7 @@ impl AlpacaClient {
     pub async fn get_watchlist(&self, id: &str) -> Result<Watchlist> {
         self.http
             .get(self.url(&format!("/watchlists/{}", id)))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("GET /watchlists/{id} request failed")?
@@ -136,7 +138,7 @@ impl AlpacaClient {
         let body = serde_json::json!({ "symbol": symbol });
         self.http
             .post(self.url(&format!("/watchlists/{}", id)))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .json(&body)
             .send()
             .await
@@ -149,7 +151,7 @@ impl AlpacaClient {
     pub async fn remove_from_watchlist(&self, id: &str, symbol: &str) -> Result<Watchlist> {
         self.http
             .delete(self.url(&format!("/watchlists/{}/{}", id, symbol)))
-            .headers(self.auth_headers())
+            .headers(self.auth_headers()?)
             .send()
             .await
             .context("DELETE /watchlists/{id}/{symbol} request failed")?

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -64,6 +64,96 @@ fn watchlist_json(id: &str) -> serde_json::Value {
     })
 }
 
+// ── auth_headers – invalid credentials (regression for issue #5) ─────────────
+//
+// Before the fix, HeaderValue::from_str().unwrap() would panic on any key or
+// secret that contains non-ASCII, whitespace, or control characters.  Each
+// test below constructs a client with a bad credential and asserts that the
+// first call returns Err (with a descriptive message) rather than panicking.
+
+fn bad_key_config(base_url: String, key: &str) -> AlpacaConfig {
+    AlpacaConfig {
+        base_url,
+        key: key.into(),
+        secret: "good-secret".into(),
+        env: AlpacaEnv::Paper,
+    }
+}
+
+fn bad_secret_config(base_url: String, secret: &str) -> AlpacaConfig {
+    AlpacaConfig {
+        base_url,
+        key: "PKTEST000".into(),
+        secret: secret.into(),
+        env: AlpacaEnv::Paper,
+    }
+}
+
+#[tokio::test]
+async fn key_with_trailing_newline_returns_err_not_panic() {
+    // Trailing newline is the most common copy-paste mistake.
+    let client = AlpacaClient::new(bad_key_config("http://localhost".into(), "PKTEST\n"));
+    let result = client.get_account().await;
+    assert!(
+        result.is_err(),
+        "expected Err for key with trailing newline, got Ok"
+    );
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(
+        msg.contains("API key"),
+        "error message should mention 'API key', got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn secret_with_trailing_newline_returns_err_not_panic() {
+    let client = AlpacaClient::new(bad_secret_config(
+        "http://localhost".into(),
+        "mysecret\n",
+    ));
+    let result = client.get_account().await;
+    assert!(
+        result.is_err(),
+        "expected Err for secret with trailing newline, got Ok"
+    );
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(
+        msg.contains("API secret"),
+        "error message should mention 'API secret', got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn key_with_non_ascii_returns_err_not_panic() {
+    let client = AlpacaClient::new(bad_key_config("http://localhost".into(), "PK\u{00e9}TEST"));
+    let result = client.get_account().await;
+    assert!(
+        result.is_err(),
+        "expected Err for key with non-ASCII char, got Ok"
+    );
+}
+
+#[tokio::test]
+async fn key_with_control_character_returns_err_not_panic() {
+    // ASCII control character (DEL = 0x7f) is also invalid in an HTTP header.
+    let client = AlpacaClient::new(bad_key_config("http://localhost".into(), "PK\x7fTEST"));
+    let result = client.get_account().await;
+    assert!(
+        result.is_err(),
+        "expected Err for key with control character, got Ok"
+    );
+}
+
+#[tokio::test]
+async fn key_with_embedded_space_returns_err_not_panic() {
+    let client = AlpacaClient::new(bad_key_config("http://localhost".into(), "PK TEST 000"));
+    let result = client.get_account().await;
+    assert!(
+        result.is_err(),
+        "expected Err for key with embedded space, got Ok"
+    );
+}
+
 // ── Auth headers ──────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -107,10 +107,7 @@ async fn key_with_trailing_newline_returns_err_not_panic() {
 
 #[tokio::test]
 async fn secret_with_trailing_newline_returns_err_not_panic() {
-    let client = AlpacaClient::new(bad_secret_config(
-        "http://localhost".into(),
-        "mysecret\n",
-    ));
+    let client = AlpacaClient::new(bad_secret_config("http://localhost".into(), "mysecret\n"));
     let result = client.get_account().await;
     assert!(
         result.is_err(),


### PR DESCRIPTION
## Problem

`auth_headers()` called `.unwrap()` on `HeaderValue::from_str()`, crashing the process if the API key or secret contained non-ASCII, whitespace, or control characters (e.g. a trailing newline from copy-paste).

## Fix

Changed `auth_headers()` to return `anyhow::Result<HeaderMap>`. Each `HeaderValue::from_str()` call now uses `.context()` for a descriptive error message. All 10 call sites already return `Result`, so they propagate with `?` — turning a hard panic into a clear, recoverable error.

## Testing

All 101 existing tests pass (`cargo test`).

Closes #5