### PR TITLE
feat(input): implement mouse click handling for TUI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ratatui::layout::Rect;
+
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use super::*;
@@ -196,6 +198,25 @@ pub enum Modal {
     },
 }
 
+/// Screen areas of interactive elements, populated by the renderer each frame.
+/// Used by the mouse event handler to map click coordinates to actions.
+#[derive(Default, Clone, Debug)]
+pub struct HitAreas {
+    /// The tab bar row. Divided into 4 equal segments to identify which tab was clicked.
+    pub tab_bar: Rect,
+    /// Y coordinate of the first data row in the active list panel.
+    /// Accounts for block border + header rows. `0` means no active list.
+    pub list_data_start_y: u16,
+    /// Orders panel sub-tab bar. Divided into 3 equal segments (Open/Filled/Cancelled).
+    pub orders_subtab_bar: Option<Rect>,
+    /// OrderEntry modal: clickable field rows keyed by [`OrderField`].
+    pub modal_fields: Vec<(OrderField, Rect)>,
+    /// OrderEntry modal: submit button row.
+    pub modal_submit: Option<Rect>,
+    /// Confirm modal: button row (left half = Yes, right half = No).
+    pub modal_confirm_buttons: Option<Rect>,
+}
+
 pub struct App {
     pub config: AlpacaConfig,
     pub refresh_notify: Arc<Notify>,
@@ -222,6 +243,9 @@ pub struct App {
 
     pub status_msg: String,
     pub should_quit: bool,
+
+    /// Interactive element positions from the last rendered frame.
+    pub hit_areas: HitAreas,
 }
 
 impl App {
@@ -253,6 +277,7 @@ impl App {
             searching: false,
             status_msg: String::from("Loading…"),
             should_quit: false,
+            hit_areas: HitAreas::default(),
         }
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,10 +1,12 @@
 pub(crate) mod modal;
+pub(crate) mod mouse;
 pub(crate) mod orders;
 pub(crate) mod positions;
 pub(crate) mod search;
 pub(crate) mod watchlist;
 
 pub(crate) use modal::handle_modal_key;
+pub(crate) use mouse::handle_mouse;
 pub(crate) use orders::handle_orders_key;
 pub(crate) use positions::handle_positions_key;
 pub(crate) use search::handle_search_key;

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,0 +1,139 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+
+use crate::app::{App, Modal, OrderField, OrdersSubTab, Tab};
+
+/// Returns `true` if (`col`, `row`) is inside `rect`.
+fn hit(rect: Rect, col: u16, row: u16) -> bool {
+    col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
+}
+
+pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
+    if mouse.kind != MouseEventKind::Down(MouseButton::Left) {
+        return;
+    }
+
+    let col = mouse.column;
+    let row = mouse.row;
+
+    // Modals have exclusive input priority.
+    if app.modal.is_some() {
+        handle_modal_mouse(app, col, row);
+        return;
+    }
+
+    // ── Tab bar ──────────────────────────────────────────────────────────────
+    let tab_bar = app.hit_areas.tab_bar;
+    if hit(tab_bar, col, row) && tab_bar.width >= 4 {
+        let tab_w = tab_bar.width / 4;
+        let idx = ((col - tab_bar.x) / tab_w).min(3) as usize;
+        app.active_tab = Tab::from_index(idx);
+        return;
+    }
+
+    // ── Orders sub-tab bar ───────────────────────────────────────────────────
+    if let Some(subtab_rect) = app.hit_areas.orders_subtab_bar {
+        if hit(subtab_rect, col, row) && app.active_tab == Tab::Orders && subtab_rect.width >= 3 {
+            let tab_w = subtab_rect.width / 3;
+            let idx = ((col - subtab_rect.x) / tab_w).min(2);
+            app.orders_subtab = match idx {
+                0 => OrdersSubTab::Open,
+                1 => OrdersSubTab::Filled,
+                _ => OrdersSubTab::Cancelled,
+            };
+            app.orders_state.select(Some(0));
+            return;
+        }
+    }
+
+    // ── List row ─────────────────────────────────────────────────────────────
+    let start_y = app.hit_areas.list_data_start_y;
+    if start_y > 0 && row >= start_y {
+        let data_row = (row - start_y) as usize;
+        let offset = match app.active_tab {
+            Tab::Watchlist => app.watchlist_state.offset(),
+            Tab::Positions => app.positions_state.offset(),
+            Tab::Orders => app.orders_state.offset(),
+            Tab::Account => return,
+        };
+        let idx = data_row + offset;
+        match app.active_tab {
+            Tab::Watchlist => {
+                let len = app.watchlist.as_ref().map(|w| w.assets.len()).unwrap_or(0);
+                if idx < len {
+                    app.watchlist_state.select(Some(idx));
+                }
+            }
+            Tab::Positions => {
+                if idx < app.positions.len() {
+                    app.positions_state.select(Some(idx));
+                }
+            }
+            Tab::Orders => {
+                let len = app.filtered_orders().len();
+                if idx < len {
+                    app.orders_state.select(Some(idx));
+                }
+            }
+            Tab::Account => {}
+        }
+    }
+}
+
+fn handle_modal_mouse(app: &mut App, col: u16, row: u16) {
+    // ── OrderEntry: submit button ─────────────────────────────────────────────
+    if let Some(submit_rect) = app.hit_areas.modal_submit {
+        if hit(submit_rect, col, row) {
+            if let Some(Modal::OrderEntry(ref mut state)) = app.modal {
+                state.focused_field = OrderField::Submit;
+            }
+            crate::input::handle_modal_key(app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+            return;
+        }
+    }
+
+    // ── OrderEntry: field focus + radio button toggles ────────────────────────
+    let clicked = app
+        .hit_areas
+        .modal_fields
+        .iter()
+        .find(|(_, rect)| hit(*rect, col, row))
+        .map(|(field, rect)| (field.clone(), *rect));
+
+    if let Some((field, rect)) = clicked {
+        match field {
+            OrderField::Side => {
+                if let Some(Modal::OrderEntry(ref mut state)) = app.modal {
+                    state.focused_field = OrderField::Side;
+                    // Left half of the row → BUY, right half → SELL.
+                    state.side_buy = col < rect.x + rect.width / 2;
+                }
+            }
+            OrderField::OrderType => {
+                if let Some(Modal::OrderEntry(ref mut state)) = app.modal {
+                    state.focused_field = OrderField::OrderType;
+                    // Left half → LIMIT, right half → MARKET.
+                    state.market_order = col >= rect.x + rect.width / 2;
+                }
+            }
+            other => {
+                if let Some(Modal::OrderEntry(ref mut state)) = app.modal {
+                    state.focused_field = other;
+                }
+            }
+        }
+        return;
+    }
+
+    // ── Confirm: yes / no buttons ─────────────────────────────────────────────
+    if let Some(btn_rect) = app.hit_areas.modal_confirm_buttons {
+        if hit(btn_rect, col, row) {
+            let code = if col < btn_rect.x + btn_rect.width / 2 {
+                KeyCode::Char('y')
+            } else {
+                KeyCode::Char('n')
+            };
+            crate::input::handle_modal_key(app, KeyEvent::new(code, KeyModifiers::NONE));
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,9 +11,12 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, Tab};
+use crate::app::{App, HitAreas, Tab};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
+    // Reset hit areas at the start of each frame so stale rects are never used.
+    app.hit_areas = HitAreas::default();
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -24,14 +27,28 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         ])
         .split(frame.area());
 
+    app.hit_areas.tab_bar = chunks[1];
+
     dashboard::render_header(frame, chunks[0], app);
     dashboard::render_tabs(frame, chunks[1], app);
 
     match app.active_tab {
         Tab::Account => account::render(frame, chunks[2], app),
-        Tab::Watchlist => watchlist::render(frame, chunks[2], app),
-        Tab::Positions => positions::render(frame, chunks[2], app),
-        Tab::Orders => orders::render(frame, chunks[2], app),
+        Tab::Watchlist => {
+            // Data rows begin after top border (1) + header row (1)
+            app.hit_areas.list_data_start_y = chunks[2].y + 2;
+            watchlist::render(frame, chunks[2], app);
+        }
+        Tab::Positions => {
+            app.hit_areas.list_data_start_y = chunks[2].y + 2;
+            positions::render(frame, chunks[2], app);
+        }
+        Tab::Orders => {
+            // Orders has a 1-row sub-tab bar, then the table block.
+            // Data rows begin after sub-tab bar (1) + top border (1) + header row (1).
+            app.hit_areas.list_data_start_y = chunks[2].y + 3;
+            orders::render(frame, chunks[2], app);
+        }
     }
 
     dashboard::render_status(frame, chunks[3], app);

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use crate::app::{App, ConfirmAction, Modal, OrderEntryState, OrderField};
 use crate::ui::{popup_area, theme};
 
-pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &App) {
+pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
     match modal {
         Modal::Help => render_help(frame, area),
         Modal::OrderEntry(state) => render_order_entry(frame, area, state, app),
@@ -18,7 +18,7 @@ pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &App) {
             message,
             action,
             confirmed,
-        } => render_confirm(frame, area, message, action, *confirmed),
+        } => render_confirm(frame, area, message, action, *confirmed, app),
         Modal::AddSymbol { input, .. } => render_add_symbol(frame, area, input),
     }
 }
@@ -101,7 +101,7 @@ fn render_help(frame: &mut Frame, area: Rect) {
     frame.render_widget(footer, footer_area);
 }
 
-fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, app: &App) {
+fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, app: &mut App) {
     let popup = popup_area(area, 45, 60);
     frame.render_widget(Clear, popup);
 
@@ -131,6 +131,16 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
             Constraint::Length(1), // hint
         ])
         .split(inner);
+
+    // Populate hit areas for mouse click handling
+    app.hit_areas.modal_fields = vec![
+        (OrderField::Symbol, chunks[0]),
+        (OrderField::Side, chunks[2]),
+        (OrderField::OrderType, chunks[3]),
+        (OrderField::Qty, chunks[4]),
+        (OrderField::Price, chunks[5]),
+    ];
+    app.hit_areas.modal_submit = Some(chunks[10]);
 
     let focused = |field: &OrderField| *field == state.focused_field;
 
@@ -374,6 +384,7 @@ fn render_confirm(
     message: &str,
     _action: &ConfirmAction,
     confirmed: bool,
+    app: &mut App,
 ) {
     let popup = popup_area(area, 40, 25);
     frame.render_widget(Clear, popup);
@@ -395,6 +406,9 @@ fn render_confirm(
             Constraint::Length(1),
         ])
         .split(inner);
+
+    // Store button row for mouse hit-testing (left = Yes, right = No)
+    app.hit_areas.modal_confirm_buttons = Some(chunks[2]);
 
     frame.render_widget(
         Paragraph::new(format!("  {}", message)).style(theme::style_bold()),

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -14,6 +14,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         .constraints([Constraint::Length(1), Constraint::Min(1)])
         .split(area);
 
+    app.hit_areas.orders_subtab_bar = Some(chunks[0]);
     render_subtabs(frame, chunks[0], app);
     render_table(frame, chunks[1], app);
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,14 +3,14 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use crate::app::{App, Modal, Tab};
 use crate::events::Event;
 use crate::input::{
-    handle_modal_key, handle_orders_key, handle_positions_key, handle_search_key,
+    handle_modal_key, handle_mouse, handle_orders_key, handle_positions_key, handle_search_key,
     handle_watchlist_key,
 };
 
 pub fn update(app: &mut App, event: Event) {
     match event {
         Event::Input(key) => handle_key(app, key),
-        Event::Mouse(_) => {}
+        Event::Mouse(m) => handle_mouse(app, m),
         Event::Resize(_, _) => {}
 
         Event::AccountUpdated(a) => {
@@ -108,7 +108,10 @@ mod tests {
     use crate::commands::Command;
     use crate::events::Event;
     use crate::types::{AccountInfo, MarketClock, Order, Quote};
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    };
+    use ratatui::layout::Rect;
 
     fn key(code: KeyCode) -> Event {
         Event::Input(KeyEvent::new(code, KeyModifiers::NONE))
@@ -116,6 +119,33 @@ mod tests {
 
     fn ctrl(code: KeyCode) -> Event {
         Event::Input(KeyEvent::new(code, KeyModifiers::CONTROL))
+    }
+
+    fn mouse_click(col: u16, row: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        })
+    }
+
+    fn mouse_move(col: u16, row: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        })
+    }
+
+    fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
     }
 
     // ── Data events ───────────────────────────────────────────────────────────
@@ -752,6 +782,82 @@ mod tests {
             app.status_msg, "System busy — please retry",
             "full channel should show busy message"
         );
+    }
+
+    #[test]
+    fn mouse_click_tab_bar_switches_tab() {
+        let (mut app, _rx) = app_with_capacity(4);
+        // Tab bar: full width 80, 4 tabs of 20 cols each, at row 2
+        // Tabs: 0=Account, 1=Watchlist, 2=Positions, 3=Orders
+        app.hit_areas.tab_bar = rect(0, 2, 80, 1);
+        assert_eq!(app.active_tab, Tab::Account);
+
+        // Click in second tab (col 20..39 → Watchlist)
+        update(&mut app, mouse_click(25, 2));
+        assert_eq!(app.active_tab, Tab::Watchlist);
+
+        // Click in third tab (col 40..59 → Positions)
+        update(&mut app, mouse_click(45, 2));
+        assert_eq!(app.active_tab, Tab::Positions);
+    }
+
+    #[test]
+    fn mouse_non_left_click_ignored() {
+        let (mut app, _rx) = app_with_capacity(4);
+        app.hit_areas.tab_bar = rect(0, 2, 80, 1);
+        app.active_tab = Tab::Watchlist;
+        // MouseMove event — must not switch tab
+        update(&mut app, mouse_move(25, 2));
+        assert_eq!(app.active_tab, Tab::Watchlist);
+    }
+
+    #[test]
+    fn mouse_click_orders_subtab() {
+        let (mut app, _rx) = app_with_capacity(4);
+        app.active_tab = Tab::Orders;
+        // Subtab bar: 60 wide → each slot ~20 cols (Open / Filled / Cancelled)
+        app.hit_areas.orders_subtab_bar = Some(rect(0, 5, 60, 1));
+        assert_eq!(app.orders_subtab, OrdersSubTab::Open);
+
+        // Click second subtab (col 20 → Filled)
+        update(&mut app, mouse_click(20, 5));
+        assert_eq!(app.orders_subtab, OrdersSubTab::Filled);
+
+        // Click third subtab (col 40 → Cancelled)
+        update(&mut app, mouse_click(40, 5));
+        assert_eq!(app.orders_subtab, OrdersSubTab::Cancelled);
+    }
+
+    #[test]
+    fn mouse_click_list_row_selects_item() {
+        use crate::types::{Asset, Watchlist};
+
+        let (mut app, _rx) = app_with_capacity(4);
+        let make_asset = |sym: &str| Asset {
+            id: sym.to_string(),
+            symbol: sym.to_string(),
+            name: sym.to_string(),
+            exchange: "NASDAQ".to_string(),
+            asset_class: "us_equity".to_string(),
+            tradable: true,
+            shortable: false,
+            fractionable: false,
+            easy_to_borrow: false,
+        };
+        app.watchlist = Some(Watchlist {
+            id: "wl1".to_string(),
+            name: "Test".to_string(),
+            assets: vec![make_asset("AAPL"), make_asset("GOOG")],
+        });
+        app.watchlist_state.select(Some(0));
+        app.active_tab = Tab::Watchlist;
+
+        // List data starts at row 10 (border + header already accounted for)
+        app.hit_areas.list_data_start_y = 10;
+
+        // Click on row 11 → data_row 1 → idx 1 → selects second asset
+        update(&mut app, mouse_click(5, 11));
+        assert_eq!(app.watchlist_state.selected(), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements mouse click handling as described in #9.

### Changes

- **`src/app.rs`** — Add `HitAreas` struct with fields for tab bar, list data start Y, orders sub-tab bar, modal fields, submit button, and confirm buttons; add `hit_areas: HitAreas` to `App`
- **`src/ui/mod.rs`** — Reset and populate `app.hit_areas` each frame; compute `list_data_start_y` with correct offsets per panel
- **`src/ui/orders.rs`** — Store `orders_subtab_bar` rect before rendering sub-tabs
- **`src/ui/modals.rs`** — Change `render_order_entry` and `render_confirm` to `&mut App`; populate modal field rects, submit button, and confirm button hit areas during rendering
- **`src/input/mouse.rs`** *(new)* — `handle_mouse()` dispatches left-click events: tab bar → switch tab, orders sub-tab bar → switch sub-tab, list row → select item, modal open → `handle_modal_mouse()` which handles field focus, radio toggles (Side/OrderType), submit, and confirm yes/no
- **`src/input/mod.rs`** — Export `mouse` module and `handle_mouse`
- **`src/update.rs`** — Wire `Event::Mouse(m) => handle_mouse(app, m)`; add 4 unit tests for mouse click behaviour

Closes #9