### PR TITLE
docs: update CHANGELOG and RELEASE_NOTES for v0.2.0; bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
+## [0.2.0] — 2026-05-10
+
+Completes the Phase 2 roadmap: live WebSocket streaming, wired async command channel, structured logging, mouse interaction, and a suite of reliability fixes. Test count grows from 101 → **188**.
+
+### Added
+
+#### Streaming (Phase 2)
+- `src/stream/market.rs` — IEX WebSocket market data stream; subscribes to NBBO quotes for all watchlist symbols; live resubscription (with explicit `unsubscribe` for removed symbols) when the watchlist changes; exponential backoff reconnection (1 s → 30 s)
+- `src/stream/account.rs` — Account/trade update WebSocket stream forwarding `TradeUpdate` events for order fills; same backoff reconnection strategy
+- WebSocket connection status badges (`[MKT ●]` / `[ACCT ●]`) in the TUI header via `Event::StreamConnected` / `Event::StreamDisconnected`
+
+#### Command Channel (Phase 2)
+- `src/commands.rs` — `Command` enum (`SubmitOrder`, `CancelOrder`, `AddToWatchlist`, `RemoveFromWatchlist`) bridging the sync `update()` to async tasks
+- `src/handlers/commands.rs` — async handler task that dispatches commands to `AlpacaClient`; live order submission and watchlist mutation now make real REST calls
+
+#### Logging
+- `src/logging.rs` — structured logging via `tracing` + `tracing-appender` + `syslog`; platform-appropriate log path (`$HOME/Library/Logs/` on macOS, `$HOME/.local/share/` on Linux); `RUST_LOG` env filter support
+
+#### UX
+- Mouse click handling — tab bar and Orders sub-tab labels are clickable; hit-testing uses actual rendered label widths
+- Order Entry validation — rejects empty symbol, zero qty, or missing price on limit orders before dispatching
+- Time-in-Force toggle (DAY / GTC) in Order Entry modal; market-closed warning blocks DAY orders when market is closed
+- Status message auto-dismiss — status bar messages clear after 3 seconds
+- Portfolio history sparkline — Account panel equity sparkline pre-populated from `GET /account/portfolio/history` at startup
+
+#### Developer Experience
+- `#![deny(missing_docs)]` enforced; `///` doc comments on every public library item; `//!` module docs on every public module
+- CI `coverage` job — `cargo-llvm-cov --lcov` + Codecov upload; Codecov badge in README
+- CI `release` workflow — pre-compiled binaries for `x86_64-linux`, `x86_64-darwin`, `aarch64-darwin` on `v*` tag pushes; Release badge in README
+- `[profile.release]` — `opt-level = 3`, `lto = "thin"`, `codegen-units = 1`, `strip = "symbols"` (~30–50% binary size reduction)
+- `RUSTDOCFLAGS: "--cfg docsrs -D warnings"` in CI docs job
+
+### Fixed
+
+- **Stream unsubscribe on symbol removal** (`src/stream/market.rs`) — Alpaca IEX merges subscriptions; explicit `unsubscribe` frame now sent before re-subscribe when symbols are removed
+- **Client header panic** (`src/client.rs`) — non-ASCII / space-containing API keys now return `Err` instead of panicking in `AlpacaClient::new`
+- **Logging init without `$HOME`** (`src/logging.rs`) — graceful fallback to temp directory when `$HOME` is unset
+- **Tab bar hit-test** — mouse clicks on tab labels use rendered text widths, not fixed offsets
+- **Orders sub-tab hit-test** (`src/handlers/input.rs`) — sub-tab click areas use exact rects from the last `render()` pass
+- **Closed command channel** (`src/handlers/commands.rs`) — full or closed channel handled gracefully instead of silently dropped
+
+### Changed
+
+- `update.rs` refactored into per-panel input submodules under `src/handlers/`
+- `App` now holds `command_tx` (`mpsc::Sender<Command>`) and `symbol_tx` (`watch::Sender<Vec<String>>`) channels
+- `update()` `WatchlistUpdated` handler pushes updated symbol list to the market stream for live resubscription
+- README Status table: all four Phase 2 items marked **Done**; test count updated to 188
+- `Cargo.toml` version bumped to `0.2.0`
+
+### Tests
+
+188 total (43 lib + 126 binary + 19 HTTP integration):
+
+- 8 WebSocket integration tests (auth success, auth failure, cancellation, reconnect-after-close) × 2 stream modules
+- 2 unsubscribe integration tests (removal triggers unsubscribe frame; addition does not)
+- Regression tests for non-ASCII API key header construction
+
+---
+
 ## [0.1.0] — 2026-05-10
 
 First release. Ships as both an integratable Rust library and a standalone TUI trading dashboard.
@@ -83,12 +142,87 @@ First release. Ships as both an integratable Rust library and a standalone TUI t
 | `wiremock` | 0.6 | HTTP mocking (dev) |
 | `temp-env` | 0.3 | Env var scoping (dev) |
 
-### Known Limitations / Phase 2
+---
 
-- WebSocket market data streaming (`MarketStream`) not yet implemented — prices shown are from REST polling
-- WebSocket account/trade stream (`AccountStream`) not yet implemented — order fill notifications require manual refresh
-- Order submission and watchlist mutation are UI-only stubs — REST calls will be wired in Phase 2
+[0.2.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0
+
+
+First release. Ships as both an integratable Rust library and a standalone TUI trading dashboard.
+
+### Added
+
+#### Library (`alpaca_trader_rs`)
+- `AlpacaConfig` — resolves paper/live credentials from `.env` at startup via `ALPACA_ENV` + `LIVE_`/`PAPER_` prefixed variables
+- `AlpacaClient` — async REST client wrapping all core Alpaca v2 endpoints:
+  - `get_account`, `get_positions`, `get_orders`, `submit_order`, `cancel_order`
+  - `get_clock`, `list_watchlists`, `get_watchlist`, `add_to_watchlist`, `remove_from_watchlist`
+- Domain types with full `serde::Deserialize` support: `AccountInfo`, `Position`, `Order`, `OrderRequest`, `OrderSide`, `OrderType`, `TimeInForce`, `Quote`, `MarketClock`, `Watchlist`, `WatchlistSummary`, `Asset`
+- `Event` enum shared between the library streams and the TUI app
+
+#### TUI App (`alpaca-trader` binary)
+- Elm Architecture (TEA) event loop: typed `Event` channel, `update(app, event)` dispatch, `render(frame, app)` pure view
+- **Account panel** — equity, buying power, cash, long market value, PDT flag, intraday equity sparkline
+- **Watchlist panel** — live asset table with ask/bid prices from REST, inline `/` search filter, `a`/`d` add/remove
+- **Positions panel** — unrealised P&L per position with totals footer, live price column
+- **Orders panel** — Open / Filled / Cancelled sub-tabs switchable with `1`/`2`/`3` (context-sensitive: these keys switch global panels from other tabs)
+- **Order Entry modal** — Symbol, Side (BUY/SELL), Type (LIMIT/MARKET), Qty, Price fields; live Est. Total; buying power indicator; `Tab` field navigation
+- **Symbol Detail modal** — ask/bid, exchange, asset flags (tradable, shortable, fractionable, ETB)
+- **Help overlay** — full keyboard reference (`?`)
+- **Confirm modal** — for order cancel and watchlist removal actions
+- **Add Symbol modal** — type-to-search ticker input
+- Background tasks: REST polling every 5 s with immediate refresh on `r`; crossterm `EventStream` input task; 250 ms tick for clock updates
+- Graceful shutdown via `tokio_util::sync::CancellationToken`; terminal raw mode restored on exit
+- `run.sh` script with `--paper` / `--live` flags; `ALPACA_ENV` in `.env` selects the active environment
+
+#### Tests (101 total)
+- `types.rs` — serde round-trips, enum `as_str()`, `OrderRequest` serde rename (`order_type` → `"type"`)
+- `config.rs` — paper/live env resolution, slash trimming, MSRV, missing-var error paths (using `temp-env`)
+- `app.rs` — `Tab`/`OrderField` navigation cycles, `filtered_orders()`, `push_equity()` cap at 120 entries, watchlist search filtering
+- `update.rs` — all `Event` variants → state mutations; all keyboard paths including modal field editing, search mode, context-sensitive `1`/`2`/`3`
+- `handlers/rest.rs` — `poll_once` emits all five event types; error path sends `StatusMsg`; cancellation exits cleanly
+- `tests/client_tests.rs` — all 11 `AlpacaClient` HTTP methods against a `wiremock` mock server, including auth headers and query params
+
+#### CI / Tooling
+- GitHub Actions: Format, Clippy (`-D warnings`), Test (ubuntu + macos), MSRV (1.88), Docs
+- Security audit workflow (`cargo audit`) on Cargo file changes and weekly schedule
+- Dependabot for `cargo` and `github-actions` dependency updates (weekly)
+- `rust-version = "1.88"` declared in `Cargo.toml`
+
+#### Documentation
+- `docs/architecture.md` — TEA design, library/app boundary, module layout, data flow diagram
+- `docs/credentials-setup.md` — paper and live API key setup, env var reference
+- `docs/ui-mockups.md` — ASCII mockups for all panels and modals, full keyboard/mouse interaction spec
+- `docs/api-research.md` — live-tested REST endpoint shapes and watchlist API notes
+- `docs/testing.md` — testing strategy, mock patterns, bugs found during testing
+- `docs/github-actions.md` — GitHub Actions reference for Rust projects
+- `docs/licensing.md` — license types and Collaboration Agreement process
+
+### Fixed
+
+- `&id[..8]` panic in order cancel confirm when order ID is shorter than 8 bytes — now uses `id.len().min(8)`
+- `1`/`2`/`3` keys in Orders panel were intercepted by the global tab-switch handler, making sub-tab switching unreachable — added `if app.active_tab != Tab::Orders` guards on the global arms
+- `collapsible_match` clippy errors across all three panel key handlers and the Order Entry modal field handler — moved `if` conditions into match arm guards
+- `dtolnay/rust-toolchain@1.100` typo in CI (Rust 1.100.0 does not exist) — corrected to `@1.88`
+- `reqwest 0.13` breaking change: `.query()` moved behind the `query` feature — added `"query"` to reqwest features
+
+### Dependencies
+
+| Crate | Version | Role |
+|---|---|---|
+| `tokio` | 1 | Async runtime |
+| `reqwest` | 0.13 | HTTP client (`json` + `query` features) |
+| `tokio-tungstenite` | 0.29 | WebSocket (Phase 2) |
+| `serde` / `serde_json` | 1 | Serialization |
+| `dotenvy` | 0.15 | `.env` loading |
+| `anyhow` | 1 | Error handling |
+| `chrono` | 0.4 | Date/time |
+| `ratatui` | 0.30 | TUI rendering |
+| `crossterm` | 0.29 | Terminal backend |
+| `wiremock` | 0.6 | HTTP mocking (dev) |
+| `temp-env` | 0.3 | Env var scoping (dev) |
 
 ---
 
+[0.2.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpaca-trader-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-trader-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | Paper / Live switching (`run.sh --paper/--live`) | Done |
 | Clippy clean | Done |
 | Test strategy documented | Done |
-| Unit + integration tests (178 tests) | Done |
+| Unit + integration tests (188 tests) | Done |
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
 | Code coverage with cargo-llvm-cov + Codecov | Done |
@@ -230,10 +230,10 @@ Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag
 | Order Entry: Time-in-Force (DAY/GTC) selection | Done |
 | Order Entry: market-closed warning + DAY order block | Done |
 | Equity sparkline pre-populated from portfolio history API | Done |
-| WebSocket market data streaming | Phase 2 |
-| WebSocket account/trade stream | Phase 2 |
-| Live order submission | Phase 2 |
-| Watchlist add/remove (wired to REST) | Phase 2 |
+| WebSocket market data streaming | Done |
+| WebSocket account/trade stream | Done |
+| Live order submission | Done |
+| Watchlist add/remove (wired to REST) | Done |
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,43 +1,81 @@
-# Release Notes — v0.1.0
+# Release Notes — v0.2.0
 
-**Release date:** 2026-05-09
+**Release date:** 2026-05-10
 **MSRV:** Rust 1.88+
+**Previous release:** [v0.1.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0)
 
 ---
 
 ## Overview
 
-First public release of `alpaca-trader-rs` — an Alpaca Markets trading toolkit for Rust shipping as both an embeddable library crate and a standalone terminal UI application.
+v0.2.0 completes the Phase 2 roadmap: live WebSocket streaming for market data and account events, a fully wired async command channel for order submission and watchlist mutations, structured logging, and a raft of UX and reliability improvements. The test suite has grown from 101 to **188 tests**.
 
 ---
 
-## What's Included
+## What's New
 
-### Library (`alpaca_trader_rs`)
+### WebSocket Streaming (Phase 2 — now complete)
 
-- **`AlpacaClient`** — async REST client built on `reqwest` 0.13 with APCA authentication headers. Covers all core endpoints: account info, positions, orders (list / submit / cancel), market clock, and watchlists.
-- **`AlpacaConfig`** — loads paper or live credentials from environment variables, with trailing-slash normalisation and automatic `/v2` suffix handling.
-- **Domain types** — fully `serde`-deserializable structs for `AccountInfo`, `Position`, `Order`, `Quote`, `Watchlist`, `MarketClock`, and supporting enums (`OrderSide`, `OrderType`, `TimeInForce`).
-- **`Event` enum** — bridges terminal input, REST poll results, WebSocket data (Phase 2), and control signals over a single `tokio::sync::mpsc` channel.
+- **`src/stream/market.rs`** — connects to the Alpaca IEX market data WebSocket, authenticates, and streams real-time NBBO quotes for every symbol in the active watchlist. Resubscribes automatically when the watchlist changes; sends an explicit `unsubscribe` message for removed symbols (the protocol merges subscriptions and does not replace them). Reconnects with exponential backoff (1 s → 30 s cap) on disconnect.
+- **`src/stream/account.rs`** — connects to the Alpaca account/trade update stream and forwards `TradeUpdate` events for order fills and status changes. Same exponential-backoff reconnection strategy.
+- **Connection status indicators** — the TUI header now shows live `[MKT ●]` / `[ACCT ●]` badges, updated in real time via `Event::StreamConnected` / `Event::StreamDisconnected`.
 
-### Application (`alpaca-trader` binary)
+### Command Channel (Phase 2 — now complete)
 
-- **TUI dashboard** built on `ratatui` 0.30 and `crossterm` 0.29 with four panels:
-  - **Account** — equity, buying power, cash, day-trade count, and a scrolling equity sparkline.
-  - **Watchlist** — symbol list with live search/filter (`/`), add (`a`), and remove (`d`).
-  - **Positions** — open positions table with P&L and totals footer.
-  - **Orders** — Open / Filled / Cancelled sub-tabs; inline order entry modal; cancel confirmation dialog.
-- **Order Entry modal** — market or limit orders, buy/sell, qty, price, time-in-force.
-- **Symbol Detail modal** — per-symbol quote snapshot.
-- **Help overlay** — full keyboard reference (`?`).
-- **Paper / Live switching** — `run.sh --paper` (default) / `run.sh --live`; header badge shows `[PAPER]` (cyan) or `[LIVE]` (red) at all times.
-- **REST poll loop** — concurrent five-endpoint poll every 5 seconds via `tokio::join!`; manual refresh via `r` key.
+- **`src/commands.rs`** — defines the `Command` enum (`SubmitOrder`, `CancelOrder`, `AddToWatchlist`, `RemoveFromWatchlist`) bridging the synchronous `update()` function to the async task world.
+- **`src/handlers/commands.rs`** — async command-handler task that receives commands from `update()` over an `mpsc` channel and dispatches them to `AlpacaClient`. Live order submission and watchlist mutation now make real REST calls.
 
-### Key Bindings
+### Logging
+
+- **`src/logging.rs`** — structured logging via `tracing` + `tracing-appender` + `syslog`. Writes to a rolling file at a platform-appropriate path (`$HOME/Library/Logs/alpaca-trader/` on macOS, `$HOME/.local/share/alpaca-trader/` on Linux) and forwards to the system syslog. `RUST_LOG` controls the log level at runtime.
+
+### UX Improvements
+
+- **Mouse click handling** — clicking a tab bar label switches to that panel; clicking Orders sub-tab labels switches sub-tabs. Hit-testing uses actual rendered label widths, not fixed offsets.
+- **Order Entry validation** — the order form is validated before dispatching a command: empty symbol, zero quantity, and a missing price on limit orders are all rejected with a status-bar error message.
+- **Time-in-Force toggle** — the Order Entry modal now includes a DAY / GTC selector. When the market is closed, submitting a DAY order is blocked with a warning.
+- **Status message auto-dismiss** — status-bar messages clear automatically after 3 seconds; no manual `Esc` required.
+- **Portfolio history sparkline** — the Account panel equity sparkline is now pre-populated from `GET /account/portfolio/history` at startup (1-minute bars for the current trading day), so the chart is immediately useful even before the first real-time tick.
+
+### Developer Experience
+
+- **`#![deny(missing_docs)]`** — enforced across the entire library crate. Every public struct, enum, variant, field, and method now has a `///` doc comment; every public module has a `//!` module-level doc.
+- **CI: code coverage** — a `coverage` job runs `cargo-llvm-cov --lcov` and uploads results to Codecov. Codecov badge added to README.
+- **CI: release workflow** — `.github/workflows/release.yml` compiles and uploads pre-built binaries for `x86_64-linux`, `x86_64-darwin`, and `aarch64-darwin` on every `v*` tag push. Release badge added to README.
+- **Release profile** — `Cargo.toml` gains `[profile.release]` with `opt-level = 3`, `lto = "thin"`, `codegen-units = 1`, `strip = "symbols"`, expected to reduce binary size by ~30–50%.
+
+---
+
+## Bug Fixes
+
+| Fix | File | Detail |
+|-----|------|--------|
+| Stream unsubscribe on symbol removal | `src/stream/market.rs` | The Alpaca IEX protocol merges subscriptions; removed symbols were still streaming until the connection recycled. An explicit `unsubscribe` frame is now sent before the re-subscribe. |
+| Client header panic | `src/client.rs` | `AlpacaClient::new` called `.unwrap()` on header value construction; non-ASCII or space-containing keys now return a proper `Result::Err`. |
+| Logging init with `$HOME` unset | `src/logging.rs` | Logging initialiser no longer panics when `$HOME` is absent; falls back to a temporary directory. |
+| Tab bar hit-test | `src/handlers/input.rs` | Mouse clicks on tab bar labels used fixed offsets; replaced with widths measured from the rendered text. |
+| Orders sub-tab hit-test | `src/handlers/input.rs` | Sub-tab mouse click areas now use the exact rects captured during the last `render()` pass. |
+| Closed command channel | `src/handlers/commands.rs` | Command sends to a closed or full channel are now handled gracefully instead of silently dropped. |
+
+---
+
+## Tests
+
+**188 tests total** (up from 101 in v0.1.0):
+
+| Scope | Count | Highlights |
+|---|---|---|
+| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 43 | 8 WebSocket integration tests (auth, auth-failure, cancel, reconnect) × 2 streams; 2 unsubscribe tests; serde + env-var unit tests |
+| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`) | 126 | State logic, keyboard dispatch, mouse click paths, validation, command dispatch, REST polling |
+| HTTP integration (`tests/client_tests.rs`) | 19 | All 11 `AlpacaClient` methods against a `wiremock` mock; auth header validation; regression tests for non-ASCII keys |
+
+---
+
+## Key Bindings (unchanged from v0.1.0)
 
 | Key | Action |
 |-----|--------|
-| `1` / `2` / `3` | Switch panel (Account / Watchlist / Positions) — or switch Orders sub-tab when Orders is active |
+| `1` / `2` / `3` | Switch panel — or Orders sub-tab when Orders is active |
 | `4` | Switch to Orders panel |
 | `Tab` / `Shift-Tab` | Cycle panels forward / backward |
 | `j` / `k` or `↑` / `↓` | Navigate rows |
@@ -52,40 +90,6 @@ First public release of `alpaca-trader-rs` — an Alpaca Markets trading toolkit
 | `Esc` | Close modal |
 | `q` / `Ctrl-C` | Quit |
 
-### Infrastructure
-
-- **GitHub Actions CI** — `fmt`, `clippy` (`-D warnings`), `test` (Ubuntu + macOS matrix), `msrv` (1.88), `docs` jobs.
-- **Security audit** — `cargo-audit` on every `Cargo.toml`/`Cargo.lock` push and weekly schedule.
-- **Dependabot** — weekly automated dependency updates for Cargo and GitHub Actions.
-
-### Tests
-
-101 tests across three tiers:
-
-| Scope | Count | Approach |
-|---|---|---|
-| `types`, `config` | 20 | Pure unit — serde, enum helpers, env var parsing |
-| `app`, `update`, `handlers/rest` | 67 | State logic, keyboard dispatch, async REST polling |
-| `tests/client_tests.rs` | 14 | HTTP integration via `wiremock` mock server |
-
----
-
-## Bug Fixes
-
-- **Panic on short order IDs** (`src/update.rs`) — `&id[..8]` replaced with `&id[..id.len().min(8)]` to prevent a byte-index panic on IDs shorter than 8 characters.
-- **Orders panel `1`/`2`/`3` keys unreachable** (`src/update.rs`) — global key handler was intercepting digit keys before the Orders sub-tab handler could see them. Fixed by adding `if app.active_tab != Tab::Orders` guards.
-
----
-
-## Known Limitations / Phase 2
-
-The following features are designed but not yet implemented:
-
-- WebSocket market data streaming (real-time quotes)
-- WebSocket account/trade stream
-- Live order submission (REST wired; UI modal complete)
-- Watchlist add/remove wired to REST API
-
 ---
 
 ## Getting Started
@@ -94,7 +98,7 @@ The following features are designed but not yet implemented:
 git clone https://github.com/arunkumar-mourougappane/alpaca-trader-rs
 cd alpaca-trader-rs
 cp .env.example .env
-# Fill in credentials — see docs/credentials-setup.md
+# Fill in your credentials — see docs/credentials-setup.md
 ./run.sh           # paper trading (default)
 ./run.sh --live    # live trading
 ```


### PR DESCRIPTION
## Summary

Implements #19 — full v0.2.0 documentation update.

### Files changed

| File | Change |
|---|---|
| `CHANGELOG.md` | New `[0.2.0]` entry covering all changes since v0.1.0; retained full `[0.1.0]` entry; updated comparison links at bottom |
| `RELEASE_NOTES.md` | Fully rewritten for v0.2.0 (WebSocket streaming, command channel, logging, UX improvements, bug fixes, test count, dev experience) |
| `README.md` | All four Phase 2 status rows changed from `Phase 2` → `Done`; test count updated 178 → 188 |
| `Cargo.toml` | Version bumped `0.1.0` → `0.2.0` |
| `Cargo.lock` | Regenerated for new version |

Closes #19