### PR TITLE
feat(input): add order entry validation before submit

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod mouse;
 pub(crate) mod orders;
 pub(crate) mod positions;
 pub(crate) mod search;
+pub(crate) mod validation;
 pub(crate) mod watchlist;
 
 pub(crate) use modal::handle_modal_key;
@@ -10,6 +11,7 @@ pub(crate) use mouse::handle_mouse;
 pub(crate) use orders::handle_orders_key;
 pub(crate) use positions::handle_positions_key;
 pub(crate) use search::handle_search_key;
+pub(crate) use validation::validate;
 pub(crate) use watchlist::handle_watchlist_key;
 
 use tokio::sync::mpsc::error::TrySendError;

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -65,6 +65,16 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 },
                 KeyCode::Enter => {
                     if state.focused_field == OrderField::Submit {
+                        let buying_power = app
+                            .account
+                            .as_ref()
+                            .and_then(|a| a.buying_power.parse::<f64>().ok())
+                            .unwrap_or(0.0);
+                        if let Some(err) = crate::input::validate(&state, buying_power) {
+                            app.status_msg = err;
+                            app.modal = Some(Modal::OrderEntry(state));
+                            return;
+                        }
                         send_command(
                             app,
                             Command::SubmitOrder {

--- a/src/input/validation.rs
+++ b/src/input/validation.rs
@@ -1,0 +1,170 @@
+use crate::app::OrderEntryState;
+
+/// Validates an [`OrderEntryState`] before a submit command is dispatched.
+///
+/// Returns `None` when the state is valid, or `Some(error_message)` describing
+/// the first validation failure encountered.
+pub(crate) fn validate(state: &OrderEntryState, buying_power: f64) -> Option<String> {
+    // 1. Symbol must be non-empty.
+    if state.symbol.trim().is_empty() {
+        return Some("Symbol cannot be empty".into());
+    }
+
+    // 2. Quantity must be a positive number (if provided; an empty qty means
+    //    notional dollar amount, which requires a non-empty price instead).
+    let qty: Option<f64> = if state.qty_input.is_empty() {
+        None
+    } else {
+        match state.qty_input.parse::<f64>() {
+            Ok(v) if v > 0.0 => Some(v),
+            Ok(_) => return Some("Quantity must be greater than zero".into()),
+            Err(_) => return Some("Quantity is not a valid number".into()),
+        }
+    };
+
+    // 3. Price must be a positive number on LIMIT orders.
+    let price: Option<f64> = if state.market_order {
+        None
+    } else {
+        match state.price_input.parse::<f64>() {
+            Ok(v) if v > 0.0 => Some(v),
+            Ok(_) => return Some("Price must be greater than zero".into()),
+            Err(_) => return Some("Price is not a valid number for a LIMIT order".into()),
+        }
+    };
+
+    // 4. Estimated total must not exceed buying power.
+    //    est_total = qty * price (LIMIT) or qty alone can't be checked for MARKET;
+    //    we only gate when we have both values.
+    if let (Some(q), Some(p)) = (qty, price) {
+        let est_total = q * p;
+        if est_total > buying_power {
+            return Some(format!(
+                "Order total ${:.2} exceeds buying power ${:.2}",
+                est_total, buying_power
+            ));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::OrderEntryState;
+
+    fn base_state() -> OrderEntryState {
+        let mut s = OrderEntryState::new("AAPL".into());
+        s.market_order = false; // LIMIT
+        s.qty_input = "10".into();
+        s.price_input = "150.00".into();
+        s
+    }
+
+    #[test]
+    fn valid_limit_order_returns_none() {
+        let state = base_state();
+        assert_eq!(validate(&state, 10_000.0), None);
+    }
+
+    #[test]
+    fn valid_market_order_returns_none() {
+        let mut state = base_state();
+        state.market_order = true;
+        state.price_input.clear(); // price not required for MARKET
+        assert_eq!(validate(&state, 10_000.0), None);
+    }
+
+    #[test]
+    fn empty_symbol_fails() {
+        let mut state = base_state();
+        state.symbol.clear();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn whitespace_only_symbol_fails() {
+        let mut state = base_state();
+        state.symbol = "   ".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn zero_qty_fails() {
+        let mut state = base_state();
+        state.qty_input = "0".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn negative_qty_fails() {
+        let mut state = base_state();
+        state.qty_input = "-5".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn non_numeric_qty_fails() {
+        let mut state = base_state();
+        state.qty_input = "abc".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn empty_qty_is_allowed_as_notional() {
+        let mut state = base_state();
+        state.qty_input.clear(); // notional; price still required for LIMIT
+                                 // price is set and positive → should pass
+        assert_eq!(validate(&state, 10_000.0), None);
+    }
+
+    #[test]
+    fn zero_price_on_limit_fails() {
+        let mut state = base_state();
+        state.price_input = "0".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn negative_price_on_limit_fails() {
+        let mut state = base_state();
+        state.price_input = "-1.0".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn non_numeric_price_on_limit_fails() {
+        let mut state = base_state();
+        state.price_input = "abc".into();
+        assert!(validate(&state, 10_000.0).is_some());
+    }
+
+    #[test]
+    fn price_not_required_for_market_order() {
+        let mut state = base_state();
+        state.market_order = true;
+        state.price_input = "not-a-number".into(); // ignored for MARKET
+        assert_eq!(validate(&state, 10_000.0), None);
+    }
+
+    #[test]
+    fn total_exceeding_buying_power_fails() {
+        let state = base_state(); // 10 shares × $150 = $1500
+        assert!(validate(&state, 1_000.0).is_some());
+    }
+
+    #[test]
+    fn total_exactly_at_buying_power_passes() {
+        let state = base_state(); // 10 × 150 = 1500
+        assert_eq!(validate(&state, 1_500.0), None);
+    }
+
+    #[test]
+    fn error_message_contains_amounts_when_exceeding_buying_power() {
+        let state = base_state(); // 10 × 150 = $1500
+        let msg = validate(&state, 500.0).expect("should fail");
+        assert!(msg.contains("1500.00"), "got: {msg}");
+        assert!(msg.contains("500.00"), "got: {msg}");
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -599,7 +599,12 @@ mod tests {
     #[test]
     fn order_entry_submit_sends_submit_order_command() {
         use crate::app::{OrderEntryState, OrderField};
+        use crate::types::AccountInfo;
         let (mut app, mut cmd_rx) = app_with_rx();
+        app.account = Some(AccountInfo {
+            buying_power: "100000".into(),
+            ..Default::default()
+        });
         let mut state = OrderEntryState::new("AAPL".into());
         state.focused_field = OrderField::Submit;
         state.qty_input = "10".into();
@@ -620,7 +625,12 @@ mod tests {
     #[test]
     fn order_entry_submit_market_order_omits_price() {
         use crate::app::{OrderEntryState, OrderField};
+        use crate::types::AccountInfo;
         let (mut app, mut cmd_rx) = app_with_rx();
+        app.account = Some(AccountInfo {
+            buying_power: "100000".into(),
+            ..Default::default()
+        });
         let mut state = OrderEntryState::new("TSLA".into());
         state.focused_field = OrderField::Submit;
         state.market_order = true;
@@ -772,9 +782,15 @@ mod tests {
 
         // Now trigger another command via update() — should hit TrySendError::Full
         use crate::app::{OrderEntryState, OrderField};
+        use crate::types::AccountInfo;
+        app.account = Some(AccountInfo {
+            buying_power: "100000".into(),
+            ..Default::default()
+        });
         let mut state = OrderEntryState::new("AAPL".into());
         state.focused_field = OrderField::Submit;
         state.qty_input = "1".into();
+        state.price_input = "100.00".into();
         app.modal = Some(Modal::OrderEntry(state));
         update(&mut app, key(KeyCode::Enter));
 
@@ -867,9 +883,15 @@ mod tests {
         drop(rx);
 
         use crate::app::{OrderEntryState, OrderField};
+        use crate::types::AccountInfo;
+        app.account = Some(AccountInfo {
+            buying_power: "100000".into(),
+            ..Default::default()
+        });
         let mut state = OrderEntryState::new("AAPL".into());
         state.focused_field = OrderField::Submit;
         state.qty_input = "1".into();
+        state.price_input = "100.00".into();
         app.modal = Some(Modal::OrderEntry(state));
         update(&mut app, key(KeyCode::Enter));
 
@@ -877,5 +899,96 @@ mod tests {
             app.status_msg, "Command handler stopped — restart app",
             "closed channel should show stopped message"
         );
+    }
+
+    // ── Validation gate tests ─────────────────────────────────────────────────
+
+    fn order_entry_submit_state(symbol: &str) -> crate::app::OrderEntryState {
+        use crate::app::{OrderEntryState, OrderField};
+        let mut s = OrderEntryState::new(symbol.into());
+        s.focused_field = OrderField::Submit;
+        s.market_order = false;
+        s.qty_input = "10".into();
+        s.price_input = "100.00".into();
+        s
+    }
+
+    #[test]
+    fn validation_empty_symbol_keeps_modal_open() {
+        let (mut app, _rx) = app_with_capacity(4);
+        let mut state = order_entry_submit_state("");
+        state.symbol.clear();
+        app.modal = Some(Modal::OrderEntry(state));
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(
+            app.modal.is_some(),
+            "modal must stay open on validation failure"
+        );
+        assert!(
+            !app.status_msg.is_empty(),
+            "status_msg must contain error text"
+        );
+    }
+
+    #[test]
+    fn validation_zero_qty_keeps_modal_open() {
+        let (mut app, _rx) = app_with_capacity(4);
+        let mut state = order_entry_submit_state("AAPL");
+        state.qty_input = "0".into();
+        app.modal = Some(Modal::OrderEntry(state));
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(app.modal.is_some());
+        assert!(!app.status_msg.is_empty());
+    }
+
+    #[test]
+    fn validation_non_numeric_price_on_limit_keeps_modal_open() {
+        let (mut app, _rx) = app_with_capacity(4);
+        let mut state = order_entry_submit_state("AAPL");
+        state.price_input = "bad".into();
+        app.modal = Some(Modal::OrderEntry(state));
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(app.modal.is_some());
+        assert!(!app.status_msg.is_empty());
+    }
+
+    #[test]
+    fn validation_exceeds_buying_power_keeps_modal_open() {
+        use crate::types::AccountInfo;
+        let (mut app, _rx) = app_with_capacity(4);
+        app.account = Some(AccountInfo {
+            buying_power: "500".into(), // 10 × 100 = 1000 > 500
+            ..Default::default()
+        });
+        let state = order_entry_submit_state("AAPL");
+        app.modal = Some(Modal::OrderEntry(state));
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(app.modal.is_some());
+        assert!(!app.status_msg.is_empty());
+    }
+
+    #[test]
+    fn validation_pass_sends_command_and_closes_modal() {
+        use crate::types::AccountInfo;
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.account = Some(AccountInfo {
+            buying_power: "100000".into(),
+            ..Default::default()
+        });
+        let state = order_entry_submit_state("AAPL");
+        app.modal = Some(Modal::OrderEntry(state));
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(app.modal.is_none(), "modal should close on valid submit");
+        cmd_rx.try_recv().expect("command should be sent");
     }
 }


### PR DESCRIPTION
## Summary

Implements order entry validation as described in #10.

### Changes

- **`src/input/validation.rs`** *(new)* — `validate(state, buying_power) -> Option<String>` with four checks:
  - Symbol non-empty (trimmed)
  - Qty parses to positive f64 if provided (empty = notional, allowed)
  - Price parses to positive f64 on LIMIT orders
  - Estimated total (qty × price) does not exceed buying power
- **`src/input/modal.rs`** — Before dispatching `Command::SubmitOrder`, call `validate()`; on failure set `app.status_msg` and keep modal open
- **`src/input/mod.rs`** — Added `pub(crate) mod validation` + `pub(crate) use validation::validate`
- **`src/update.rs`** — Updated 3 existing submit tests to supply `buying_power` and `price_input`; added 5 new integration tests for validation gate

### Tests

- 15 unit tests in `validation.rs` covering all branches
- 5 integration tests in `update.rs` verifying modal stays open / closes on valid submit

Closes #10