### PR TITLE
test(stream): add WebSocket integration tests for stream run() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
 | Code coverage with cargo-llvm-cov + Codecov | Done |
+| WebSocket integration tests (auth, cancel, reconnect) | Done |
 | Status message auto-dismiss (3 s TTL) | Done |
 | WebSocket stream connection status in header | Done |
 | Order Entry: Time-in-Force (DAY/GTC) selection | Done |

--- a/src/stream/account.rs
+++ b/src/stream/account.rs
@@ -27,6 +27,15 @@ pub async fn run(tx: Sender<Event>, cancel: CancellationToken, config: AlpacaCon
         .replace("https://", "wss://")
         + "/stream";
 
+    run_inner(tx, cancel, config, &ws_url).await
+}
+
+async fn run_inner(
+    tx: Sender<Event>,
+    cancel: CancellationToken,
+    config: AlpacaConfig,
+    ws_url: &str,
+) {
     let mut backoff = 1u64;
 
     loop {
@@ -38,7 +47,7 @@ pub async fn run(tx: Sender<Event>, cancel: CancellationToken, config: AlpacaCon
             _ = async {} => {}
         }
 
-        match run_once(&tx, &cancel, &config, &ws_url).await {
+        match run_once(&tx, &cancel, &config, ws_url).await {
             Ok(_) => return,
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff, "account stream disconnected, reconnecting");
@@ -208,5 +217,228 @@ mod tests {
         // order object is missing required fields like id, symbol, etc.
         let msg = r#"{"stream":"trade_updates","data":{"event":"fill","order":{"bad":"data"}}}"#;
         assert!(parse_trade_update(msg).is_none());
+    }
+}
+
+#[cfg(test)]
+mod integration {
+    use super::*;
+    use crate::config::AlpacaEnv;
+    use futures::SinkExt;
+    use tokio::sync::mpsc;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    fn test_config() -> AlpacaConfig {
+        AlpacaConfig {
+            base_url: String::new(),
+            key: "test-key".to_string(),
+            secret: "test-secret".to_string(),
+            env: AlpacaEnv::Paper,
+        }
+    }
+
+    async fn bind_local() -> (tokio::net::TcpListener, String) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        (listener, format!("ws://127.0.0.1:{}", port))
+    }
+
+    fn trade_update_json() -> &'static str {
+        r#"{
+            "stream": "trade_updates",
+            "data": {
+                "event": "fill",
+                "order": {
+                    "id": "order-abc",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "qty": "5",
+                    "order_type": "limit",
+                    "limit_price": "185.00",
+                    "status": "filled",
+                    "filled_qty": "5",
+                    "time_in_force": "day"
+                }
+            }
+        }"#
+    }
+
+    #[tokio::test]
+    async fn account_run_once_auth_success_emits_trade_update() {
+        let (listener, url) = bind_local().await;
+
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await; // consume auth
+            ws.send(Message::Text(
+                r#"{"stream":"authorization","data":{"status":"authorized"}}"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws.next().await; // consume listen
+            ws.send(Message::Text(trade_update_json().into()))
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        });
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let cancel2 = cancel.clone();
+        let tx2 = tx.clone();
+        let config = test_config();
+        let url2 = url.clone();
+
+        tokio::spawn(async move {
+            run_once(&tx2, &cancel2, &config, &url2).await.ok();
+            cancel2.cancel();
+        });
+
+        let order = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                match rx.recv().await? {
+                    Event::TradeUpdate(o) => return Some(o),
+                    _ => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for TradeUpdate")
+        .expect("channel closed");
+
+        assert_eq!(order.id, "order-abc");
+        assert_eq!(order.symbol, "AAPL");
+        assert_eq!(order.status, "filled");
+    }
+
+    #[tokio::test]
+    async fn account_run_once_auth_failure_returns_err() {
+        let (listener, url) = bind_local().await;
+
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await;
+            ws.send(Message::Text(
+                r#"{"stream":"authorization","data":{"status":"rejected"}}"#.into(),
+            ))
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (tx, _rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+
+        let result = run_once(&tx, &cancel, &test_config(), &url).await;
+        assert!(result.is_err(), "auth failure should return Err");
+    }
+
+    #[tokio::test]
+    async fn account_run_once_exits_cleanly_on_cancellation() {
+        let (listener, url) = bind_local().await;
+        let cancel = CancellationToken::new();
+        let cancel2 = cancel.clone();
+
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await;
+            ws.send(Message::Text(
+                r#"{"stream":"authorization","data":{"status":"authorized"}}"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws.next().await; // consume listen
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+
+        let (tx, _rx) = mpsc::channel(16);
+        let config = test_config();
+        let url2 = url.clone();
+
+        let task = tokio::spawn(async move { run_once(&tx, &cancel2, &config, &url2).await });
+
+        // Allow time for auth to complete and stream to enter the main loop
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("task should finish within 1s after cancellation");
+        assert!(
+            matches!(result.unwrap(), Ok(())),
+            "cancellation should return Ok"
+        );
+    }
+
+    #[tokio::test]
+    async fn account_run_reconnects_after_server_close() {
+        let (listener, url) = bind_local().await;
+
+        tokio::spawn(async move {
+            // First connection: authenticate then close
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await;
+            ws.send(Message::Text(
+                r#"{"stream":"authorization","data":{"status":"authorized"}}"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws.next().await; // consume listen
+            drop(ws); // close — triggers reconnect
+
+            // Second connection: authenticate and send a trade update
+            let (tcp2, _) = listener.accept().await.unwrap();
+            let mut ws2 = accept_async(tcp2).await.unwrap();
+            let _ = ws2.next().await;
+            ws2.send(Message::Text(
+                r#"{"stream":"authorization","data":{"status":"authorized"}}"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws2.next().await;
+            ws2.send(Message::Text(trade_update_json().into()))
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        });
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+        let cancel2 = cancel.clone();
+
+        let url2 = url.clone();
+        tokio::spawn(async move {
+            run_inner(tx, cancel2, test_config(), &url2).await;
+        });
+
+        let mut saw_disconnect = false;
+        let mut saw_trade = false;
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !saw_disconnect || !saw_trade {
+                match rx.recv().await {
+                    Some(Event::StreamDisconnected(StreamKind::Account)) => {
+                        saw_disconnect = true;
+                    }
+                    Some(Event::TradeUpdate(o)) if o.symbol == "AAPL" => {
+                        saw_trade = true;
+                    }
+                    Some(_) => {}
+                    None => break,
+                }
+            }
+        })
+        .await
+        .expect("should see disconnect + reconnect trade update within 5s");
+
+        cancel.cancel();
+        assert!(
+            saw_disconnect,
+            "should emit StreamDisconnected on first close"
+        );
+        assert!(saw_trade, "should emit TradeUpdate after reconnect");
     }
 }

--- a/src/stream/market.rs
+++ b/src/stream/market.rs
@@ -23,7 +23,17 @@ pub async fn run(
     tx: Sender<Event>,
     cancel: CancellationToken,
     config: AlpacaConfig,
+    symbol_rx: watch::Receiver<Vec<String>>,
+) {
+    run_inner(tx, cancel, config, symbol_rx, DATA_URL).await
+}
+
+async fn run_inner(
+    tx: Sender<Event>,
+    cancel: CancellationToken,
+    config: AlpacaConfig,
     mut symbol_rx: watch::Receiver<Vec<String>>,
+    url: &str,
 ) {
     let mut backoff = 1u64;
 
@@ -45,7 +55,7 @@ pub async fn run(
             }
         }
 
-        match run_once(&tx, &cancel, &config, &mut symbol_rx).await {
+        match run_once(&tx, &cancel, &config, &mut symbol_rx, url).await {
             Ok(_) => {
                 // clean shutdown requested
                 return;
@@ -68,10 +78,11 @@ async fn run_once(
     cancel: &CancellationToken,
     config: &AlpacaConfig,
     symbol_rx: &mut watch::Receiver<Vec<String>>,
+    url: &str,
 ) -> anyhow::Result<()> {
-    info!(url = DATA_URL, "connecting to market data stream");
+    info!(url = url, "connecting to market data stream");
 
-    let (ws, _) = connect_async(DATA_URL).await?;
+    let (ws, _) = connect_async(url).await?;
     let (mut write, mut read) = ws.split();
 
     // Authenticate
@@ -242,5 +253,218 @@ mod tests {
         assert_eq!(quotes[0].symbol, "AAPL");
         assert!(quotes[0].ap.is_none());
         assert!(quotes[0].bp.is_none());
+    }
+}
+
+#[cfg(test)]
+mod integration {
+    use super::*;
+    use crate::config::AlpacaEnv;
+    use futures::SinkExt;
+    use tokio::sync::{mpsc, watch};
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    fn test_config() -> AlpacaConfig {
+        AlpacaConfig {
+            base_url: String::new(),
+            key: "test-key".to_string(),
+            secret: "test-secret".to_string(),
+            env: AlpacaEnv::Paper,
+        }
+    }
+
+    async fn bind_local() -> (tokio::net::TcpListener, String) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        (listener, format!("ws://127.0.0.1:{}", port))
+    }
+
+    #[tokio::test]
+    async fn market_run_once_auth_success_emits_quote() {
+        let (listener, url) = bind_local().await;
+
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await; // consume auth
+            ws.send(Message::Text(
+                r#"[{"T":"success","msg":"authenticated"}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws.next().await; // consume subscribe
+            ws.send(Message::Text(
+                r#"[{"T":"q","S":"AAPL","ap":185.0,"bp":184.9}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        });
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let (_sym_tx, mut sym_rx) = watch::channel(vec!["AAPL".to_string()]);
+
+        let cancel2 = cancel.clone();
+        let url2 = url.clone();
+        let tx2 = tx.clone();
+        tokio::spawn(async move {
+            run_once(&tx2, &cancel2, &test_config(), &mut sym_rx, &url2)
+                .await
+                .ok();
+            cancel2.cancel();
+        });
+
+        let quote = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                match rx.recv().await? {
+                    Event::MarketQuote(q) => return Some(q),
+                    _ => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for MarketQuote")
+        .expect("channel closed");
+
+        assert_eq!(quote.symbol, "AAPL");
+        assert_eq!(quote.ap, Some(185.0));
+        assert_eq!(quote.bp, Some(184.9));
+    }
+
+    #[tokio::test]
+    async fn market_run_once_auth_failure_returns_err() {
+        let (listener, url) = bind_local().await;
+
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await;
+            ws.send(Message::Text(
+                r#"[{"T":"error","msg":"invalid credentials"}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (tx, _rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let (_sym_tx, mut sym_rx) = watch::channel(vec!["AAPL".to_string()]);
+
+        let result = run_once(&tx, &cancel, &test_config(), &mut sym_rx, &url).await;
+        assert!(result.is_err(), "auth failure should return Err");
+    }
+
+    #[tokio::test]
+    async fn market_run_once_exits_cleanly_on_cancellation() {
+        let (listener, url) = bind_local().await;
+        let cancel = CancellationToken::new();
+        let cancel2 = cancel.clone();
+
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await;
+            ws.send(Message::Text(
+                r#"[{"T":"success","msg":"authenticated"}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws.next().await; // consume subscribe
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+
+        let (tx, _rx) = mpsc::channel(16);
+        let (_sym_tx, mut sym_rx) = watch::channel(vec!["AAPL".to_string()]);
+        let config = test_config();
+        let url2 = url.clone();
+
+        let task =
+            tokio::spawn(async move { run_once(&tx, &cancel2, &config, &mut sym_rx, &url2).await });
+
+        // Give the stream time to authenticate and enter the main loop
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("task should finish within 1s after cancellation");
+        assert!(
+            matches!(result.unwrap(), Ok(())),
+            "cancellation should return Ok"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_run_reconnects_after_server_close() {
+        let (listener, url) = bind_local().await;
+
+        tokio::spawn(async move {
+            // First connection: authenticate then close
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(tcp).await.unwrap();
+            let _ = ws.next().await;
+            ws.send(Message::Text(
+                r#"[{"T":"success","msg":"authenticated"}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws.next().await; // consume subscribe
+            drop(ws); // close — triggers reconnect
+
+            // Second connection: send a quote
+            let (tcp2, _) = listener.accept().await.unwrap();
+            let mut ws2 = accept_async(tcp2).await.unwrap();
+            let _ = ws2.next().await;
+            ws2.send(Message::Text(
+                r#"[{"T":"success","msg":"authenticated"}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            let _ = ws2.next().await;
+            ws2.send(Message::Text(
+                r#"[{"T":"q","S":"TSLA","ap":200.0,"bp":199.9}]"#.into(),
+            ))
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        });
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+        let cancel2 = cancel.clone();
+        let (_sym_tx, sym_rx) = watch::channel(vec!["TSLA".to_string()]);
+
+        let url2 = url.clone();
+        tokio::spawn(async move {
+            run_inner(tx, cancel2, test_config(), sym_rx, &url2).await;
+        });
+
+        let mut saw_disconnect = false;
+        let mut saw_quote = false;
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !saw_disconnect || !saw_quote {
+                match rx.recv().await {
+                    Some(Event::StreamDisconnected(StreamKind::Market)) => {
+                        saw_disconnect = true;
+                    }
+                    Some(Event::MarketQuote(q)) if q.symbol == "TSLA" => {
+                        saw_quote = true;
+                    }
+                    Some(_) => {}
+                    None => break,
+                }
+            }
+        })
+        .await
+        .expect("should see disconnect + reconnect quote within 5s");
+
+        cancel.cancel();
+        assert!(
+            saw_disconnect,
+            "should emit StreamDisconnected on first close"
+        );
+        assert!(saw_quote, "should emit MarketQuote after reconnect");
     }
 }


### PR DESCRIPTION
Implements issue #16: WebSocket integration tests for market and account stream `run()` functions.

## Changes

### Refactoring
- Extract `run_inner(url: &str, ...)` in both `market.rs` and `account.rs` so tests can drive the full reconnect loop against a local server
- Add `url: &str` parameter to `run_once` in `market.rs` (account.rs already had it)

### New integration tests (8 total, 4 per stream)
| Test | Verifies |
|---|---|
| `auth_success_emits_quote/trade_update` | Auth handshake → `StreamConnected` + data event emitted |
| `auth_failure_returns_err` | `run_once` returns `Err` on bad auth without panicking |
| `exits_cleanly_on_cancellation` | Task completes within 1s with `Ok(())` after cancel |
| `reconnects_after_server_close` | `StreamDisconnected` emitted, then data from second connection |

All tests use `tokio_tungstenite::accept_async` with `127.0.0.1:0` (ephemeral port, no conflicts).

Closes #16