### PR TITLE
feat(ui): show WebSocket stream connection status in header

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -319,6 +319,11 @@ pub struct App {
     pub status_msg: StatusMessage,
     pub should_quit: bool,
 
+    /// `true` while the market-data WebSocket is connected and authenticated.
+    pub market_stream_ok: bool,
+    /// `true` while the account WebSocket is connected and authenticated.
+    pub account_stream_ok: bool,
+
     /// Interactive element positions from the last rendered frame.
     pub hit_areas: HitAreas,
 }
@@ -352,6 +357,8 @@ impl App {
             searching: false,
             status_msg: StatusMessage::persistent("Loading…"),
             should_quit: false,
+            market_stream_ok: false,
+            account_stream_ok: false,
             hit_areas: HitAreas::default(),
         }
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,13 @@
 use crate::types::{AccountInfo, MarketClock, Order, Position, Quote, Watchlist};
 use crossterm::event::{KeyEvent, MouseEvent};
 
+/// Identifies which WebSocket stream a connection-status event concerns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamKind {
+    Market,
+    Account,
+}
+
 #[derive(Debug)]
 pub enum Event {
     Input(KeyEvent),
@@ -15,6 +22,9 @@ pub enum Event {
     // WebSocket (Phase 2)
     MarketQuote(Quote),
     TradeUpdate(Order),
+    // WebSocket stream connection status
+    StreamConnected(StreamKind),
+    StreamDisconnected(StreamKind),
     // Control
     Tick,
     StatusMsg(String),

--- a/src/stream/account.rs
+++ b/src/stream/account.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::config::AlpacaConfig;
-use crate::events::Event;
+use crate::events::{Event, StreamKind};
 use crate::types::Order;
 
 const MAX_BACKOFF_SECS: u64 = 30;
@@ -42,6 +42,9 @@ pub async fn run(tx: Sender<Event>, cancel: CancellationToken, config: AlpacaCon
             Ok(_) => return,
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff, "account stream disconnected, reconnecting");
+                let _ = tx
+                    .send(Event::StreamDisconnected(StreamKind::Account))
+                    .await;
                 tokio::select! {
                     _ = cancel.cancelled() => return,
                     _ = tokio::time::sleep(Duration::from_secs(backoff)) => {}
@@ -87,6 +90,7 @@ async fn run_once(
     });
     write.send(Message::Text(listen.to_string().into())).await?;
     info!("account stream subscribed to trade_updates");
+    let _ = tx.send(Event::StreamConnected(StreamKind::Account)).await;
 
     loop {
         tokio::select! {

--- a/src/stream/market.rs
+++ b/src/stream/market.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::config::AlpacaConfig;
-use crate::events::Event;
+use crate::events::{Event, StreamKind};
 use crate::types::Quote;
 
 const DATA_URL: &str = "wss://stream.data.alpaca.markets/v2/iex";
@@ -52,6 +52,7 @@ pub async fn run(
             }
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff, "market stream disconnected, reconnecting");
+                let _ = tx.send(Event::StreamDisconnected(StreamKind::Market)).await;
                 tokio::select! {
                     _ = cancel.cancelled() => return,
                     _ = tokio::time::sleep(Duration::from_secs(backoff)) => {}
@@ -94,6 +95,7 @@ async fn run_once(
     let symbols = symbol_rx.borrow().clone();
     subscribe(&mut write, &symbols).await?;
     info!(count = symbols.len(), "subscribed to market quotes");
+    let _ = tx.send(Event::StreamConnected(StreamKind::Market)).await;
 
     let mut prev_symbols = symbols;
 

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1,7 +1,7 @@
 use chrono::Local;
 use ratatui::{
     layout::{Alignment, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Tabs},
     Frame,
@@ -26,7 +26,7 @@ pub fn render_header(frame: &mut Frame, area: Rect, app: &App) {
 
     let now = Local::now().format("%H:%M:%S ET  %Y-%m-%d").to_string();
 
-    let line = Line::from(vec![
+    let mut spans = vec![
         Span::styled(
             format!(" [{}] ", env_label),
             Style::default().fg(env_color).add_modifier(Modifier::BOLD),
@@ -40,7 +40,24 @@ pub fn render_header(frame: &mut Frame, area: Rect, app: &App) {
             format!("Market: {}   {}", market_status, now),
             Style::default().fg(theme::DIM),
         ),
-    ]);
+    ];
+
+    if !app.market_stream_ok || !app.account_stream_ok {
+        let which = match (app.market_stream_ok, app.account_stream_ok) {
+            (false, false) => " ⚠ STREAM",
+            (false, true) => " ⚠ MARKET",
+            (true, false) => " ⚠ ACCOUNT",
+            _ => unreachable!(),
+        };
+        spans.push(Span::styled(
+            which,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    let line = Line::from(spans);
 
     let paragraph = Paragraph::new(line)
         .block(Block::default().borders(Borders::ALL))

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::app::{App, Modal, StatusMessage, Tab};
-use crate::events::Event;
+use crate::events::{Event, StreamKind};
 use crate::input::{
     handle_modal_key, handle_mouse, handle_orders_key, handle_positions_key, handle_search_key,
     handle_watchlist_key,
@@ -52,6 +52,14 @@ pub fn update(app: &mut App, event: Event) {
             }
         }
         Event::StatusMsg(msg) => app.status_msg = StatusMessage::persistent(msg),
+        Event::StreamConnected(kind) => match kind {
+            StreamKind::Market => app.market_stream_ok = true,
+            StreamKind::Account => app.account_stream_ok = true,
+        },
+        Event::StreamDisconnected(kind) => match kind {
+            StreamKind::Market => app.market_stream_ok = false,
+            StreamKind::Account => app.account_stream_ok = false,
+        },
         Event::Tick => {
             if let Some(exp) = app.status_msg.expires_at {
                 if exp <= Instant::now() {
@@ -114,7 +122,7 @@ mod tests {
     use crate::app::test_helpers::*;
     use crate::app::{Modal, OrdersSubTab, Tab};
     use crate::commands::Command;
-    use crate::events::Event;
+    use crate::events::{Event, StreamKind};
     use crate::types::{AccountInfo, MarketClock, Order, Quote};
     use crossterm::event::{
         KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
@@ -266,6 +274,57 @@ mod tests {
         let mut app = make_test_app();
         update(&mut app, Event::StatusMsg("hello".into()));
         assert_eq!(app.status_msg, "hello");
+    }
+
+    #[test]
+    fn stream_connected_market_sets_flag() {
+        let mut app = make_test_app();
+        assert!(!app.market_stream_ok);
+        update(&mut app, Event::StreamConnected(StreamKind::Market));
+        assert!(app.market_stream_ok);
+        assert!(
+            !app.account_stream_ok,
+            "account flag must remain unaffected"
+        );
+    }
+
+    #[test]
+    fn stream_connected_account_sets_flag() {
+        let mut app = make_test_app();
+        update(&mut app, Event::StreamConnected(StreamKind::Account));
+        assert!(app.account_stream_ok);
+        assert!(!app.market_stream_ok, "market flag must remain unaffected");
+    }
+
+    #[test]
+    fn stream_disconnected_market_clears_flag() {
+        let mut app = make_test_app();
+        app.market_stream_ok = true;
+        app.account_stream_ok = true;
+        update(&mut app, Event::StreamDisconnected(StreamKind::Market));
+        assert!(!app.market_stream_ok);
+        assert!(app.account_stream_ok, "account flag must remain unaffected");
+    }
+
+    #[test]
+    fn stream_disconnected_account_clears_flag() {
+        let mut app = make_test_app();
+        app.market_stream_ok = true;
+        app.account_stream_ok = true;
+        update(&mut app, Event::StreamDisconnected(StreamKind::Account));
+        assert!(!app.account_stream_ok);
+        assert!(app.market_stream_ok, "market flag must remain unaffected");
+    }
+
+    #[test]
+    fn stream_connected_then_disconnected_roundtrip() {
+        let mut app = make_test_app();
+        update(&mut app, Event::StreamConnected(StreamKind::Market));
+        update(&mut app, Event::StreamConnected(StreamKind::Account));
+        assert!(app.market_stream_ok && app.account_stream_ok);
+        update(&mut app, Event::StreamDisconnected(StreamKind::Market));
+        assert!(!app.market_stream_ok);
+        assert!(app.account_stream_ok);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When the market or account WebSocket disconnects and is reconnecting (exponential backoff), the UI now shows a clearly visible ⚠ badge in the header so users understand stale prices are due to a reconnect in progress.

### Changes

- **`src/events.rs`**: New `StreamKind { Market, Account }` enum; new `Event::StreamConnected(StreamKind)` and `Event::StreamDisconnected(StreamKind)` variants
- **`src/app.rs`**: `market_stream_ok: bool` and `account_stream_ok: bool` fields (both `false` on startup)
- **`src/update.rs`**: Handles new events — `StreamConnected` sets flag to `true`, `StreamDisconnected` resets to `false`
- **`src/stream/market.rs`**: Emits `StreamConnected(Market)` after successful auth+subscribe; `StreamDisconnected(Market)` before exponential backoff
- **`src/stream/account.rs`**: Same for `Account`
- **`src/ui/dashboard.rs`**: `render_header()` appends a yellow bold badge:
  - `⚠ STREAM` — both down
  - `⚠ MARKET` — only market stream down
  - `⚠ ACCOUNT` — only account stream down
  - No badge — both connected

### Tests

5 new unit tests in `update.rs` covering connect/disconnect flag transitions and round-trip behaviour.

Closes #12