### PR TITLE
perf(build): add release profile optimisations to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ dirs               = "6"
 wiremock   = "0.6"
 tokio-test = "0.4"
 temp-env   = "0.3"
+
+[profile.release]
+opt-level     = 3
+lto           = "thin"   # link-time optimisation across crates
+codegen-units = 1        # maximise inlining at cost of compile time
+strip         = "symbols" # remove debug symbols from release binary


### PR DESCRIPTION
## Summary

Adds a `[profile.release]` section to `Cargo.toml` with the settings requested in #20.

```toml
[profile.release]
opt-level     = 3
lto           = "thin"    # cross-crate link-time optimisation
codegen-units = 1          # maximise inlining at cost of compile time
strip         = "symbols" # remove debug symbols from release binary
```

**Expected impact:** ~30–50% binary size reduction from symbol stripping + thin LTO, with improved rendering hot-path performance.

Closes #20