### PR TITLE
ci: add release workflow to publish binaries on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  upload-assets:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: alpaca-trader
+          target: ${{ matrix.target }}
+          archive: $name-$target.$ext
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # alpaca-trader-rs
 
 [![CI](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/ci.yml)
+[![Release](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/release.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/release.yml)
 [![Security audit](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/security.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/arunkumar-mourougappane/alpaca-trader-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/arunkumar-mourougappane/alpaca-trader-rs)
 ![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)
@@ -223,6 +224,7 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | GitHub Actions CI + security audit | Done |
 | Code coverage with cargo-llvm-cov + Codecov | Done |
 | WebSocket integration tests (auth, cancel, reconnect) | Done |
+| Release workflow — pre-compiled binaries on tag push | Done |
 | Status message auto-dismiss (3 s TTL) | Done |
 | WebSocket stream connection status in header | Done |
 | Order Entry: Time-in-Force (DAY/GTC) selection | Done |

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -219,6 +219,10 @@ Linux-only but simpler setup. Suitable for existing projects already using it.
 
 Builds and uploads pre-compiled binaries to a GitHub Release across multiple targets.
 
+> **Active in this project:** `.github/workflows/release.yml` triggers on `v*` tags and
+> publishes binaries for Linux (`x86_64`), macOS Intel, and macOS Apple Silicon.
+> Windows (`x86_64-pc-windows-msvc`) will be added once Windows TUI compatibility is verified.
+
 ```yaml
 name: Release
 on:
@@ -620,11 +624,10 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          # Add x86_64-pc-windows-msvc once Windows TUI compatibility is verified
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/upload-rust-binary-action@v1
         with:


### PR DESCRIPTION
Implements issue #17: release workflow that publishes pre-compiled binaries to GitHub Releases on every `v*` tag push.

## Changes

- **`.github/workflows/release.yml`** (new) — Triggers on `push: tags: ["v*"]`; uses `taiki-e/upload-rust-binary-action@v1` to build and upload binaries for:
  - `x86_64-unknown-linux-gnu` (ubuntu-latest)
  - `x86_64-apple-darwin` (macos-latest)
  - `aarch64-apple-darwin` (macos-latest)
  - Windows (`x86_64-pc-windows-msvc`) is excluded until TUI compatibility is verified
- **`README.md`** — Release badge added; feature table updated
- **`docs/github-actions.md`** — Section 4 note that the workflow is active in this project; quick-reference snippet updated to use `actions/checkout@v6` (project convention) and omit Windows

No Rust source changes — no tests required.

Closes #17