### PR TITLE
fix(input): correct Orders sub-tab bar mouse click hit-test

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -202,13 +202,14 @@ pub enum Modal {
 /// Used by the mouse event handler to map click coordinates to actions.
 #[derive(Default, Clone, Debug)]
 pub struct HitAreas {
-    /// The tab bar row. Divided into 4 equal segments to identify which tab was clicked.
+    /// The tab bar row. Each tab's exact rect is computed from label widths at hit-test time.
     pub tab_bar: Rect,
     /// Y coordinate of the first data row in the active list panel.
     /// Accounts for block border + header rows. `0` means no active list.
     pub list_data_start_y: u16,
-    /// Orders panel sub-tab bar. Divided into 3 equal segments (Open/Filled/Cancelled).
-    pub orders_subtab_bar: Option<Rect>,
+    /// Orders panel sub-tab rects, one per sub-tab (Open / Filled / Cancelled), computed from
+    /// the actual rendered label widths during each frame so dynamic counts are accounted for.
+    pub orders_subtab_rects: Vec<Rect>,
     /// OrderEntry modal: clickable field rows keyed by [`OrderField`].
     pub modal_fields: Vec<(OrderField, Rect)>,
     /// OrderEntry modal: submit button row.

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -60,17 +60,17 @@ pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
     }
 
     // ── Orders sub-tab bar ───────────────────────────────────────────────────
-    if let Some(subtab_rect) = app.hit_areas.orders_subtab_bar {
-        if hit(subtab_rect, col, row) && app.active_tab == Tab::Orders && subtab_rect.width >= 3 {
-            let tab_w = subtab_rect.width / 3;
-            let idx = ((col - subtab_rect.x) / tab_w).min(2);
-            app.orders_subtab = match idx {
-                0 => OrdersSubTab::Open,
-                1 => OrdersSubTab::Filled,
-                _ => OrdersSubTab::Cancelled,
-            };
-            app.orders_state.select(Some(0));
-            return;
+    if app.active_tab == Tab::Orders && !app.hit_areas.orders_subtab_rects.is_empty() {
+        for (idx, rect) in app.hit_areas.orders_subtab_rects.clone().iter().enumerate() {
+            if hit(*rect, col, row) {
+                app.orders_subtab = match idx {
+                    0 => OrdersSubTab::Open,
+                    1 => OrdersSubTab::Filled,
+                    _ => OrdersSubTab::Cancelled,
+                };
+                app.orders_state.select(Some(0));
+                return;
+            }
         }
     }
 

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -14,12 +14,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         .constraints([Constraint::Length(1), Constraint::Min(1)])
         .split(area);
 
-    app.hit_areas.orders_subtab_bar = Some(chunks[0]);
+    app.hit_areas.orders_subtab_rects.clear();
     render_subtabs(frame, chunks[0], app);
     render_table(frame, chunks[1], app);
 }
 
-fn render_subtabs(frame: &mut Frame, area: Rect, app: &App) {
+fn render_subtabs(frame: &mut Frame, area: Rect, app: &mut App) {
     let open_count = app
         .orders
         .iter()
@@ -47,6 +47,26 @@ fn render_subtabs(frame: &mut Frame, area: Rect, app: &App) {
         format!("2:Filled ({})", filled_count),
         format!("3:Cancelled ({})", cancelled_count),
     ];
+
+    // Compute exact per-subtab rects from actual label widths so mouse hit-testing
+    // maps clicks to the correct subtab regardless of dynamic order counts.
+    // ratatui Tabs renders each title as ` <label> ` (label.len()+2) with `|` dividers.
+    let mut x = area.x;
+    for (i, title) in titles.iter().enumerate() {
+        let w = title.len() as u16 + 2;
+        app.hit_areas
+            .orders_subtab_rects
+            .push(ratatui::layout::Rect {
+                x,
+                y: area.y,
+                width: w,
+                height: 1,
+            });
+        x += w;
+        if i + 1 < titles.len() {
+            x += 1; // `|` divider
+        }
+    }
 
     let selected = match app.orders_subtab {
         OrdersSubTab::Open => 0,

--- a/src/update.rs
+++ b/src/update.rs
@@ -846,17 +846,28 @@ mod tests {
     fn mouse_click_orders_subtab() {
         let (mut app, _rx) = app_with_capacity(4);
         app.active_tab = Tab::Orders;
-        // Subtab bar: 60 wide → each slot ~20 cols (Open / Filled / Cancelled)
-        app.hit_areas.orders_subtab_bar = Some(rect(0, 5, 60, 1));
+        // Simulate per-subtab rects as rendered from actual label widths (0 orders each):
+        //   "1:Open (0)"      → len=10 → width=12, x=0
+        //   "2:Filled (0)"    → len=12 → width=14, x=13 (12 + 1 divider)
+        //   "3:Cancelled (0)" → len=15 → width=17, x=28 (13 + 14 + 1 divider)
+        app.hit_areas.orders_subtab_rects = vec![
+            rect(0, 5, 12, 1),  // Open
+            rect(13, 5, 14, 1), // Filled
+            rect(28, 5, 17, 1), // Cancelled
+        ];
         assert_eq!(app.orders_subtab, OrdersSubTab::Open);
 
-        // Click second subtab (col 20 → Filled)
-        update(&mut app, mouse_click(20, 5));
+        // Click within Filled subtab rect
+        update(&mut app, mouse_click(13, 5));
         assert_eq!(app.orders_subtab, OrdersSubTab::Filled);
 
-        // Click third subtab (col 40 → Cancelled)
-        update(&mut app, mouse_click(40, 5));
+        // Click within Cancelled subtab rect
+        update(&mut app, mouse_click(28, 5));
         assert_eq!(app.orders_subtab, OrdersSubTab::Cancelled);
+
+        // Click back within Open subtab rect
+        update(&mut app, mouse_click(0, 5));
+        assert_eq!(app.orders_subtab, OrdersSubTab::Open);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the equal-division bug in the Orders sub-tab bar mouse hit-test introduced with issue #9.

### Root Cause
The previous implementation divided the sub-tab bar width equally by 3 (`width / 3`) to determine which sub-tab was clicked. Since ratatui's `Tabs` widget renders each tab as ` <label> ` (label + 2 spaces) with `|` dividers — not equally spaced — and the Orders sub-tab labels include dynamic order counts (e.g., `"2:Filled (12)"`), clicking any sub-tab besides the first would resolve to the wrong tab.

### Fix
- Replaced `HitAreas.orders_subtab_bar: Option<Rect>` with `orders_subtab_rects: Vec<Rect>`
- `render_subtabs()` now computes exact per-subtab rects from actual formatted label lengths during each render frame, so dynamic counts are always reflected accurately
- `handle_mouse()` iterates those rects using `hit()` for precise hit-testing
- Updated `mouse_click_orders_subtab` test to use exact column coordinates

Closes #28