### PR TITLE
feat(app): auto-dismiss transient status messages after 3 s

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,81 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use ratatui::layout::Rect;
+
+const STATUS_MSG_TTL: Duration = Duration::from_secs(3);
+
+/// A status bar message that may auto-expire.
+///
+/// Transient messages (e.g. "Order submitted", "Refreshing…") carry a 3-second TTL and are
+/// cleared automatically on the next `Tick` after they expire. Persistent messages (errors,
+/// "Loading…") set `expires_at = None` so they stay until replaced.
+#[derive(Clone, Debug)]
+pub struct StatusMessage {
+    pub text: String,
+    pub expires_at: Option<Instant>,
+}
+
+impl StatusMessage {
+    /// Creates a transient message that auto-dismisses after 3 seconds.
+    pub fn transient(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            expires_at: Some(Instant::now() + STATUS_MSG_TTL),
+        }
+    }
+
+    /// Creates a persistent message that stays until explicitly replaced.
+    pub fn persistent(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            expires_at: None,
+        }
+    }
+
+    /// Returns `true` if the message text is empty (nothing to display).
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    /// Clears the message text and removes any expiry.
+    pub fn clear(&mut self) {
+        self.text.clear();
+        self.expires_at = None;
+    }
+}
+
+impl Default for StatusMessage {
+    fn default() -> Self {
+        Self::persistent("")
+    }
+}
+
+/// Allow `PartialEq` comparisons against string literals in tests.
+impl PartialEq<str> for StatusMessage {
+    fn eq(&self, other: &str) -> bool {
+        self.text == other
+    }
+}
+
+impl PartialEq<&str> for StatusMessage {
+    fn eq(&self, other: &&str) -> bool {
+        self.text == *other
+    }
+}
+
+impl PartialEq<String> for StatusMessage {
+    fn eq(&self, other: &String) -> bool {
+        self.text == *other
+    }
+}
+
+impl PartialEq<StatusMessage> for StatusMessage {
+    fn eq(&self, other: &StatusMessage) -> bool {
+        self.text == other.text
+    }
+}
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
@@ -242,7 +316,7 @@ pub struct App {
     pub search_query: String,
     pub searching: bool,
 
-    pub status_msg: String,
+    pub status_msg: StatusMessage,
     pub should_quit: bool,
 
     /// Interactive element positions from the last rendered frame.
@@ -276,7 +350,7 @@ impl App {
             modal: None,
             search_query: String::new(),
             searching: false,
-            status_msg: String::from("Loading…"),
+            status_msg: StatusMessage::persistent("Loading…"),
             should_quit: false,
             hit_areas: HitAreas::default(),
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -16,23 +16,23 @@ pub(crate) use watchlist::handle_watchlist_key;
 
 use tokio::sync::mpsc::error::TrySendError;
 
-use crate::app::App;
+use crate::app::{App, StatusMessage};
 use crate::commands::Command;
 
 /// Send a command on the command channel and set the appropriate status message.
 ///
-/// - Success → `success_msg`
-/// - Channel full → "System busy — please retry"
-/// - Channel closed → "Command handler stopped — restart app" (+ error log)
+/// - Success → `success_msg` (transient, auto-dismissed after 3 s)
+/// - Channel full → "System busy — please retry" (transient)
+/// - Channel closed → "Command handler stopped — restart app" (persistent error)
 pub(crate) fn send_command(app: &mut App, cmd: Command, success_msg: impl Into<String>) {
     match app.command_tx.try_send(cmd) {
-        Ok(()) => app.status_msg = success_msg.into(),
+        Ok(()) => app.status_msg = StatusMessage::transient(success_msg),
         Err(TrySendError::Full(_)) => {
-            app.status_msg = "System busy — please retry".into();
+            app.status_msg = StatusMessage::transient("System busy — please retry");
         }
         Err(TrySendError::Closed(_)) => {
             tracing::error!("command channel closed; command handler has stopped");
-            app.status_msg = "Command handler stopped — restart app".into();
+            app.status_msg = StatusMessage::persistent("Command handler stopped — restart app");
         }
     }
 }

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -1,7 +1,7 @@
 use crossterm::event::KeyCode;
 
 use super::send_command;
-use crate::app::{App, ConfirmAction, Modal, OrderField};
+use crate::app::{App, ConfirmAction, Modal, OrderField, StatusMessage};
 use crate::commands::Command;
 
 pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
@@ -71,7 +71,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                             .and_then(|a| a.buying_power.parse::<f64>().ok())
                             .unwrap_or(0.0);
                         if let Some(err) = crate::input::validate(&state, buying_power) {
-                            app.status_msg = err;
+                            app.status_msg = StatusMessage::persistent(err);
                             app.modal = Some(Modal::OrderEntry(state));
                             return;
                         }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -75,7 +75,7 @@ pub fn render_status(frame: &mut Frame, area: Rect, app: &App) {
     let status = if app.status_msg.is_empty() {
         panel_hints.to_string()
     } else {
-        format!("  {}  │{}", app.status_msg, panel_hints)
+        format!("  {}  │{}", app.status_msg.text, panel_hints)
     };
 
     let para = Paragraph::new(status).style(Style::default().fg(theme::DIM));

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,8 @@
+use std::time::Instant;
+
 use crossterm::event::{KeyCode, KeyModifiers};
 
-use crate::app::{App, Modal, Tab};
+use crate::app::{App, Modal, StatusMessage, Tab};
 use crate::events::Event;
 use crate::input::{
     handle_modal_key, handle_mouse, handle_orders_key, handle_positions_key, handle_search_key,
@@ -49,8 +51,14 @@ pub fn update(app: &mut App, event: Event) {
                 app.orders.insert(0, o);
             }
         }
-        Event::StatusMsg(msg) => app.status_msg = msg,
-        Event::Tick => {}
+        Event::StatusMsg(msg) => app.status_msg = StatusMessage::persistent(msg),
+        Event::Tick => {
+            if let Some(exp) = app.status_msg.expires_at {
+                if exp <= Instant::now() {
+                    app.status_msg.clear();
+                }
+            }
+        }
         Event::Quit => app.should_quit = true,
     }
 }
@@ -84,7 +92,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         KeyCode::Tab => app.active_tab = app.active_tab.next(),
         KeyCode::BackTab => app.active_tab = app.active_tab.prev(),
         KeyCode::Char('r') => {
-            app.status_msg = "Refreshing…".into();
+            app.status_msg = StatusMessage::transient("Refreshing…");
             app.refresh_notify.notify_one();
         }
         _ => handle_panel_key(app, key),
@@ -274,6 +282,68 @@ mod tests {
         update(&mut app, Event::Tick);
         assert!(!app.should_quit);
         assert_eq!(app.status_msg, before_status);
+    }
+
+    #[test]
+    fn tick_clears_expired_transient_status_msg() {
+        use std::time::{Duration, Instant};
+        let mut app = make_test_app();
+        // Set an already-expired transient message.
+        app.status_msg = crate::app::StatusMessage {
+            text: "Order submitted".into(),
+            expires_at: Some(Instant::now() - Duration::from_secs(1)),
+        };
+        update(&mut app, Event::Tick);
+        assert!(
+            app.status_msg.is_empty(),
+            "expired transient message should be cleared"
+        );
+    }
+
+    #[test]
+    fn tick_does_not_clear_unexpired_transient_status_msg() {
+        use std::time::{Duration, Instant};
+        let mut app = make_test_app();
+        // Set a transient message that expires in the far future.
+        app.status_msg = crate::app::StatusMessage {
+            text: "Refreshing…".into(),
+            expires_at: Some(Instant::now() + Duration::from_secs(60)),
+        };
+        update(&mut app, Event::Tick);
+        assert_eq!(
+            app.status_msg, "Refreshing…",
+            "non-expired message must not be cleared"
+        );
+    }
+
+    #[test]
+    fn tick_does_not_clear_persistent_status_msg() {
+        let mut app = make_test_app();
+        app.status_msg = crate::app::StatusMessage::persistent("Loading…");
+        update(&mut app, Event::Tick);
+        assert_eq!(
+            app.status_msg, "Loading…",
+            "persistent message must survive tick"
+        );
+    }
+
+    #[test]
+    fn status_msg_transient_has_expiry() {
+        let msg = crate::app::StatusMessage::transient("Submitting order…");
+        assert!(!msg.text.is_empty());
+        assert!(
+            msg.expires_at.is_some(),
+            "transient message must have an expiry"
+        );
+    }
+
+    #[test]
+    fn status_msg_persistent_has_no_expiry() {
+        let msg = crate::app::StatusMessage::persistent("Error: unauthorized");
+        assert!(
+            msg.expires_at.is_none(),
+            "persistent message must have no expiry"
+        );
     }
 
     // ── Global key events ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the plain `status_msg: String` field with a typed `StatusMessage` struct that carries an optional `expires_at: Option<Instant>`. On every `Event::Tick` the handler checks whether the deadline has passed and clears the message automatically.

### Changes

- **`src/app.rs`**: New `StatusMessage { text, expires_at }` with:
  - `StatusMessage::transient(text)` — 3-second auto-dismiss TTL
  - `StatusMessage::persistent(text)` — stays until replaced
  - `PartialEq` impls vs `&str`, `str`, `String`, and self (by text) so all existing test assertions continue to work without modification
- **`src/update.rs`**: `Event::Tick` now drives expiry; `Event::StatusMsg` → persistent; "Refreshing…" → transient
- **`src/input/mod.rs`**: `send_command()` success and "System busy" → transient; "Command handler stopped" → persistent
- **`src/input/modal.rs`**: Validation errors → persistent (user must read and fix)
- **`src/ui/dashboard.rs`**: Reads `.text` for display

### TTL classification
| Message | Kind |
|---|---|
| "Loading…" | persistent |
| API / system errors via `Event::StatusMsg` | persistent |
| Validation errors (order modal) | persistent |
| "Command handler stopped" | persistent |
| "Refreshing…" | transient (3 s) |
| "Submitting order…", "Adding …", "Removing …", "Cancelling …" | transient (3 s) |
| "System busy — please retry" | transient (3 s) |

### Tests added
5 new unit tests covering expired/unexpired/persistent tick behaviour and the constructor helpers.

Closes #11