### PR TITLE
feat(ui): pre-populate equity sparkline from portfolio history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,14 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | Paper / Live switching (`run.sh --paper/--live`) | Done |
 | Clippy clean | Done |
 | Test strategy documented | Done |
-| Unit + integration tests (171 tests) | Done |
+| Unit + integration tests (178 tests) | Done |
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
 | Status message auto-dismiss (3 s TTL) | Done |
 | WebSocket stream connection status in header | Done |
 | Order Entry: Time-in-Force (DAY/GTC) selection | Done |
 | Order Entry: market-closed warning + DAY order block | Done |
+| Equity sparkline pre-populated from portfolio history API | Done |
 | WebSocket market data streaming | Phase 2 |
 | WebSocket account/trade stream | Phase 2 |
 | Live order submission | Phase 2 |

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,8 @@ use reqwest::header::{HeaderMap, HeaderValue};
 
 use crate::config::AlpacaConfig;
 use crate::types::{
-    AccountInfo, MarketClock, Order, OrderRequest, Position, Watchlist, WatchlistSummary,
+    AccountInfo, MarketClock, Order, OrderRequest, PortfolioHistory, Position, Watchlist,
+    WatchlistSummary,
 };
 
 pub struct AlpacaClient {
@@ -158,5 +159,18 @@ impl AlpacaClient {
             .json::<Watchlist>()
             .await
             .context("DELETE /watchlists/{id}/{symbol} parse failed")
+    }
+
+    pub async fn get_portfolio_history(&self) -> Result<PortfolioHistory> {
+        self.http
+            .get(self.url("/account/portfolio/history"))
+            .query(&[("timeframe", "1Min"), ("period", "1D")])
+            .headers(self.auth_headers()?)
+            .send()
+            .await
+            .context("GET /account/portfolio/history request failed")?
+            .json::<PortfolioHistory>()
+            .await
+            .context("GET /account/portfolio/history parse failed")
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -25,6 +25,8 @@ pub enum Event {
     // WebSocket stream connection status
     StreamConnected(StreamKind),
     StreamDisconnected(StreamKind),
+    // Startup: pre-populate equity sparkline from portfolio history API
+    PortfolioHistoryLoaded(Vec<f64>),
     // Control
     Tick,
     StatusMsg(String),

--- a/src/handlers/rest.rs
+++ b/src/handlers/rest.rs
@@ -31,7 +31,7 @@ pub async fn run(
 }
 
 pub async fn poll_once(tx: Sender<Event>, client: Arc<AlpacaClient>) {
-    poll_all(&client, &tx).await;
+    tokio::join!(poll_all(&client, &tx), poll_portfolio_history(&client, &tx));
 }
 
 async fn poll_all(client: &AlpacaClient, tx: &Sender<Event>) {
@@ -114,6 +114,20 @@ async fn poll_watchlist(client: &AlpacaClient, tx: &Sender<Event>) {
     }
 }
 
+async fn poll_portfolio_history(client: &AlpacaClient, tx: &Sender<Event>) {
+    match client.get_portfolio_history().await {
+        Ok(h) => {
+            let data: Vec<f64> = h.equity.into_iter().flatten().collect();
+            if !data.is_empty() {
+                let _ = tx.send(Event::PortfolioHistoryLoaded(data)).await;
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Portfolio history unavailable: {}", e);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,6 +198,19 @@ mod tests {
             })))
             .mount(server)
             .await;
+
+        Mock::given(method("GET"))
+            .and(path("/account/portfolio/history"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "equity": [100000.0, 100100.5, null, 100200.0],
+                "timestamp": [1000, 1060, 1120, 1180],
+                "profit_loss": [0.0, 100.5, null, 200.0],
+                "profit_loss_pct": [0.0, 0.001, null, 0.002],
+                "base_value": 100000.0,
+                "timeframe": "1Min"
+            })))
+            .mount(server)
+            .await;
     }
 
     #[tokio::test]
@@ -223,6 +250,12 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, Event::WatchlistUpdated(_))),
             "missing WatchlistUpdated"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::PortfolioHistoryLoaded(_))),
+            "missing PortfolioHistoryLoaded"
         );
     }
 
@@ -329,5 +362,153 @@ mod tests {
             .await
             .expect("run() did not exit within 2 seconds")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn poll_once_sends_portfolio_history_with_nulls_filtered() {
+        let server = MockServer::start().await;
+        mount_all(&server).await;
+
+        let client = Arc::new(AlpacaClient::new(test_config(server.uri())));
+        let (tx, mut rx) = mpsc::channel(32);
+        poll_once(tx, client).await;
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let history_event = events
+            .iter()
+            .find_map(|e| {
+                if let Event::PortfolioHistoryLoaded(data) = e {
+                    Some(data)
+                } else {
+                    None
+                }
+            })
+            .expect("PortfolioHistoryLoaded should be emitted");
+
+        // mount_all provides [100000.0, 100100.5, null, 100200.0]
+        // null is filtered out → 3 values
+        assert_eq!(history_event.len(), 3);
+        assert!((history_event[0] - 100000.0).abs() < 0.01);
+        assert!((history_event[1] - 100100.5).abs() < 0.01);
+        assert!((history_event[2] - 100200.0).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn poll_once_portfolio_history_error_is_silently_ignored() {
+        let server = MockServer::start().await;
+        mount_all(&server).await;
+
+        // Override portfolio history with a 500 error by pointing at a fresh server
+        // that has no mocks (all unmocked paths → wiremock returns 404).
+        // We only need to confirm no PortfolioHistoryLoaded arrives when the call fails.
+        let err_server = MockServer::start().await;
+        // Mount all except portfolio history on err_server so other events arrive.
+        Mock::given(method("GET"))
+            .and(path("/account"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": "ACTIVE", "equity": "100000", "buying_power": "200000",
+                "cash": "100000", "long_market_value": "0",
+                "daytrade_count": 0, "pattern_day_trader": false, "currency": "USD"
+            })))
+            .mount(&err_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/positions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&err_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/orders"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&err_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/clock"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "is_open": false, "next_open": "", "next_close": "", "timestamp": ""
+            })))
+            .mount(&err_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/watchlists"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&err_server)
+            .await;
+        // No mock for /account/portfolio/history → wiremock returns 500-ish
+
+        let client = Arc::new(AlpacaClient::new(test_config(err_server.uri())));
+        let (tx, mut rx) = mpsc::channel(32);
+        poll_once(tx, client).await;
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::PortfolioHistoryLoaded(_))),
+            "portfolio history error must not emit PortfolioHistoryLoaded"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_once_portfolio_history_all_null_does_not_emit_event() {
+        let server = MockServer::start().await;
+
+        // Minimal mocks so poll_all doesn't fail loudly
+        Mock::given(method("GET"))
+            .and(path("/account"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": "ACTIVE", "equity": "0", "buying_power": "0",
+                "cash": "0", "long_market_value": "0",
+                "daytrade_count": 0, "pattern_day_trader": false, "currency": "USD"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/positions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/orders"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/clock"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "is_open": false, "next_open": "", "next_close": "", "timestamp": ""
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/watchlists"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+        // All equity values are null (market closed all day)
+        Mock::given(method("GET"))
+            .and(path("/account/portfolio/history"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "equity": [null, null, null],
+                "timestamp": [1000, 1060, 1120],
+                "profit_loss": [null, null, null],
+                "profit_loss_pct": [null, null, null],
+                "base_value": 0.0,
+                "timeframe": "1Min"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = Arc::new(AlpacaClient::new(test_config(server.uri())));
+        let (tx, mut rx) = mpsc::channel(32);
+        poll_once(tx, client).await;
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::PortfolioHistoryLoaded(_))),
+            "all-null equity must not emit PortfolioHistoryLoaded"
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -293,3 +293,13 @@ pub struct Asset {
     #[serde(default)]
     pub easy_to_borrow: bool,
 }
+
+/// Response from `GET /v2/account/portfolio/history`.
+///
+/// The `equity` array contains one value per time bucket; entries are `null`
+/// when the market was closed during that interval.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PortfolioHistory {
+    /// Dollar equity values per time bucket; `None` means market was closed.
+    pub equity: Vec<Option<f64>>,
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -60,6 +60,11 @@ pub fn update(app: &mut App, event: Event) {
             StreamKind::Market => app.market_stream_ok = false,
             StreamKind::Account => app.account_stream_ok = false,
         },
+        Event::PortfolioHistoryLoaded(data) => {
+            // Convert dollar values → cents (u64) to match equity_history format.
+            // Keep all samples; ongoing push_equity() calls will append new ones.
+            app.equity_history = data.into_iter().map(|v| (v * 100.0) as u64).collect();
+        }
         Event::Tick => {
             if let Some(exp) = app.status_msg.expires_at {
                 if exp <= Instant::now() {
@@ -332,6 +337,45 @@ mod tests {
         let mut app = make_test_app();
         update(&mut app, Event::Quit);
         assert!(app.should_quit);
+    }
+
+    // ── PortfolioHistoryLoaded ────────────────────────────────────────────────
+
+    #[test]
+    fn portfolio_history_loaded_replaces_equity_history() {
+        let mut app = make_test_app();
+        let data = vec![1000.0_f64, 1001.5, 1002.0];
+        update(&mut app, Event::PortfolioHistoryLoaded(data));
+        assert_eq!(app.equity_history, vec![100000, 100150, 100200]);
+    }
+
+    #[test]
+    fn portfolio_history_loaded_overwrites_existing_history() {
+        let mut app = make_test_app();
+        app.equity_history = vec![99999];
+        let data = vec![500.0_f64, 600.0];
+        update(&mut app, Event::PortfolioHistoryLoaded(data));
+        assert_eq!(app.equity_history, vec![50000, 60000]);
+    }
+
+    #[test]
+    fn portfolio_history_loaded_empty_vec_clears_history() {
+        let mut app = make_test_app();
+        app.equity_history = vec![12345];
+        update(&mut app, Event::PortfolioHistoryLoaded(vec![]));
+        assert!(app.equity_history.is_empty());
+    }
+
+    #[test]
+    fn portfolio_history_loaded_preserves_all_samples() {
+        let mut app = make_test_app();
+        let data: Vec<f64> = (0..390).map(|i| 100.0 + i as f64 * 0.1).collect();
+        update(&mut app, Event::PortfolioHistoryLoaded(data));
+        assert_eq!(
+            app.equity_history.len(),
+            390,
+            "all intraday samples should be kept"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implements issue 14: populate equity sparkline from portfolio history on startup.

Changes:
- types.rs: PortfolioHistory struct with equity: Vec<Option<f64>>
- client.rs: get_portfolio_history() calling GET /account/portfolio/history?timeframe=1Min&period=1D
- events.rs: Event::PortfolioHistoryLoaded(Vec<f64>) variant
- handlers/rest.rs: poll_once() runs poll_portfolio_history() concurrently; null values filtered; errors silently logged
- update.rs: PortfolioHistoryLoaded handler replaces app.equity_history (dollar to cents)
- 7 new tests (4 update, 3 rest); mount_all updated; 178 tests total
- README: feature table and test count updated

Closes #14