### PR TITLE
feat(order-entry): TIF toggle and market-closed warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,13 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | Paper / Live switching (`run.sh --paper/--live`) | Done |
 | Clippy clean | Done |
 | Test strategy documented | Done |
-| Unit + integration tests (101 tests) | Done |
+| Unit + integration tests (171 tests) | Done |
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
+| Status message auto-dismiss (3 s TTL) | Done |
+| WebSocket stream connection status in header | Done |
+| Order Entry: Time-in-Force (DAY/GTC) selection | Done |
+| Order Entry: market-closed warning + DAY order block | Done |
 | WebSocket market data streaming | Phase 2 |
 | WebSocket account/trade stream | Phase 2 |
 | Live order submission | Phase 2 |

--- a/src/app.rs
+++ b/src/app.rs
@@ -196,6 +196,7 @@ pub enum OrderField {
     OrderType,
     Qty,
     Price,
+    TimeInForce,
     Submit,
 }
 
@@ -206,7 +207,8 @@ impl OrderField {
             OrderField::Side => OrderField::OrderType,
             OrderField::OrderType => OrderField::Qty,
             OrderField::Qty => OrderField::Price,
-            OrderField::Price => OrderField::Submit,
+            OrderField::Price => OrderField::TimeInForce,
+            OrderField::TimeInForce => OrderField::Submit,
             OrderField::Submit => OrderField::Symbol,
         }
     }
@@ -218,7 +220,8 @@ impl OrderField {
             OrderField::OrderType => OrderField::Side,
             OrderField::Qty => OrderField::OrderType,
             OrderField::Price => OrderField::Qty,
-            OrderField::Submit => OrderField::Price,
+            OrderField::TimeInForce => OrderField::Price,
+            OrderField::Submit => OrderField::TimeInForce,
         }
     }
 }
@@ -228,6 +231,7 @@ pub struct OrderEntryState {
     pub symbol: String,
     pub side_buy: bool,     // true = BUY, false = SELL
     pub market_order: bool, // true = MARKET, false = LIMIT
+    pub gtc_order: bool,    // true = GTC, false = DAY
     pub qty_input: String,
     pub price_input: String,
     pub focused_field: OrderField,
@@ -239,6 +243,7 @@ impl OrderEntryState {
             symbol,
             side_buy: true,
             market_order: false,
+            gtc_order: false,
             qty_input: String::new(),
             price_input: String::new(),
             focused_field: OrderField::Qty,
@@ -477,14 +482,16 @@ mod tests {
         assert_eq!(OrderField::Side.next(), OrderField::OrderType);
         assert_eq!(OrderField::OrderType.next(), OrderField::Qty);
         assert_eq!(OrderField::Qty.next(), OrderField::Price);
-        assert_eq!(OrderField::Price.next(), OrderField::Submit);
+        assert_eq!(OrderField::Price.next(), OrderField::TimeInForce);
+        assert_eq!(OrderField::TimeInForce.next(), OrderField::Submit);
         assert_eq!(OrderField::Submit.next(), OrderField::Symbol);
     }
 
     #[test]
     fn order_field_prev_full_cycle() {
         assert_eq!(OrderField::Symbol.prev(), OrderField::Submit);
-        assert_eq!(OrderField::Submit.prev(), OrderField::Price);
+        assert_eq!(OrderField::Submit.prev(), OrderField::TimeInForce);
+        assert_eq!(OrderField::TimeInForce.prev(), OrderField::Price);
         assert_eq!(OrderField::Price.prev(), OrderField::Qty);
         assert_eq!(OrderField::Qty.prev(), OrderField::OrderType);
         assert_eq!(OrderField::OrderType.prev(), OrderField::Side);

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -32,6 +32,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 KeyCode::Left | KeyCode::Right => match state.focused_field {
                     OrderField::Side => state.side_buy = !state.side_buy,
                     OrderField::OrderType => state.market_order = !state.market_order,
+                    OrderField::TimeInForce => state.gtc_order = !state.gtc_order,
                     _ => {}
                 },
                 KeyCode::Char(c) => match state.focused_field {
@@ -70,7 +71,9 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                             .as_ref()
                             .and_then(|a| a.buying_power.parse::<f64>().ok())
                             .unwrap_or(0.0);
-                        if let Some(err) = crate::input::validate(&state, buying_power) {
+                        let market_open = app.clock.as_ref().map(|c| c.is_open).unwrap_or(true);
+                        if let Some(err) = crate::input::validate(&state, buying_power, market_open)
+                        {
                             app.status_msg = StatusMessage::persistent(err);
                             app.modal = Some(Modal::OrderEntry(state));
                             return;
@@ -96,7 +99,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                                 } else {
                                     Some(state.price_input.clone())
                                 },
-                                time_in_force: "day".into(),
+                                time_in_force: if state.gtc_order { "gtc" } else { "day" }.into(),
                             },
                             "Submitting order…",
                         );

--- a/src/input/validation.rs
+++ b/src/input/validation.rs
@@ -4,13 +4,25 @@ use crate::app::OrderEntryState;
 ///
 /// Returns `None` when the state is valid, or `Some(error_message)` describing
 /// the first validation failure encountered.
-pub(crate) fn validate(state: &OrderEntryState, buying_power: f64) -> Option<String> {
+///
+/// `market_open` should reflect `app.clock.as_ref().map(|c| c.is_open).unwrap_or(true)`.
+/// DAY orders are blocked when the market is closed; GTC orders are always allowed.
+pub(crate) fn validate(
+    state: &OrderEntryState,
+    buying_power: f64,
+    market_open: bool,
+) -> Option<String> {
     // 1. Symbol must be non-empty.
     if state.symbol.trim().is_empty() {
         return Some("Symbol cannot be empty".into());
     }
 
-    // 2. Quantity must be a positive number (if provided; an empty qty means
+    // 2. Block DAY orders when market is closed.
+    if !market_open && !state.gtc_order {
+        return Some("Market is closed — switch to GTC or wait for market open".into());
+    }
+
+    // 3. Quantity must be a positive number (if provided; an empty qty means
     //    notional dollar amount, which requires a non-empty price instead).
     let qty: Option<f64> = if state.qty_input.is_empty() {
         None
@@ -22,7 +34,7 @@ pub(crate) fn validate(state: &OrderEntryState, buying_power: f64) -> Option<Str
         }
     };
 
-    // 3. Price must be a positive number on LIMIT orders.
+    // 4. Price must be a positive number on LIMIT orders.
     let price: Option<f64> = if state.market_order {
         None
     } else {
@@ -33,7 +45,7 @@ pub(crate) fn validate(state: &OrderEntryState, buying_power: f64) -> Option<Str
         }
     };
 
-    // 4. Estimated total must not exceed buying power.
+    // 5. Estimated total must not exceed buying power.
     //    est_total = qty * price (LIMIT) or qty alone can't be checked for MARKET;
     //    we only gate when we have both values.
     if let (Some(q), Some(p)) = (qty, price) {
@@ -57,6 +69,7 @@ mod tests {
     fn base_state() -> OrderEntryState {
         let mut s = OrderEntryState::new("AAPL".into());
         s.market_order = false; // LIMIT
+        s.gtc_order = false; // DAY
         s.qty_input = "10".into();
         s.price_input = "150.00".into();
         s
@@ -65,7 +78,7 @@ mod tests {
     #[test]
     fn valid_limit_order_returns_none() {
         let state = base_state();
-        assert_eq!(validate(&state, 10_000.0), None);
+        assert_eq!(validate(&state, 10_000.0, true), None);
     }
 
     #[test]
@@ -73,42 +86,42 @@ mod tests {
         let mut state = base_state();
         state.market_order = true;
         state.price_input.clear(); // price not required for MARKET
-        assert_eq!(validate(&state, 10_000.0), None);
+        assert_eq!(validate(&state, 10_000.0, true), None);
     }
 
     #[test]
     fn empty_symbol_fails() {
         let mut state = base_state();
         state.symbol.clear();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
     fn whitespace_only_symbol_fails() {
         let mut state = base_state();
         state.symbol = "   ".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
     fn zero_qty_fails() {
         let mut state = base_state();
         state.qty_input = "0".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
     fn negative_qty_fails() {
         let mut state = base_state();
         state.qty_input = "-5".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
     fn non_numeric_qty_fails() {
         let mut state = base_state();
         state.qty_input = "abc".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
@@ -116,28 +129,28 @@ mod tests {
         let mut state = base_state();
         state.qty_input.clear(); // notional; price still required for LIMIT
                                  // price is set and positive → should pass
-        assert_eq!(validate(&state, 10_000.0), None);
+        assert_eq!(validate(&state, 10_000.0, true), None);
     }
 
     #[test]
     fn zero_price_on_limit_fails() {
         let mut state = base_state();
         state.price_input = "0".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
     fn negative_price_on_limit_fails() {
         let mut state = base_state();
         state.price_input = "-1.0".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
     fn non_numeric_price_on_limit_fails() {
         let mut state = base_state();
         state.price_input = "abc".into();
-        assert!(validate(&state, 10_000.0).is_some());
+        assert!(validate(&state, 10_000.0, true).is_some());
     }
 
     #[test]
@@ -145,26 +158,65 @@ mod tests {
         let mut state = base_state();
         state.market_order = true;
         state.price_input = "not-a-number".into(); // ignored for MARKET
-        assert_eq!(validate(&state, 10_000.0), None);
+        assert_eq!(validate(&state, 10_000.0, true), None);
     }
 
     #[test]
     fn total_exceeding_buying_power_fails() {
         let state = base_state(); // 10 shares × $150 = $1500
-        assert!(validate(&state, 1_000.0).is_some());
+        assert!(validate(&state, 1_000.0, true).is_some());
     }
 
     #[test]
     fn total_exactly_at_buying_power_passes() {
         let state = base_state(); // 10 × 150 = 1500
-        assert_eq!(validate(&state, 1_500.0), None);
+        assert_eq!(validate(&state, 1_500.0, true), None);
     }
 
     #[test]
     fn error_message_contains_amounts_when_exceeding_buying_power() {
         let state = base_state(); // 10 × 150 = $1500
-        let msg = validate(&state, 500.0).expect("should fail");
+        let msg = validate(&state, 500.0, true).expect("should fail");
         assert!(msg.contains("1500.00"), "got: {msg}");
         assert!(msg.contains("500.00"), "got: {msg}");
+    }
+
+    // ── Market-closed checks ──────────────────────────────────────────────────
+
+    #[test]
+    fn day_order_when_market_closed_fails() {
+        let mut state = base_state();
+        state.gtc_order = false; // DAY
+        let msg = validate(&state, 10_000.0, false).expect("should fail");
+        assert!(
+            msg.to_lowercase().contains("closed") || msg.to_lowercase().contains("gtc"),
+            "expected closed/GTC mention, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gtc_order_when_market_closed_passes() {
+        let mut state = base_state();
+        state.gtc_order = true; // GTC — valid outside market hours
+        assert_eq!(validate(&state, 10_000.0, false), None);
+    }
+
+    #[test]
+    fn day_order_when_market_open_passes() {
+        let state = base_state(); // DAY, market open
+        assert_eq!(validate(&state, 10_000.0, true), None);
+    }
+
+    #[test]
+    fn market_closed_error_checked_before_other_errors() {
+        // Even with a bad qty, the market-closed error should surface first
+        let mut state = base_state();
+        state.gtc_order = false;
+        state.qty_input = "-99".into();
+        let msg = validate(&state, 10_000.0, false).expect("should fail");
+        assert!(
+            msg.to_lowercase().contains("closed") || msg.to_lowercase().contains("gtc"),
+            "market-closed check should run before qty check; got: {msg}"
+        );
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -102,7 +102,7 @@ fn render_help(frame: &mut Frame, area: Rect) {
 }
 
 fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, app: &mut App) {
-    let popup = popup_area(area, 45, 60);
+    let popup = popup_area(area, 45, 65);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -117,20 +117,24 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // Symbol
-            Constraint::Length(1), // blank
-            Constraint::Length(1), // Side
-            Constraint::Length(1), // Type
-            Constraint::Length(1), // Qty
-            Constraint::Length(1), // Price
-            Constraint::Length(1), // blank
-            Constraint::Length(1), // Est Total
-            Constraint::Length(1), // Buying Power
-            Constraint::Length(1), // blank
-            Constraint::Length(1), // Submit / Cancel
-            Constraint::Length(1), // hint
+            Constraint::Length(1), // [0]  Symbol
+            Constraint::Length(1), // [1]  blank
+            Constraint::Length(1), // [2]  Side
+            Constraint::Length(1), // [3]  Type
+            Constraint::Length(1), // [4]  Qty
+            Constraint::Length(1), // [5]  Price
+            Constraint::Length(1), // [6]  TimeInForce
+            Constraint::Length(1), // [7]  blank
+            Constraint::Length(1), // [8]  Est Total
+            Constraint::Length(1), // [9]  Buying Power
+            Constraint::Length(1), // [10] blank
+            Constraint::Length(1), // [11] Market-closed warning
+            Constraint::Length(1), // [12] Submit / Cancel
+            Constraint::Length(1), // [13] hint
         ])
         .split(inner);
+
+    let market_open = app.clock.as_ref().map(|c| c.is_open).unwrap_or(true);
 
     // Populate hit areas for mouse click handling
     app.hit_areas.modal_fields = vec![
@@ -139,8 +143,9 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
         (OrderField::OrderType, chunks[3]),
         (OrderField::Qty, chunks[4]),
         (OrderField::Price, chunks[5]),
+        (OrderField::TimeInForce, chunks[6]),
     ];
-    app.hit_areas.modal_submit = Some(chunks[10]);
+    app.hit_areas.modal_submit = Some(chunks[12]);
 
     let focused = |field: &OrderField| *field == state.focused_field;
 
@@ -232,6 +237,15 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
         );
     }
 
+    // TimeInForce
+    let tif_line = Line::from(vec![
+        Span::styled("  TIF     ", Style::default().fg(theme::DIM)),
+        radio(!state.gtc_order, "DAY"),
+        Span::raw("  "),
+        radio(state.gtc_order, "GTC"),
+    ]);
+    frame.render_widget(Paragraph::new(tif_line), chunks[6]);
+
     // Est Total
     let est_total = estimate_total(state);
     frame.render_widget(
@@ -239,7 +253,7 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
             Span::styled("  Est. Total  ", Style::default().fg(theme::DIM)),
             Span::styled(est_total, theme::style_bold()),
         ])),
-        chunks[7],
+        chunks[8],
     );
 
     // Buying power
@@ -253,14 +267,30 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
             Span::styled("  Buying Power  ", Style::default().fg(theme::DIM)),
             Span::styled(bp, theme::style_bold()),
         ])),
-        chunks[8],
+        chunks[9],
     );
 
-    // Buttons
-    let submit_style = if focused(&OrderField::Submit) {
+    // Market-closed warning
+    if !market_open && !state.gtc_order {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                "  ⚠ Market closed — switch to GTC or wait",
+                Style::default()
+                    .fg(theme::YELLOW)
+                    .add_modifier(Modifier::BOLD),
+            )])),
+            chunks[11],
+        );
+    }
+
+    // Submit button — dimmed when market is closed and order is DAY
+    let market_closed_day = !market_open && !state.gtc_order;
+    let submit_style = if focused(&OrderField::Submit) && !market_closed_day {
         Style::default()
             .fg(theme::BRAND_CYAN)
             .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else if market_closed_day {
+        Style::default().fg(theme::DIM)
     } else {
         Style::default()
     };
@@ -269,13 +299,13 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
         Span::raw("  "),
         Span::styled("[ Esc: Cancel ]", Style::default().fg(theme::DIM)),
     ]);
-    frame.render_widget(Paragraph::new(buttons), chunks[10]);
+    frame.render_widget(Paragraph::new(buttons), chunks[12]);
 
     // Hint
     frame.render_widget(
         Paragraph::new("  Tab:Next  ←/→:Toggle  Enter:Advance  Esc:Close")
             .style(Style::default().fg(theme::DIM)),
-        chunks[11],
+        chunks[13],
     );
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -4,6 +4,7 @@ pub const BRAND_CYAN: Color = Color::Cyan;
 pub const BRAND_RED: Color = Color::Red;
 pub const GREEN: Color = Color::Green;
 pub const RED: Color = Color::Red;
+pub const YELLOW: Color = Color::Yellow;
 pub const DIM: Color = Color::DarkGray;
 pub const BORDER_COLOR: Color = Color::DarkGray;
 pub const SELECTED_BG: Color = Color::Rgb(40, 40, 80);


### PR DESCRIPTION
Implements issue 13: warn/block order submission when the market is closed.

Changes:
- OrderField: added TimeInForce variant between Price and Submit
- OrderEntryState: added gtc_order bool field (false=DAY, true=GTC)
- validate(): new market_open bool parameter; DAY orders blocked when closed
- handle_modal_key(): toggle gtc_order via left/right on TimeInForce field
- render_order_entry(): TIF DAY/GTC radio row, yellow warning, dimmed Submit
- ui/theme.rs: added YELLOW colour constant
- Tests: 4 new validation tests + all existing tests updated
- README: feature table updated, test count 171

Closes #13