### PR TITLE
docs(api): add comprehensive doc comments to all public library items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps --all-features
         env:
-          RUSTDOCFLAGS: "-D warnings"
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
 
   coverage:
     name: Coverage

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+//! Async HTTP client wrapping the Alpaca Markets REST API.
 use anyhow::{Context, Result};
 use reqwest::header::{HeaderMap, HeaderValue};
 
@@ -7,12 +8,18 @@ use crate::types::{
     WatchlistSummary,
 };
 
+/// Async HTTP client for the Alpaca Markets REST API.
+///
+/// All methods require valid credentials in the [`AlpacaConfig`] provided at
+/// construction time. Each call sets the `APCA-API-KEY-ID` and
+/// `APCA-API-SECRET-KEY` request headers automatically.
 pub struct AlpacaClient {
     http: reqwest::Client,
     config: AlpacaConfig,
 }
 
 impl AlpacaClient {
+    /// Create a new client using the given configuration.
     pub fn new(config: AlpacaConfig) -> Self {
         Self {
             http: reqwest::Client::new(),
@@ -39,6 +46,7 @@ impl AlpacaClient {
         format!("{}{}", self.config.base_url, path)
     }
 
+    /// Fetch the current account snapshot (`GET /account`).
     pub async fn get_account(&self) -> Result<AccountInfo> {
         self.http
             .get(self.url("/account"))
@@ -51,6 +59,7 @@ impl AlpacaClient {
             .context("GET /account parse failed")
     }
 
+    /// Fetch all current open positions (`GET /positions`).
     pub async fn get_positions(&self) -> Result<Vec<Position>> {
         self.http
             .get(self.url("/positions"))
@@ -63,6 +72,9 @@ impl AlpacaClient {
             .context("GET /positions parse failed")
     }
 
+    /// Fetch orders filtered by `status` (`GET /orders?status=<status>&limit=100`).
+    ///
+    /// Common values for `status`: `"open"`, `"closed"`, `"all"`.
     pub async fn get_orders(&self, status: &str) -> Result<Vec<Order>> {
         self.http
             .get(self.url("/orders"))
@@ -76,6 +88,9 @@ impl AlpacaClient {
             .context("GET /orders parse failed")
     }
 
+    /// Submit a new order (`POST /orders`).
+    ///
+    /// Returns the created [`Order`] with its assigned `id` and initial status.
     pub async fn submit_order(&self, req: &OrderRequest) -> Result<Order> {
         self.http
             .post(self.url("/orders"))
@@ -89,6 +104,7 @@ impl AlpacaClient {
             .context("POST /orders parse failed")
     }
 
+    /// Cancel an open order by its ID (`DELETE /orders/{id}`).
     pub async fn cancel_order(&self, id: &str) -> Result<()> {
         self.http
             .delete(self.url(&format!("/orders/{}", id)))
@@ -99,6 +115,9 @@ impl AlpacaClient {
         Ok(())
     }
 
+    /// Fetch the current market clock (`GET /clock`).
+    ///
+    /// Returns whether the market is open and the next open/close times.
     pub async fn get_clock(&self) -> Result<MarketClock> {
         self.http
             .get(self.url("/clock"))
@@ -111,6 +130,11 @@ impl AlpacaClient {
             .context("GET /clock parse failed")
     }
 
+    /// List all watchlists for the account (`GET /watchlists`).
+    ///
+    /// Returns summaries (id + name only). Use [`get_watchlist`] to fetch full asset lists.
+    ///
+    /// [`get_watchlist`]: AlpacaClient::get_watchlist
     pub async fn list_watchlists(&self) -> Result<Vec<WatchlistSummary>> {
         self.http
             .get(self.url("/watchlists"))
@@ -123,6 +147,7 @@ impl AlpacaClient {
             .context("GET /watchlists parse failed")
     }
 
+    /// Fetch a watchlist including its full asset list (`GET /watchlists/{id}`).
     pub async fn get_watchlist(&self, id: &str) -> Result<Watchlist> {
         self.http
             .get(self.url(&format!("/watchlists/{}", id)))
@@ -135,6 +160,9 @@ impl AlpacaClient {
             .context("GET /watchlists/{id} parse failed")
     }
 
+    /// Add a symbol to a watchlist (`POST /watchlists/{id}`).
+    ///
+    /// Returns the updated [`Watchlist`] with the new symbol included.
     pub async fn add_to_watchlist(&self, id: &str, symbol: &str) -> Result<Watchlist> {
         let body = serde_json::json!({ "symbol": symbol });
         self.http
@@ -149,6 +177,9 @@ impl AlpacaClient {
             .context("POST /watchlists/{id} parse failed")
     }
 
+    /// Remove a symbol from a watchlist (`DELETE /watchlists/{id}/{symbol}`).
+    ///
+    /// Returns the updated [`Watchlist`] with the symbol removed.
     pub async fn remove_from_watchlist(&self, id: &str, symbol: &str) -> Result<Watchlist> {
         self.http
             .delete(self.url(&format!("/watchlists/{}/{}", id, symbol)))
@@ -161,6 +192,10 @@ impl AlpacaClient {
             .context("DELETE /watchlists/{id}/{symbol} parse failed")
     }
 
+    /// Fetch intraday portfolio equity history (`GET /account/portfolio/history`).
+    ///
+    /// Requests 1-minute bars for the current trading day. Equity values are
+    /// `None` for buckets when the market was closed.
     pub async fn get_portfolio_history(&self) -> Result<PortfolioHistory> {
         self.http
             .get(self.url("/account/portfolio/history"))

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,22 +1,39 @@
-/// Commands sent from `update()` (sync) to the async command handler task.
-/// This is the bridge across the sync/async boundary for all mutation operations.
+//! Commands sent across the sync/async boundary from the UI to the async handler task.
+/// Commands sent from `update()` (sync) to the async command-handler task.
+///
+/// This enum bridges the sync/async boundary for all mutation operations
+/// initiated from key-press handlers in the UI layer.
 #[derive(Debug)]
 pub enum Command {
+    /// Submit a new order to the broker.
     SubmitOrder {
+        /// Ticker symbol to trade (e.g., `"AAPL"`).
         symbol: String,
-        side: String,       // "buy" | "sell"
-        order_type: String, // "market" | "limit"
+        /// Order direction: `"buy"` or `"sell"`.
+        side: String,
+        /// Execution type: `"market"` or `"limit"`.
+        order_type: String,
+        /// Whole-share quantity; `None` when using notional.
         qty: Option<String>,
+        /// Limit price for limit orders; `None` for market orders.
         price: Option<String>,
+        /// Time-in-force: `"day"` or `"gtc"`.
         time_in_force: String,
     },
-    CancelOrder(String), // order id
+    /// Cancel an open order identified by its Alpaca order ID.
+    CancelOrder(String),
+    /// Add a symbol to a watchlist.
     AddToWatchlist {
+        /// UUID of the target watchlist.
         watchlist_id: String,
+        /// Ticker symbol to add.
         symbol: String,
     },
+    /// Remove a symbol from a watchlist.
     RemoveFromWatchlist {
+        /// UUID of the target watchlist.
         watchlist_id: String,
+        /// Ticker symbol to remove.
         symbol: String,
     },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+//! Runtime configuration loaded from environment variables.
 use anyhow::{anyhow, Context, Result};
 
 #[cfg(test)]
@@ -116,22 +117,47 @@ mod tests {
     }
 }
 
+/// Selects which Alpaca trading environment to connect to.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AlpacaEnv {
+    /// Alpaca paper-trading environment — uses simulated funds with no real money.
     Paper,
+    /// Alpaca live-trading environment — uses real funds; handle with care.
     Live,
 }
 
+/// Runtime configuration loaded from environment variables.
+///
+/// Construct via [`AlpacaConfig::from_env`]; the individual fields are
+/// exposed so downstream code can read the resolved values without
+/// re-parsing the environment.
 #[derive(Debug, Clone)]
 pub struct AlpacaConfig {
-    /// REST base URL, includes /v2, no trailing slash
+    /// REST base URL including `/v2`, without a trailing slash.
+    ///
+    /// Example: `https://paper-api.alpaca.markets/v2`
     pub base_url: String,
+    /// Alpaca API key ID (`APCA-API-KEY-ID` header value).
     pub key: String,
+    /// Alpaca API secret key (`APCA-API-SECRET-KEY` header value).
     pub secret: String,
+    /// Which environment (paper / live) this config targets.
     pub env: AlpacaEnv,
 }
 
 impl AlpacaConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// Reads `ALPACA_ENV` (defaults to `"paper"`) then picks the matching set
+    /// of variables:
+    ///
+    /// | Env | Variables required |
+    /// |-----|--------------------|
+    /// | `paper` | `PAPER_ALPACA_ENDPOINT`, `PAPER_ALPACA_KEY`, `PAPER_ALPACA_SECRET` |
+    /// | `live`  | `LIVE_ALPACA_ENDPOINT`,  `LIVE_ALPACA_KEY`,  `LIVE_ALPACA_SECRET`  |
+    ///
+    /// Returns an error if any required variable is missing or if `ALPACA_ENV`
+    /// is set to an unrecognised value.
     pub fn from_env() -> Result<Self> {
         let env_label = std::env::var("ALPACA_ENV").unwrap_or_else(|_| "paper".into());
 
@@ -173,6 +199,9 @@ impl AlpacaConfig {
         }
     }
 
+    /// Returns a short uppercase label for the current environment.
+    ///
+    /// Returns `"PAPER"` or `"LIVE"`. Useful for status-bar display.
     pub fn env_label(&self) -> &'static str {
         match self.env {
             AlpacaEnv::Paper => "PAPER",

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,34 +1,52 @@
+//! Application event types that flow through the central event channel.
 use crate::types::{AccountInfo, MarketClock, Order, Position, Quote, Watchlist};
 use crossterm::event::{KeyEvent, MouseEvent};
 
 /// Identifies which WebSocket stream a connection-status event concerns.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamKind {
+    /// Real-time market data stream (quotes, trades).
     Market,
+    /// Account/order update stream (trade confirmations, account changes).
     Account,
 }
 
+/// All events that flow through the application's event channel.
+///
+/// The event loop receives these from background tasks (REST pollers,
+/// WebSocket streams, terminal input) and forwards them to `update()`.
 #[derive(Debug)]
 pub enum Event {
+    /// A keyboard key was pressed.
     Input(KeyEvent),
+    /// A mouse event occurred (click, scroll, etc.).
     Mouse(MouseEvent),
+    /// The terminal was resized to the given `(columns, rows)`.
     Resize(u16, u16),
-    // REST poll results
+    /// Latest account snapshot from the REST poll.
     AccountUpdated(AccountInfo),
+    /// Current open positions from the REST poll.
     PositionsUpdated(Vec<Position>),
+    /// Current orders from the REST poll.
     OrdersUpdated(Vec<Order>),
+    /// Market clock state from the REST poll.
     ClockUpdated(MarketClock),
+    /// Updated watchlist (after an add/remove command or periodic poll).
     WatchlistUpdated(Watchlist),
-    // WebSocket (Phase 2)
+    /// Latest NBBO quote received from the market data WebSocket.
     MarketQuote(Quote),
+    /// Order update received from the account WebSocket stream.
     TradeUpdate(Order),
-    // WebSocket stream connection status
+    /// A WebSocket stream successfully (re)connected.
     StreamConnected(StreamKind),
+    /// A WebSocket stream disconnected; reconnection will be attempted.
     StreamDisconnected(StreamKind),
-    // Startup: pre-populate equity sparkline from portfolio history API
+    /// Portfolio equity history loaded at startup for the sparkline.
     PortfolioHistoryLoaded(Vec<f64>),
-    // Control
+    /// Periodic tick to trigger UI refresh / REST polls.
     Tick,
+    /// One-shot status message to display in the status bar.
     StatusMsg(String),
+    /// Request to quit the application.
     Quit,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Alpaca Markets trading library.
+//!
+//! Provides an async REST client, real-time WebSocket stream abstractions, and
+//! all supporting domain types for building Alpaca trading applications in Rust.
+
+#![deny(missing_docs)]
+
 pub mod client;
 pub mod commands;
 pub mod config;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,4 @@
+//! Application logging setup using `tracing` and `tracing-appender`.
 use std::sync::Mutex;
 
 use tracing_appender::non_blocking::WorkerGuard;

--- a/src/stream/account.rs
+++ b/src/stream/account.rs
@@ -1,3 +1,10 @@
+//! Account and order update WebSocket stream.
+//!
+//! Connects to the Alpaca account stream endpoint, authenticates, and
+//! forwards [`TradeUpdate`] events to the application event channel.
+//! Reconnects automatically with a backoff delay on disconnection.
+//!
+//! [`TradeUpdate`]: crate::events::Event::TradeUpdate
 use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};

--- a/src/stream/market.rs
+++ b/src/stream/market.rs
@@ -1,3 +1,11 @@
+//! Real-time market data WebSocket stream.
+//!
+//! Connects to the Alpaca market data stream endpoint, authenticates,
+//! subscribes to quotes for the symbols in the active watchlist, and
+//! forwards [`MarketQuote`] events to the application event channel.
+//! Reconnects automatically with a backoff delay on disconnection.
+//!
+//! [`MarketQuote`]: crate::events::Event::MarketQuote
 use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,2 +1,7 @@
+//! WebSocket stream modules for real-time data.
+//!
+//! - [`account`] — account/order update stream
+//! - [`market`] — real-time market quotes stream
+
 pub mod account;
 pub mod market;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+//! Domain types used throughout the library and the binary crate.
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
@@ -135,62 +136,99 @@ mod tests {
     }
 }
 
+/// Snapshot of account balances and status from `GET /account`.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct AccountInfo {
+    /// Account status (e.g., `"ACTIVE"`).
     pub status: String,
+    /// Total account equity as a dollar string.
     pub equity: String,
+    /// Buying power available for new orders, as a dollar string.
     pub buying_power: String,
+    /// Cash balance, as a dollar string.
     pub cash: String,
+    /// Total long market value of all positions, as a dollar string.
     pub long_market_value: String,
+    /// Number of day trades made in the rolling 5-business-day window.
     pub daytrade_count: u32,
+    /// Whether the account has been flagged as a pattern day trader.
     pub pattern_day_trader: bool,
+    /// Account currency (typically `"USD"`).
     pub currency: String,
+    /// Total portfolio value; may be absent on some account types.
     #[serde(default)]
     pub portfolio_value: Option<String>,
 }
 
+/// A single open or closed position held in the account.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Position {
+    /// Ticker symbol (e.g., `"AAPL"`).
     pub symbol: String,
+    /// Number of shares held (positive = long, may be fractional).
     pub qty: String,
+    /// Average cost basis per share, as a dollar string.
     pub avg_entry_price: String,
+    /// Current price per share, as a dollar string.
     pub current_price: String,
+    /// Current market value of the entire position, as a dollar string.
     pub market_value: String,
+    /// Total unrealised profit/loss, as a dollar string.
     pub unrealized_pl: String,
+    /// Total unrealised profit/loss percentage, as a decimal string.
     pub unrealized_plpc: String,
+    /// Position side: `"long"` or `"short"`.
     pub side: String,
+    /// Asset class (e.g., `"us_equity"`, `"crypto"`).
     #[serde(default)]
     pub asset_class: String,
 }
 
+/// An order placed with the broker (open, filled, cancelled, etc.).
 #[derive(Debug, Clone, Deserialize)]
 pub struct Order {
+    /// Unique order ID assigned by Alpaca.
     pub id: String,
+    /// Ticker symbol the order is for.
     pub symbol: String,
+    /// Order direction: `"buy"` or `"sell"`.
     pub side: String,
+    /// Whole-share quantity. Mutually exclusive with `notional`.
     #[serde(default)]
     pub qty: Option<String>,
+    /// Dollar notional amount. Mutually exclusive with `qty`.
     #[serde(default)]
     pub notional: Option<String>,
+    /// Order type: `"market"`, `"limit"`, etc.
     pub order_type: String,
+    /// Limit price for limit orders; absent for market orders.
     #[serde(default)]
     pub limit_price: Option<String>,
+    /// Current order status (e.g., `"new"`, `"filled"`, `"canceled"`).
     pub status: String,
+    /// ISO 8601 timestamp of when the order was submitted.
     #[serde(default)]
     pub submitted_at: Option<String>,
+    /// ISO 8601 timestamp of when the order was fully filled.
     #[serde(default)]
     pub filled_at: Option<String>,
+    /// Number of shares filled so far.
     pub filled_qty: String,
+    /// Time-in-force: `"day"`, `"gtc"`, etc.
     pub time_in_force: String,
 }
 
+/// Direction of an order.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OrderSide {
+    /// Buy (long) order.
     Buy,
+    /// Sell (short or close-long) order.
     Sell,
 }
 
 impl OrderSide {
+    /// Returns the lowercase API string for this side: `"buy"` or `"sell"`.
     pub fn as_str(&self) -> &'static str {
         match self {
             OrderSide::Buy => "buy",
@@ -199,13 +237,17 @@ impl OrderSide {
     }
 }
 
+/// Execution type of an order.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OrderType {
+    /// Execute immediately at the best available price.
     Market,
+    /// Execute only at the specified limit price or better.
     Limit,
 }
 
 impl OrderType {
+    /// Returns the lowercase API string: `"market"` or `"limit"`.
     pub fn as_str(&self) -> &'static str {
         match self {
             OrderType::Market => "market",
@@ -214,13 +256,17 @@ impl OrderType {
     }
 }
 
+/// How long an order remains active before it is automatically cancelled.
 #[derive(Debug, Clone)]
 pub enum TimeInForce {
+    /// Active only for the current trading day.
     Day,
+    /// Active until explicitly cancelled (Good Till Cancelled).
     Gtc,
 }
 
 impl TimeInForce {
+    /// Returns the lowercase API string: `"day"` or `"gtc"`.
     pub fn as_str(&self) -> &'static str {
         match self {
             TimeInForce::Day => "day",
@@ -229,67 +275,109 @@ impl TimeInForce {
     }
 }
 
+/// Request body sent to `POST /orders`.
+///
+/// Either `qty` or `notional` must be set; not both.
 #[derive(Debug, Clone, Serialize)]
 pub struct OrderRequest {
+    /// Ticker symbol to trade.
     pub symbol: String,
+    /// Whole-share quantity; omitted when using notional.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub qty: Option<String>,
+    /// Dollar notional; omitted when using share quantity.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notional: Option<String>,
+    /// Order direction — `"buy"` or `"sell"`.
     pub side: String,
+    /// Order type — `"market"`, `"limit"`, etc.
     #[serde(rename = "type")]
     pub order_type: String,
+    /// Time-in-force — `"day"`, `"gtc"`, etc.
     pub time_in_force: String,
+    /// Required for limit orders; omitted for market orders.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit_price: Option<String>,
 }
 
+/// Current market clock from `GET /clock`.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct MarketClock {
+    /// `true` if the primary US equity market is currently open.
     pub is_open: bool,
+    /// ISO 8601 timestamp of the next market open.
     pub next_open: String,
+    /// ISO 8601 timestamp of the next market close.
     pub next_close: String,
+    /// Current server timestamp in ISO 8601 format.
     pub timestamp: String,
 }
 
+/// Latest NBBO quote for a symbol from the market data stream.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Quote {
+    /// Ticker symbol this quote is for.
     pub symbol: String,
+    /// Ask price (best offer), absent before the first quote arrives.
     #[serde(default)]
     pub ap: Option<f64>,
+    /// Bid price (best bid), absent before the first quote arrives.
     #[serde(default)]
     pub bp: Option<f64>,
+    /// Ask size in round lots.
     #[serde(default)]
     pub as_: Option<u64>,
+    /// Bid size in round lots.
     #[serde(default)]
     pub bs: Option<u64>,
 }
 
+/// Brief watchlist descriptor returned by `GET /watchlists`.
+///
+/// For the full asset list use [`Watchlist`] via [`AlpacaClient::get_watchlist`].
+///
+/// [`AlpacaClient::get_watchlist`]: crate::client::AlpacaClient::get_watchlist
 #[derive(Debug, Clone, Deserialize)]
 pub struct WatchlistSummary {
+    /// Unique watchlist identifier (UUID).
     pub id: String,
+    /// Human-readable watchlist name.
     pub name: String,
 }
 
+/// Full watchlist including its constituent assets.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Watchlist {
+    /// Unique watchlist identifier (UUID).
     pub id: String,
+    /// Human-readable watchlist name.
     pub name: String,
+    /// Ordered list of assets in this watchlist.
     #[serde(default)]
     pub assets: Vec<Asset>,
 }
 
+/// An individual asset returned inside a [`Watchlist`] or from `GET /assets`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Asset {
+    /// Unique asset identifier (UUID).
     pub id: String,
+    /// Ticker symbol (e.g., `"AAPL"`).
     pub symbol: String,
+    /// Full company or asset name.
     pub name: String,
+    /// Exchange on which the asset trades (e.g., `"NASDAQ"`).
     pub exchange: String,
+    /// Asset class (e.g., `"us_equity"`, `"crypto"`).
     #[serde(rename = "class")]
     pub asset_class: String,
+    /// Whether the asset is currently tradable via the API.
     pub tradable: bool,
+    /// Whether the asset can be sold short.
     pub shortable: bool,
+    /// Whether fractional-share quantities are supported.
     pub fractionable: bool,
+    /// Whether the asset is easy to borrow for shorting.
     #[serde(default)]
     pub easy_to_borrow: bool,
 }


### PR DESCRIPTION
## Summary

Implements #18 — adds `///` doc comments to every public item in the library crate and enforces coverage with `#![deny(missing_docs)]`.

### Changes

- **`src/lib.rs`** —
- **`src/config.rs`** —
- **`src/client.rs`** —
- **`src/types.rs`** —
- **`src/commands.rs`** —
- **`src/events.rs`** —
- **`src/logging.rs`** —
- **`src/stream/mod.rs`** —
- **`src/stream/account.rs`** —
- **`src/stream/market.rs`** —
- **`.github/workflows/ci.yml`** — add `--cfg docsrs` to `RUSTDOCFLAGS` in the docs job

### Verification

`cargo fmt`, `cargo clippy --all-targets --all-features` (zero warnings), and `cargo test` (all 186 tests pass) were run before committing.

Closes #18