### PR TITLE
ci(release): fix archive template variables and add contents: write permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   upload-assets:
+    permissions:
+      contents: write   # required to create a GitHub Release and upload assets
+
     strategy:
       matrix:
         include:
@@ -24,5 +27,5 @@ jobs:
         with:
           bin: alpaca-trader
           target: ${{ matrix.target }}
-          archive: $name-$target.$ext
+          archive: $bin-$target
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes two bugs that caused the v0.2.0 release workflow to fail (run #25640818960):

### Bug 1 — Unexpanded archive template variables
The `archive` field used `$name-$target.$ext` where:
- `$name` is not a valid template variable for `taiki-e/upload-rust-binary-action`; the correct variable is `$bin`
- `$ext` must not appear in the archive **stem** — the action appends the file extension (`.tar.gz` / `.zip`) automatically

Both were passed through as literal strings, producing a filename like `$name-x86_64-apple-darwin.$ext.tar.gz`.

**Fix:** `archive: $bin-$target` → produces e.g. `alpaca-trader-x86_64-apple-darwin.tar.gz`

### Bug 2 — HTTP 403 on release asset upload
The job lacked `permissions: contents: write`. Without it the default `GITHUB_TOKEN` cannot create a GitHub Release or upload assets.

**Fix:** Added `permissions: contents: write` to the job.