### PR TITLE
ci: add code coverage reporting with cargo-llvm-cov and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,16 @@ jobs:
       - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: "-D warnings"
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo llvm-cov --all-features --lcov --output-path coverage.lcov
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.lcov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/ci.yml)
 [![Security audit](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/security.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/arunkumar-mourougappane/alpaca-trader-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/arunkumar-mourougappane/alpaca-trader-rs)
 ![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)
 ![License: Proprietary](https://img.shields.io/badge/license-Proprietary-red.svg)
 
@@ -220,6 +221,7 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | Unit + integration tests (178 tests) | Done |
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
+| Code coverage with cargo-llvm-cov + Codecov | Done |
 | Status message auto-dismiss (3 s TTL) | Done |
 | WebSocket stream connection status in header | Done |
 | Order Entry: Time-in-Force (DAY/GTC) selection | Done |

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -161,6 +161,27 @@ updates:
 
 LLVM source-based instrumentation. More accurate than tarpaulin and cross-platform.
 
+> **Active in this project:** The `coverage` job in `.github/workflows/ci.yml` uses
+> `cargo-llvm-cov` + Codecov on every push/PR. Results are reported to Codecov and
+> displayed via the badge in `README.md`.
+
+```yaml
+coverage:
+  name: Coverage
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: taiki-e/install-action@cargo-llvm-cov
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo llvm-cov --all-features --lcov --output-path coverage.lcov
+    - uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.lcov
+```
+
+Full reference with additional options:
+
 ```yaml
 - uses: taiki-e/install-action@cargo-llvm-cov
 


### PR DESCRIPTION
Implements issue 15: add coverage CI job and Codecov badge.

Changes:
- .github/workflows/ci.yml: new 'coverage' job using taiki-e/install-action@cargo-llvm-cov, cargo llvm-cov --all-features --lcov, and codecov/codecov-action@v3
- README.md: Codecov badge added alongside CI and security audit badges; feature table updated
- docs/github-actions.md: section 3 notes the job is active in this project with the exact YAML used

No Rust source changes — no new tests required.

Closes #15