### PR TITLE
feat(config): replace ALPACA_ENV with --paper CLI flag; default to live

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,11 @@
-# Select environment: paper (default) or live
-ALPACA_ENV=paper
-
-# Paper trading credentials (free, no real money)
+# Paper trading credentials (simulated funds — safe for development)
+# Used when running with: alpaca-trader --paper  (or  ./run.sh --paper)
 PAPER_ALPACA_ENDPOINT=https://paper-api.alpaca.markets/v2
 PAPER_ALPACA_KEY=your-paper-key-id
 PAPER_ALPACA_SECRET=your-paper-secret-key
 
-# Live trading credentials (real money — use with caution)
+# Live trading credentials (real money — handle with care)
+# Used by default: alpaca-trader  (or  ./run.sh)
 LIVE_ALPACA_ENDPOINT=https://api.alpaca.markets
 LIVE_ALPACA_KEY=your-live-key-id
 LIVE_ALPACA_SECRET=your-live-secret-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
-## [0.3.0] — unreleased
+## [0.3.0] — 2026-05-10
 
 Introduces OS-native keychain credential storage with an interactive first-run provisioning flow, and replaces the `ALPACA_ENV` environment variable with a `--paper` CLI flag.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Introduces OS-native keychain credential storage with an interactive first-run p
 - **`--paper` CLI flag** replaces `ALPACA_ENV` env var for environment selection
   - `alpaca-trader` (no flag) → **live** account (real money, new default)
   - `alpaca-trader --paper` → paper account (simulated funds)
+- **Credential resolution order** (highest → lowest priority):
+  1. `ALPACA_API_KEY` + `ALPACA_API_SECRET` — unified pair; ideal for CI, Docker, systemd
+  2. `LIVE_ALPACA_KEY` + `LIVE_ALPACA_SECRET` (or `PAPER_*`) — per-environment; developer `.env` files
+  3. OS-native keychain — returning desktop users
+  4. Interactive TTY prompt — first-run desktop
 - **`AlpacaConfig::from_env(AlpacaEnv)`** — signature now takes the environment explicitly; `ALPACA_ENV` is no longer read
 - `src/main.rs` — calls `credentials::resolve(env)` before `enable_raw_mode()`, then `AlpacaConfig::from_credentials()`
 - `run.sh` — passes `--paper` to the binary instead of exporting `ALPACA_ENV`; `--live` kept as a no-op alias; `.env` loading is now optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
+## [0.3.0] — unreleased
+
+Introduces OS-native keychain credential storage with an interactive first-run provisioning flow, and replaces the `ALPACA_ENV` environment variable with a `--paper` CLI flag.
+
+### Added
+
+#### Credential Storage (`src/credentials.rs`)
+- Tiered credential resolution: environment variables → OS-native keychain → interactive TTY prompt
+- `credentials::resolve(AlpacaEnv)` must be called before `enable_raw_mode()` — it may print to stderr and read from stdin
+- OS-native backends via platform-conditional `keyring` v3 — no C-library dependency on any platform:
+  - macOS: Keychain Access (`apple-native`)
+  - Windows: Credential Store (`windows-native`)
+  - Linux: kernel keyutils (`linux-native`) — cross-compiles cleanly; no `libdbus`
+- First-run interactive prompt via `rpassword` v7 — opens `/dev/tty` directly, unaffected by stdin redirection
+- Prompts user to store credentials in the OS keychain after successful entry (default: yes)
+- Graceful degradation when keychain is unavailable (locked, WSL, headless) — warns and continues session-only
+- Clear error with instructions when running headless (no TTY) with no credentials configured
+
+#### Library (`alpaca_trader_rs`)
+- `ResolvedCredentials` — public struct carrying resolved `endpoint`, `key`, `secret`, and `env`
+- `AlpacaConfig::from_credentials(ResolvedCredentials)` — new constructor; applies the same URL normalisation as `from_env`
+
+### Changed
+
+- **`--paper` CLI flag** replaces `ALPACA_ENV` env var for environment selection
+  - `alpaca-trader` (no flag) → **live** account (real money, new default)
+  - `alpaca-trader --paper` → paper account (simulated funds)
+- **`AlpacaConfig::from_env(AlpacaEnv)`** — signature now takes the environment explicitly; `ALPACA_ENV` is no longer read
+- `src/main.rs` — calls `credentials::resolve(env)` before `enable_raw_mode()`, then `AlpacaConfig::from_credentials()`
+- `run.sh` — passes `--paper` to the binary instead of exporting `ALPACA_ENV`; `--live` kept as a no-op alias; `.env` loading is now optional
+- `.env.example` — removed `ALPACA_ENV=paper`; clarified which vars belong to each environment
+- `docs/credentials-setup.md`, `docs/architecture.md`, `docs/testing.md`, `README.md`, `docs/README.md` — all updated to document the new `--paper` flag and credential resolution flow
+
+### ⚠️ Breaking Changes
+
+- **Default environment changed from paper → live.** Users who relied on the old paper default must now pass `--paper` explicitly.
+- `ALPACA_ENV` is no longer read. Setting it in the environment or `.env` file has no effect.
+- `AlpacaConfig::from_env()` now requires an `AlpacaEnv` argument.
+
+### Dependencies
+
+- Added `rpassword = "7"` (TTY password prompts)
+- Added `keyring = "3"` with platform-conditional native features (macOS / Windows / Linux)
+
+---
+
 ## [0.2.0] — 2026-05-10
 
 Completes the Phase 2 roadmap: live WebSocket streaming, wired async command channel, structured logging, mouse interaction, and a suite of reliability fixes. Test count grows from 101 → **188**.
@@ -144,85 +190,6 @@ First release. Ships as both an integratable Rust library and a standalone TUI t
 
 ---
 
-[0.2.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0
-
-
-First release. Ships as both an integratable Rust library and a standalone TUI trading dashboard.
-
-### Added
-
-#### Library (`alpaca_trader_rs`)
-- `AlpacaConfig` — resolves paper/live credentials from `.env` at startup via `ALPACA_ENV` + `LIVE_`/`PAPER_` prefixed variables
-- `AlpacaClient` — async REST client wrapping all core Alpaca v2 endpoints:
-  - `get_account`, `get_positions`, `get_orders`, `submit_order`, `cancel_order`
-  - `get_clock`, `list_watchlists`, `get_watchlist`, `add_to_watchlist`, `remove_from_watchlist`
-- Domain types with full `serde::Deserialize` support: `AccountInfo`, `Position`, `Order`, `OrderRequest`, `OrderSide`, `OrderType`, `TimeInForce`, `Quote`, `MarketClock`, `Watchlist`, `WatchlistSummary`, `Asset`
-- `Event` enum shared between the library streams and the TUI app
-
-#### TUI App (`alpaca-trader` binary)
-- Elm Architecture (TEA) event loop: typed `Event` channel, `update(app, event)` dispatch, `render(frame, app)` pure view
-- **Account panel** — equity, buying power, cash, long market value, PDT flag, intraday equity sparkline
-- **Watchlist panel** — live asset table with ask/bid prices from REST, inline `/` search filter, `a`/`d` add/remove
-- **Positions panel** — unrealised P&L per position with totals footer, live price column
-- **Orders panel** — Open / Filled / Cancelled sub-tabs switchable with `1`/`2`/`3` (context-sensitive: these keys switch global panels from other tabs)
-- **Order Entry modal** — Symbol, Side (BUY/SELL), Type (LIMIT/MARKET), Qty, Price fields; live Est. Total; buying power indicator; `Tab` field navigation
-- **Symbol Detail modal** — ask/bid, exchange, asset flags (tradable, shortable, fractionable, ETB)
-- **Help overlay** — full keyboard reference (`?`)
-- **Confirm modal** — for order cancel and watchlist removal actions
-- **Add Symbol modal** — type-to-search ticker input
-- Background tasks: REST polling every 5 s with immediate refresh on `r`; crossterm `EventStream` input task; 250 ms tick for clock updates
-- Graceful shutdown via `tokio_util::sync::CancellationToken`; terminal raw mode restored on exit
-- `run.sh` script with `--paper` / `--live` flags; `ALPACA_ENV` in `.env` selects the active environment
-
-#### Tests (101 total)
-- `types.rs` — serde round-trips, enum `as_str()`, `OrderRequest` serde rename (`order_type` → `"type"`)
-- `config.rs` — paper/live env resolution, slash trimming, MSRV, missing-var error paths (using `temp-env`)
-- `app.rs` — `Tab`/`OrderField` navigation cycles, `filtered_orders()`, `push_equity()` cap at 120 entries, watchlist search filtering
-- `update.rs` — all `Event` variants → state mutations; all keyboard paths including modal field editing, search mode, context-sensitive `1`/`2`/`3`
-- `handlers/rest.rs` — `poll_once` emits all five event types; error path sends `StatusMsg`; cancellation exits cleanly
-- `tests/client_tests.rs` — all 11 `AlpacaClient` HTTP methods against a `wiremock` mock server, including auth headers and query params
-
-#### CI / Tooling
-- GitHub Actions: Format, Clippy (`-D warnings`), Test (ubuntu + macos), MSRV (1.88), Docs
-- Security audit workflow (`cargo audit`) on Cargo file changes and weekly schedule
-- Dependabot for `cargo` and `github-actions` dependency updates (weekly)
-- `rust-version = "1.88"` declared in `Cargo.toml`
-
-#### Documentation
-- `docs/architecture.md` — TEA design, library/app boundary, module layout, data flow diagram
-- `docs/credentials-setup.md` — paper and live API key setup, env var reference
-- `docs/ui-mockups.md` — ASCII mockups for all panels and modals, full keyboard/mouse interaction spec
-- `docs/api-research.md` — live-tested REST endpoint shapes and watchlist API notes
-- `docs/testing.md` — testing strategy, mock patterns, bugs found during testing
-- `docs/github-actions.md` — GitHub Actions reference for Rust projects
-- `docs/licensing.md` — license types and Collaboration Agreement process
-
-### Fixed
-
-- `&id[..8]` panic in order cancel confirm when order ID is shorter than 8 bytes — now uses `id.len().min(8)`
-- `1`/`2`/`3` keys in Orders panel were intercepted by the global tab-switch handler, making sub-tab switching unreachable — added `if app.active_tab != Tab::Orders` guards on the global arms
-- `collapsible_match` clippy errors across all three panel key handlers and the Order Entry modal field handler — moved `if` conditions into match arm guards
-- `dtolnay/rust-toolchain@1.100` typo in CI (Rust 1.100.0 does not exist) — corrected to `@1.88`
-- `reqwest 0.13` breaking change: `.query()` moved behind the `query` feature — added `"query"` to reqwest features
-
-### Dependencies
-
-| Crate | Version | Role |
-|---|---|---|
-| `tokio` | 1 | Async runtime |
-| `reqwest` | 0.13 | HTTP client (`json` + `query` features) |
-| `tokio-tungstenite` | 0.29 | WebSocket (Phase 2) |
-| `serde` / `serde_json` | 1 | Serialization |
-| `dotenvy` | 0.15 | `.env` loading |
-| `anyhow` | 1 | Error handling |
-| `chrono` | 0.4 | Date/time |
-| `ratatui` | 0.30 | TUI rendering |
-| `crossterm` | 0.29 | Terminal backend |
-| `wiremock` | 0.6 | HTTP mocking (dev) |
-| `temp-env` | 0.3 | Env var scoping (dev) |
-
----
-
+[0.3.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "crossterm",
  "dirs",
  "dotenvy",
@@ -50,6 +51,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,6 +270,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +317,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1157,6 +1254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1615,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpaca-trader-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -28,8 +28,10 @@ dependencies = [
  "dirs",
  "dotenvy",
  "futures",
+ "keyring",
  "ratatui",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "syslog",
@@ -215,6 +217,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1357,6 +1365,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -1528,7 +1561,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2176,6 +2209,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,7 +2280,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2254,7 +2308,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2313,6 +2367,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -3524,6 +3591,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio-util        = { version = "0.7",  features = ["rt"] }
 # App
 ratatui    = "0.30"
 crossterm  = { version = "0.29", features = ["event-stream"] }
+clap       = { version = "4", features = ["derive"] }
 
 # Logging
 tracing            = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-trader-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]
@@ -31,6 +31,7 @@ tokio-util        = { version = "0.7",  features = ["rt"] }
 ratatui    = "0.30"
 crossterm  = { version = "0.29", features = ["event-stream"] }
 clap       = { version = "4", features = ["derive"] }
+rpassword  = "7"
 
 # Logging
 tracing            = "0.1"
@@ -38,6 +39,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender   = "0.2"
 syslog             = "6"
 dirs               = "6"
+
+# Platform-conditional keychain storage (no C-library dependency on any platform)
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3", features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3", features = ["windows-native"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# linux-native uses kernel keyutils — cross-compiles cleanly; no libdbus required
+keyring = { version = "3", features = ["linux-native"] }
 
 [dev-dependencies]
 wiremock   = "0.6"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ cp .env.example .env
 ### Run
 
 ```bash
-./run.sh           # paper trading (default)
-./run.sh --paper   # explicitly paper
-./run.sh --live    # live trading (real money)
+./run.sh           # live trading (real money — default)
+./run.sh --paper   # paper trading (simulated funds)
+./run.sh --live    # same as default; accepted for backwards compatibility
 ```
 
 The header badge shows **[PAPER]** in cyan or **[LIVE]** in red at all times.
@@ -191,17 +191,21 @@ alpaca-trader-rs/
 
 ## Environment Variables
 
-Stored in `.env` with `LIVE_` / `PAPER_` prefixes. The `--paper` / `--live` flag to `run.sh` (or `ALPACA_ENV` in `.env`) selects which set is active.
+Credentials are stored in `.env` using `LIVE_` / `PAPER_` prefixes. Only the
+variables for the active environment are read — the opposing set is ignored.
+The environment is chosen via the `--paper` CLI flag (default: live).
+
+> ⚠️ **Breaking change from v0.2.0**: the default environment is now **live**.
+> Users who previously relied on the paper default must pass `--paper` explicitly.
 
 | Variable | Description |
 |---|---|
-| `ALPACA_ENV` | `paper` (default) or `live` |
-| `PAPER_ALPACA_ENDPOINT` | `https://paper-api.alpaca.markets/v2` |
-| `PAPER_ALPACA_KEY` | Paper API key ID |
-| `PAPER_ALPACA_SECRET` | Paper API secret key |
-| `LIVE_ALPACA_ENDPOINT` | `https://api.alpaca.markets` |
-| `LIVE_ALPACA_KEY` | Live API key ID |
-| `LIVE_ALPACA_SECRET` | Live API secret key |
+| `PAPER_ALPACA_ENDPOINT` | `https://paper-api.alpaca.markets/v2` — required with `--paper` |
+| `PAPER_ALPACA_KEY` | Paper API key ID — required with `--paper` |
+| `PAPER_ALPACA_SECRET` | Paper API secret key — required with `--paper` |
+| `LIVE_ALPACA_ENDPOINT` | `https://api.alpaca.markets` — required by default |
+| `LIVE_ALPACA_KEY` | Live API key ID — required by default |
+| `LIVE_ALPACA_SECRET` | Live API secret key — required by default |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 - **Library** (`alpaca_trader_rs` crate): typed async REST client, shared domain types, and WebSocket streaming primitives — embed it in your own Rust application.
 - **App** (`alpaca-trader` binary): a full interactive terminal dashboard built on the library, with live account data, positions, orders, watchlist management, and order entry.
 
-
-
 ---
 
 ## Running the App
@@ -23,15 +21,50 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 - Rust 1.88+ (`rustup update stable`)
 - An Alpaca Markets account — paper trading is free at [alpaca.markets](https://alpaca.markets)
 
-### Setup
+### Installation
 
 ```bash
 git clone https://github.com/arunkumar-mourougappane/alpaca-trader-rs
 cd alpaca-trader-rs
-
-cp .env.example .env
-# Fill in your API keys — see docs/credentials-setup.md
 ```
+
+### Credential Setup
+
+The app resolves credentials in priority order (highest wins):
+
+| Priority | Method | When to use |
+|---|---|---|
+| 1 | `ALPACA_API_KEY` + `ALPACA_API_SECRET` env vars | CI, Docker, systemd — single pair for both environments |
+| 2 | `LIVE_ALPACA_KEY`/`SECRET` or `PAPER_ALPACA_KEY`/`SECRET` env vars | Per-environment `.env` file on developer machines |
+| 3 | OS-native keychain | Desktop users — keys are saved once and reused |
+| 4 | Interactive TTY prompt (first run) | No credentials configured yet — app prompts and offers to save to keychain |
+
+**Option A — First run (interactive, recommended for desktop):**
+
+Just run the app. If no credentials are found, it prompts for your API key and secret, then
+offers to save them to the OS keychain (macOS Keychain, Windows Credential Store, or Linux keyutils).
+
+```bash
+./run.sh --paper   # prompted for paper keys on first run
+./run.sh           # prompted for live keys on first run
+```
+
+**Option B — `.env` file (recommended for development):**
+
+```bash
+cp .env.example .env
+# Edit .env and fill in your API keys — see docs/credentials-setup.md
+```
+
+**Option C — Environment variables (CI / containers):**
+
+```bash
+export ALPACA_API_KEY=your-key-id
+export ALPACA_API_SECRET=your-secret-key
+./run.sh --paper
+```
+
+> See [docs/credentials-setup.md](docs/credentials-setup.md) for obtaining keys from the Alpaca dashboard.
 
 ### Run
 
@@ -42,6 +75,18 @@ cp .env.example .env
 ```
 
 The header badge shows **[PAPER]** in cyan or **[LIVE]** in red at all times.
+
+### Managing Stored Credentials
+
+To clear credentials saved in the OS keychain:
+
+```bash
+alpaca-trader --reset paper   # remove paper keychain entries
+alpaca-trader --reset live    # remove live keychain entries
+```
+
+If credentials were loaded from a `.env` file or environment variable instead, the command
+prints the variable names to unset and the file to edit.
 
 ### Key Bindings
 
@@ -150,6 +195,7 @@ alpaca-trader-rs/
 ├── src/
 │   ├── lib.rs              # Library root — public API
 │   ├── main.rs             # Binary entry point — TUI app
+│   ├── credentials.rs      # Credential resolution: env vars → keychain → TTY prompt  [app-only]
 │   ├── config.rs           # AlpacaConfig: env resolution, paper/live selection
 │   ├── client.rs           # AlpacaClient: all REST methods
 │   ├── types.rs            # Shared domain types (serde-deserializable)
@@ -191,21 +237,30 @@ alpaca-trader-rs/
 
 ## Environment Variables
 
-Credentials are stored in `.env` using `LIVE_` / `PAPER_` prefixes. Only the
-variables for the active environment are read — the opposing set is ignored.
-The environment is chosen via the `--paper` CLI flag (default: live).
+Credentials are loaded from the environment (or a `.env` file via `dotenvy`). Only the
+variables for the active environment are used — the opposing set is ignored.
 
 > ⚠️ **Breaking change from v0.2.0**: the default environment is now **live**.
 > Users who previously relied on the paper default must pass `--paper` explicitly.
+> `ALPACA_ENV` is no longer read.
+
+### Unified pair (highest priority)
 
 | Variable | Description |
 |---|---|
-| `PAPER_ALPACA_ENDPOINT` | `https://paper-api.alpaca.markets/v2` — required with `--paper` |
-| `PAPER_ALPACA_KEY` | Paper API key ID — required with `--paper` |
-| `PAPER_ALPACA_SECRET` | Paper API secret key — required with `--paper` |
-| `LIVE_ALPACA_ENDPOINT` | `https://api.alpaca.markets` — required by default |
-| `LIVE_ALPACA_KEY` | Live API key ID — required by default |
-| `LIVE_ALPACA_SECRET` | Live API secret key — required by default |
+| `ALPACA_API_KEY` | API key ID — used for whichever environment (`--paper` or live) is active |
+| `ALPACA_API_SECRET` | API secret key — paired with `ALPACA_API_KEY` |
+
+### Per-environment variables
+
+| Variable | Description |
+|---|---|
+| `PAPER_ALPACA_ENDPOINT` | `https://paper-api.alpaca.markets/v2` — optional override |
+| `PAPER_ALPACA_KEY` | Paper API key ID |
+| `PAPER_ALPACA_SECRET` | Paper API secret key |
+| `LIVE_ALPACA_ENDPOINT` | `https://api.alpaca.markets` — optional override |
+| `LIVE_ALPACA_KEY` | Live API key ID |
+| `LIVE_ALPACA_SECRET` | Live API secret key |
 
 ---
 
@@ -225,7 +280,7 @@ The environment is chosen via the `--paper` CLI flag (default: live).
 | Paper / Live switching (`run.sh --paper/--live`) | Done |
 | Clippy clean | Done |
 | Test strategy documented | Done |
-| Unit + integration tests (188 tests) | Done |
+| Unit + integration tests (198 tests) | Done |
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
 | Code coverage with cargo-llvm-cov + Codecov | Done |
@@ -240,6 +295,10 @@ The environment is chosen via the `--paper` CLI flag (default: live).
 | WebSocket account/trade stream | Done |
 | Live order submission | Done |
 | Watchlist add/remove (wired to REST) | Done |
+| OS-native keychain credential storage (macOS / Windows / Linux) | Done |
+| Interactive first-run credential prompt with keychain save offer | Done |
+| `ALPACA_API_KEY` / `ALPACA_API_SECRET` unified env vars | Done |
+| `--reset <paper\|live>` CLI flag to clear stored keychain credentials | Done |
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,94 +1,157 @@
-# Release Notes — v0.2.0
+# Release Notes — v0.3.0
 
-**Release date:** 2026-05-10
+**Release date:** unreleased
 **MSRV:** Rust 1.88+
-**Previous release:** [v0.1.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0)
+**Previous release:** [v0.2.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.2.0)
 
 ---
 
 ## Overview
 
-v0.2.0 completes the Phase 2 roadmap: live WebSocket streaming for market data and account events, a fully wired async command channel for order submission and watchlist mutations, structured logging, and a raft of UX and reliability improvements. The test suite has grown from 101 to **188 tests**.
+v0.3.0 overhauls credential management. The app no longer requires a `.env` file to run — on
+first launch it prompts for API keys via the terminal and offers to save them to the OS native
+keychain, so subsequent runs need no configuration at all. For CI, containers, and power users the
+existing env-var approach is preserved and extended with a new unified `ALPACA_API_KEY` /
+`ALPACA_API_SECRET` pair. The `ALPACA_ENV` env var is retired in favour of a `--paper` CLI flag,
+and a new `--reset` flag lets users clear stored keychain entries from the command line.
+
+The test suite grows from **188 → 198 tests**.
 
 ---
 
 ## What's New
 
-### WebSocket Streaming (Phase 2 — now complete)
+### OS-Native Keychain Credential Storage
 
-- **`src/stream/market.rs`** — connects to the Alpaca IEX market data WebSocket, authenticates, and streams real-time NBBO quotes for every symbol in the active watchlist. Resubscribes automatically when the watchlist changes; sends an explicit `unsubscribe` message for removed symbols (the protocol merges subscriptions and does not replace them). Reconnects with exponential backoff (1 s → 30 s cap) on disconnect.
-- **`src/stream/account.rs`** — connects to the Alpaca account/trade update stream and forwards `TradeUpdate` events for order fills and status changes. Same exponential-backoff reconnection strategy.
-- **Connection status indicators** — the TUI header now shows live `[MKT ●]` / `[ACCT ●]` badges, updated in real time via `Event::StreamConnected` / `Event::StreamDisconnected`.
+Credentials are now stored and retrieved from the platform keychain — no extra software required,
+no C-library dependencies:
 
-### Command Channel (Phase 2 — now complete)
+| Platform | Backend |
+|---|---|
+| macOS | Keychain Access (`apple-native`) |
+| Windows | Credential Store (`windows-native`) |
+| Linux | Kernel keyutils (`linux-native`) — cross-compiles cleanly, no `libdbus` |
 
-- **`src/commands.rs`** — defines the `Command` enum (`SubmitOrder`, `CancelOrder`, `AddToWatchlist`, `RemoveFromWatchlist`) bridging the synchronous `update()` function to the async task world.
-- **`src/handlers/commands.rs`** — async command-handler task that receives commands from `update()` over an `mpsc` channel and dispatches them to `AlpacaClient`. Live order submission and watchlist mutation now make real REST calls.
+Graceful degradation when the keychain is unavailable (locked, WSL, headless CI) — the app warns
+and continues with session-only credentials.
 
-### Logging
+### Interactive First-Run Provisioning
 
-- **`src/logging.rs`** — structured logging via `tracing` + `tracing-appender` + `syslog`. Writes to a rolling file at a platform-appropriate path (`$HOME/Library/Logs/alpaca-trader/` on macOS, `$HOME/.local/share/alpaca-trader/` on Linux) and forwards to the system syslog. `RUST_LOG` controls the log level at runtime.
+When no credentials are found in the environment or keychain, `alpaca-trader` prompts for the API
+key and secret directly on the terminal (via `rpassword`, which opens `/dev/tty` directly and
+is unaffected by stdin redirection). After a successful entry the user is offered the option to
+save the credentials to the keychain (default: yes).
 
-### UX Improvements
+```
+alpaca-trader --paper
+  → Alpaca paper API key: ****
+  → Alpaca paper API secret: ****
+  → Save to keychain? [Y/n]: Y
+  ✓ Paper credentials saved.
+```
 
-- **Mouse click handling** — clicking a tab bar label switches to that panel; clicking Orders sub-tab labels switches sub-tabs. Hit-testing uses actual rendered label widths, not fixed offsets.
-- **Order Entry validation** — the order form is validated before dispatching a command: empty symbol, zero quantity, and a missing price on limit orders are all rejected with a status-bar error message.
-- **Time-in-Force toggle** — the Order Entry modal now includes a DAY / GTC selector. When the market is closed, submitting a DAY order is blocked with a warning.
-- **Status message auto-dismiss** — status-bar messages clear automatically after 3 seconds; no manual `Esc` required.
-- **Portfolio history sparkline** — the Account panel equity sparkline is now pre-populated from `GET /account/portfolio/history` at startup (1-minute bars for the current trading day), so the chart is immediately useful even before the first real-time tick.
+On subsequent runs the keychain is queried automatically — no further input required.
 
-### Developer Experience
+### `--paper` CLI Flag
 
-- **`#![deny(missing_docs)]`** — enforced across the entire library crate. Every public struct, enum, variant, field, and method now has a `///` doc comment; every public module has a `//!` module-level doc.
-- **CI: code coverage** — a `coverage` job runs `cargo-llvm-cov --lcov` and uploads results to Codecov. Codecov badge added to README.
-- **CI: release workflow** — `.github/workflows/release.yml` compiles and uploads pre-built binaries for `x86_64-linux`, `x86_64-darwin`, and `aarch64-darwin` on every `v*` tag push. Release badge added to README.
-- **Release profile** — `Cargo.toml` gains `[profile.release]` with `opt-level = 3`, `lto = "thin"`, `codegen-units = 1`, `strip = "symbols"`, expected to reduce binary size by ~30–50%.
+`ALPACA_ENV` is retired. The active trading environment is now selected on the command line:
+
+```bash
+alpaca-trader           # live account (real money — default)
+alpaca-trader --paper   # paper account (simulated funds)
+```
+
+`run.sh` accepts the same flags and passes them through to the binary.
+
+### `ALPACA_API_KEY` / `ALPACA_API_SECRET` Unified Env Vars
+
+A single credential pair now works for both environments. This is ideal for CI pipelines,
+Docker images, and systemd services where environment-switching happens at the process level:
+
+```bash
+export ALPACA_API_KEY=your-key-id
+export ALPACA_API_SECRET=your-secret-key
+alpaca-trader --paper   # or without --paper for live
+```
+
+**Full credential resolution order (highest priority first):**
+
+1. `ALPACA_API_KEY` + `ALPACA_API_SECRET` — unified pair
+2. `LIVE_ALPACA_KEY` / `LIVE_ALPACA_SECRET` or `PAPER_ALPACA_KEY` / `PAPER_ALPACA_SECRET` — per-environment (developer `.env` files)
+3. OS-native keychain — returning desktop users
+4. Interactive TTY prompt — first-run desktop
+
+### `--reset` Flag
+
+Clear stored keychain entries for a given environment without entering the TUI:
+
+```bash
+alpaca-trader --reset paper   # removes paper keychain entries
+alpaca-trader --reset live    # removes live keychain entries
+```
+
+If the credentials for that environment were loaded from a `.env` file or environment variable
+(rather than the keychain) the command prints the exact variable names to unset and suggests
+which file to edit.
+
+### New Public Library API
+
+| Item | Description |
+|---|---|
+| `ResolvedCredentials` | Public struct carrying resolved `endpoint`, `key`, `secret`, and `env` |
+| `AlpacaConfig::from_credentials(ResolvedCredentials)` | New constructor; applies the same URL normalisation as `from_env` |
 
 ---
 
-## Bug Fixes
+## ⚠️ Breaking Changes
 
-| Fix | File | Detail |
-|-----|------|--------|
-| Stream unsubscribe on symbol removal | `src/stream/market.rs` | The Alpaca IEX protocol merges subscriptions; removed symbols were still streaming until the connection recycled. An explicit `unsubscribe` frame is now sent before the re-subscribe. |
-| Client header panic | `src/client.rs` | `AlpacaClient::new` called `.unwrap()` on header value construction; non-ASCII or space-containing keys now return a proper `Result::Err`. |
-| Logging init with `$HOME` unset | `src/logging.rs` | Logging initialiser no longer panics when `$HOME` is absent; falls back to a temporary directory. |
-| Tab bar hit-test | `src/handlers/input.rs` | Mouse clicks on tab bar labels used fixed offsets; replaced with widths measured from the rendered text. |
-| Orders sub-tab hit-test | `src/handlers/input.rs` | Sub-tab mouse click areas now use the exact rects captured during the last `render()` pass. |
-| Closed command channel | `src/handlers/commands.rs` | Command sends to a closed or full channel are now handled gracefully instead of silently dropped. |
+| Change | Migration |
+|---|---|
+| **Default environment is now live** (was paper) | Pass `--paper` explicitly if you relied on the old paper default |
+| **`ALPACA_ENV` is no longer read** | Remove it from `.env` / shell config; use `--paper` flag instead |
+| **`AlpacaConfig::from_env()` now requires an `AlpacaEnv` argument** | Update call sites: `AlpacaConfig::from_env(AlpacaEnv::Paper)` |
 
 ---
 
 ## Tests
 
-**188 tests total** (up from 101 in v0.1.0):
+**198 tests total** (up from 188 in v0.2.0):
 
 | Scope | Count | Highlights |
 |---|---|---|
-| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 43 | 8 WebSocket integration tests (auth, auth-failure, cancel, reconnect) × 2 streams; 2 unsubscribe tests; serde + env-var unit tests |
-| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`) | 126 | State logic, keyboard dispatch, mouse click paths, validation, command dispatch, REST polling |
-| HTTP integration (`tests/client_tests.rs`) | 19 | All 11 `AlpacaClient` methods against a `wiremock` mock; auth header validation; regression tests for non-ASCII keys |
+| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 42 | Serde round-trips, env-var resolution, WebSocket integration tests |
+| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/credentials.rs`) | 137 | State logic, keyboard dispatch, credential resolution (11 new), `--reset` paths |
+| HTTP integration (`tests/client_tests.rs`) | 19 | All 11 `AlpacaClient` methods against a `wiremock` mock |
+
+New credential tests cover:
+
+- Unified `ALPACA_API_KEY`/`ALPACA_API_SECRET` for live and paper environments
+- Per-env prefixed vars (`LIVE_*`, `PAPER_*`)
+- Priority ordering (unified vars beat prefixed vars)
+- Custom endpoint override via `LIVE_ALPACA_ENDPOINT` / `PAPER_ALPACA_ENDPOINT`
+- Empty value filtering (empty string treated as absent)
+- Cross-env isolation (paper vars not visible when resolving live, and vice versa)
 
 ---
 
-## Key Bindings (unchanged from v0.1.0)
+## Dependencies Added
 
-| Key | Action |
-|-----|--------|
-| `1` / `2` / `3` | Switch panel — or Orders sub-tab when Orders is active |
-| `4` | Switch to Orders panel |
-| `Tab` / `Shift-Tab` | Cycle panels forward / backward |
-| `j` / `k` or `↑` / `↓` | Navigate rows |
-| `g` / `G` | Jump to first / last row |
-| `Enter` | Open symbol detail |
-| `o` | New order |
-| `c` | Cancel selected order |
-| `a` / `d` | Add / remove watchlist symbol |
-| `/` | Search / filter watchlist |
-| `r` | Force refresh |
-| `?` | Help overlay |
-| `Esc` | Close modal |
-| `q` / `Ctrl-C` | Quit |
+| Crate | Version | Role |
+|---|---|---|
+| `rpassword` | 7 | TTY password prompts (reads `/dev/tty` directly) |
+| `keyring` | 3 | OS-native keychain with platform-conditional native features |
+
+---
+
+## Upgrade Guide from v0.2.0
+
+1. **Check your default environment.** If you ran `./run.sh` or `alpaca-trader` without flags and expected paper trading, add `--paper` to your command or script.
+
+2. **Remove `ALPACA_ENV`.** If it's in your `.env` file or shell profile, delete the line — it is silently ignored and may cause confusion.
+
+3. **Optionally migrate keys to the keychain.** Run `alpaca-trader --paper` (or without `--paper` for live). If keys are already in `.env` they'll be picked up; the app will not re-prompt. To trigger the save-to-keychain flow, unset the env vars and run again.
+
+4. **Library consumers**: update `AlpacaConfig::from_env()` calls to pass the environment: `AlpacaConfig::from_env(AlpacaEnv::Live)` or `AlpacaConfig::from_env(AlpacaEnv::Paper)`.
 
 ---
 
@@ -97,10 +160,19 @@ v0.2.0 completes the Phase 2 roadmap: live WebSocket streaming for market data a
 ```bash
 git clone https://github.com/arunkumar-mourougappane/alpaca-trader-rs
 cd alpaca-trader-rs
-cp .env.example .env
-# Fill in your credentials — see docs/credentials-setup.md
-./run.sh           # paper trading (default)
-./run.sh --live    # live trading
+
+# First run — app will prompt for credentials and offer to save to keychain
+./run.sh --paper   # paper trading (simulated funds — recommended for first run)
+./run.sh           # live trading  (real money — default)
 ```
 
-See [README.md](README.md) for full setup instructions and [docs/](docs/) for architecture, API research, and testing strategy.
+Or configure via `.env`:
+
+```bash
+cp .env.example .env
+# Fill in your credentials — see docs/credentials-setup.md
+./run.sh --paper
+```
+
+See [README.md](README.md) for full setup options and [docs/credentials-setup.md](docs/credentials-setup.md) for obtaining API keys from the Alpaca dashboard.
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes — v0.3.0
 
-**Release date:** unreleased
+**Release date:** 2026-05-10
 **MSRV:** Rust 1.88+
 **Previous release:** [v0.2.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.2.0)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,8 @@ The `.env` file holds credentials for both environments under separate prefixes:
 | `PAPER_ALPACA_ENDPOINT` | `https://paper-api.alpaca.markets/v2` |
 | `PAPER_ALPACA_KEY` | Paper trading API key ID |
 | `PAPER_ALPACA_SECRET` | Paper trading API secret key |
-| `ALPACA_ENV` | `paper` (default) or `live` — selects which prefix to use |
+
+Environment variables are optional — on first launch the app will prompt interactively and offer to save credentials to the OS keychain.
 
 See [credentials-setup.md](credentials-setup.md) for setup details.
 
@@ -123,11 +124,9 @@ See [credentials-setup.md](credentials-setup.md) for setup details.
 
 ## Paper vs Live Trading
 
-Set `ALPACA_ENV=paper` (the default) to trade against Alpaca's simulation environment — no real money involved. Set `ALPACA_ENV=live` to use the live account. Both key pairs live in the same `.env` file; no code changes are needed to switch.
+Run with `--paper` to trade against Alpaca's simulation environment — no real money involved. Omit the flag (the default) to use the live account. The TUI header shows **[PAPER]** in cyan or **[LIVE]** in red so the active environment is always visible.
 
-The TUI header shows **[PAPER]** in cyan or **[LIVE]** in red so the active environment is always visible.
-
-> Always develop and test with `ALPACA_ENV=paper`. Paper trading resets positions daily at market open.
+> Always develop and test with `--paper`. Paper trading resets positions daily at market open.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,9 +100,7 @@ pub struct AlpacaConfig {
 }
 
 impl AlpacaConfig {
-    pub fn from_env() -> Result<Self, ConfigError>;  // reads ALPACA_ENV + prefixed vars
-    pub fn paper(key: &str, secret: &str) -> Self;
-    pub fn live(key: &str, secret: &str) -> Self;
+    pub fn from_env(env: AlpacaEnv) -> Result<Self>;  // reads LIVE_* or PAPER_* vars for the given env
 }
 ```
 
@@ -286,11 +284,11 @@ Pure read of `&App`, writes only to `Frame` — no side effects.
 
 ## Paper vs Live Trading
 
-Controlled entirely by `ALPACA_ENV`. The library resolves the active config at startup; all downstream code is identical between environments.
+Controlled by the `--paper` CLI flag. The binary defaults to **live**. All downstream code is identical between environments; only `AlpacaConfig` and the TUI badge differ.
 
-| Config point | Paper | Live |
+| Config point | Paper (`--paper`) | Live (default) |
 |---|---|---|
-| `ALPACA_ENV` | `paper` | `live` |
+| CLI flag | `--paper` | *(omit)* |
 | REST base URL | `https://paper-api.alpaca.markets/v2` | `https://api.alpaca.markets/v2` |
 | Account WebSocket | `wss://paper-api.alpaca.markets/stream` | `wss://api.alpaca.markets/stream` |
 | Market data WebSocket | `wss://stream.data.alpaca.markets/v2/iex` | Same (or `/v2/sip` with subscription) |
@@ -328,8 +326,7 @@ Terminal raw mode is restored via a `Drop` guard wrapping the `ratatui::Terminal
 
 ## Testing Against Paper Trading
 
-1. Set `ALPACA_ENV=paper` in `.env`.
-2. Run `cargo run --bin alpaca-trader`.
-3. The header shows **[PAPER]** — no real money at risk.
-4. Place orders through the UI; fills appear in the Orders panel via the account WebSocket stream within seconds.
-5. Paper positions reset daily at market open.
+1. Run `cargo run --bin alpaca-trader -- --paper`.
+2. The header shows **[PAPER]** — no real money at risk.
+3. Place orders through the UI; fills appear in the Orders panel via the account WebSocket stream within seconds.
+4. Paper positions reset daily at market open.

--- a/docs/credentials-setup.md
+++ b/docs/credentials-setup.md
@@ -59,29 +59,25 @@ Or use the `dotenvy` crate (add to `Cargo.toml`) to load it automatically at sta
 
 ### Selecting an Environment at Runtime
 
-The app reads an `ALPACA_ENV` variable (default: `paper`) to choose which prefix to use:
+The environment is selected via the `--paper` CLI flag. The binary defaults to **live** when the flag is absent. Only the credentials for the active environment are read — the opposing set is ignored entirely.
 
 ```bash
-ALPACA_ENV=paper cargo run    # uses PAPER_ALPACA_* vars (default)
-ALPACA_ENV=live   cargo run   # uses LIVE_ALPACA_* vars
+alpaca-trader           # live trading (real money — default)
+alpaca-trader --paper   # paper trading (simulated funds)
 ```
 
-In Rust, resolve the active credentials at startup:
+Using `run.sh`:
+
+```bash
+./run.sh           # live (default)
+./run.sh --paper   # paper
+```
+
+In Rust, the environment is resolved in `src/main.rs` and passed directly to `AlpacaConfig::from_env`:
 
 ```rust
-let env = std::env::var("ALPACA_ENV").unwrap_or_else(|_| "paper".into());
-let (key, secret, endpoint) = match env.as_str() {
-    "live" => (
-        std::env::var("LIVE_ALPACA_KEY")?,
-        std::env::var("LIVE_ALPACA_SECRET")?,
-        std::env::var("LIVE_ALPACA_ENDPOINT")?,
-    ),
-    _ => (
-        std::env::var("PAPER_ALPACA_KEY")?,
-        std::env::var("PAPER_ALPACA_SECRET")?,
-        std::env::var("PAPER_ALPACA_ENDPOINT")?,
-    ),
-};
+let env = if args.paper { AlpacaEnv::Paper } else { AlpacaEnv::Live };
+AlpacaConfig::from_env(env)?;
 ```
 
 ---

--- a/docs/credentials-setup.md
+++ b/docs/credentials-setup.md
@@ -32,34 +32,69 @@ This guide covers how to obtain and configure Alpaca API credentials for both pa
 
 ## 3. Configure Credentials
 
-The application reads credentials from a `.env` file at the project root. Both environments are stored in the same file using a `LIVE_` / `PAPER_` prefix so you can switch at runtime without editing the file.
+Starting with v0.3.0, a `.env` file is no longer required. The app resolves credentials
+using a four-tier priority chain — the first match wins:
 
-### `.env` File Structure
+| Priority | Source | Notes |
+|---|---|---|
+| 1 | `ALPACA_API_KEY` + `ALPACA_API_SECRET` env vars | Unified pair; ideal for CI, Docker, systemd |
+| 2 | `LIVE_ALPACA_KEY`/`SECRET` or `PAPER_ALPACA_KEY`/`SECRET` | Per-environment; typical developer `.env` files |
+| 3 | OS-native keychain | macOS Keychain, Windows Credential Store, Linux keyutils |
+| 4 | Interactive TTY prompt | First-run: app prompts and offers to save to keychain |
+
+### Option A — Let the app prompt (recommended for desktop)
+
+Just run the app. On first run with no credentials configured it will ask for your
+API key and secret, then offer to save them to the OS keychain so you won't be
+prompted again.
+
+```bash
+alpaca-trader --paper   # prompted once for paper keys
+alpaca-trader           # prompted once for live keys
+```
+
+To clear stored keychain entries later:
+
+```bash
+alpaca-trader --reset paper
+alpaca-trader --reset live
+```
+
+### Option B — `.env` file (recommended for development)
+
+```bash
+cp .env.example .env
+# Edit .env and fill in your keys
+```
+
+Both environments can live in the same file:
 
 ```env
-LIVE_ALPACA_ENDPOINT=https://api.alpaca.markets
-LIVE_ALPACA_KEY=your-live-key-id
-LIVE_ALPACA_SECRET=your-live-secret-key
-
+# Paper trading (simulated funds — used with: alpaca-trader --paper)
 PAPER_ALPACA_ENDPOINT=https://paper-api.alpaca.markets/v2
 PAPER_ALPACA_KEY=your-paper-key-id
 PAPER_ALPACA_SECRET=your-paper-secret-key
+
+# Live trading (real money — default)
+LIVE_ALPACA_ENDPOINT=https://api.alpaca.markets
+LIVE_ALPACA_KEY=your-live-key-id
+LIVE_ALPACA_SECRET=your-live-secret-key
 ```
 
-> `PAPER_ALPACA_ENDPOINT` already includes `/v2`. `LIVE_ALPACA_ENDPOINT` does not — append `/v2` in code when constructing request URLs.
+> `PAPER_ALPACA_ENDPOINT` already includes `/v2`. `LIVE_ALPACA_ENDPOINT` does not — the app appends `/v2` when constructing request URLs.
 
-Load before running:
+### Option C — Unified env vars (CI / containers)
+
+A single `ALPACA_API_KEY` + `ALPACA_API_SECRET` pair is used for whichever environment
+(`--paper` or live) is active at runtime:
 
 ```bash
-set -a && source .env && set +a
-cargo run
+export ALPACA_API_KEY=your-key-id
+export ALPACA_API_SECRET=your-secret-key
+alpaca-trader --paper
 ```
 
-Or use the `dotenvy` crate (add to `Cargo.toml`) to load it automatically at startup.
-
 ### Selecting an Environment at Runtime
-
-The environment is selected via the `--paper` CLI flag. The binary defaults to **live** when the flag is absent. Only the credentials for the active environment are read — the opposing set is ignored entirely.
 
 ```bash
 alpaca-trader           # live trading (real money — default)
@@ -71,13 +106,6 @@ Using `run.sh`:
 ```bash
 ./run.sh           # live (default)
 ./run.sh --paper   # paper
-```
-
-In Rust, the environment is resolved in `src/main.rs` and passed directly to `AlpacaConfig::from_env`:
-
-```rust
-let env = if args.paper { AlpacaEnv::Paper } else { AlpacaEnv::Live };
-AlpacaConfig::from_env(env)?;
 ```
 
 ---
@@ -151,5 +179,5 @@ Expected response: `"ACTIVE"`
 - [ ] `.env` file is listed in `.gitignore`
 - [ ] API keys are **never** hard-coded in source files
 - [ ] Paper trading keys are used during all development and testing
-- [ ] Live keys are stored in a secrets manager (e.g., macOS Keychain, 1Password, AWS Secrets Manager) rather than a plain `.env` file
+- [ ] Live keys are stored in the OS keychain (via the built-in first-run prompt) rather than a plain `.env` file
 - [ ] Live keys have IP allow-listing enabled in the Alpaca dashboard if your deployment has a static IP

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -84,13 +84,12 @@ mod tests {
     fn from_env_paper() {
         temp_env::with_vars(
             [
-                ("ALPACA_ENV",            Some("paper")),
                 ("PAPER_ALPACA_ENDPOINT", Some("https://paper-api.alpaca.markets/v2")),
                 ("PAPER_ALPACA_KEY",      Some("PKTEST000")),
                 ("PAPER_ALPACA_SECRET",   Some("secret000")),
             ],
             || {
-                let cfg = AlpacaConfig::from_env().unwrap();
+                let cfg = AlpacaConfig::from_env(AlpacaEnv::Paper).unwrap();
                 assert_eq!(cfg.env, AlpacaEnv::Paper);
                 assert_eq!(cfg.base_url, "https://paper-api.alpaca.markets/v2");
                 assert_eq!(cfg.key, "PKTEST000");
@@ -238,16 +237,16 @@ async fn poll_once_emits_account_event() {
 | `order_notional_qty_null` | Order with `qty: null` deserializes without error; `qty` is `None` |
 | `watchlist_empty_assets_default` | `Watchlist` with no `assets` key deserializes to empty `Vec` |
 
-### `config.rs` — 7 tests (all using `temp-env`)
+### `config.rs` — 8 tests (all using `temp-env`)
 
 | Test | What it checks |
 |---|---|
-| `from_env_paper_selects_paper_vars` | Correct `base_url`, `key`, `secret`, `env == Paper` |
-| `from_env_live_appends_v2` | Live endpoint without `/v2` gets it appended; no double slash |
+| `from_env_paper_selects_paper_vars` | `from_env(Paper)` → correct `base_url`, `key`, `secret`, `env == Paper` |
+| `from_env_live_appends_v2` | `from_env(Live)` → live endpoint without `/v2` gets it appended; no double slash |
 | `from_env_paper_trailing_slash_stripped` | `https://paper-api.alpaca.markets/v2/` → no trailing slash |
-| `from_env_unknown_env_errors` | `ALPACA_ENV=staging` → `Err` |
-| `from_env_missing_key_errors` | `PAPER_ALPACA_KEY` unset → `Err` |
-| `from_env_defaults_to_paper` | `ALPACA_ENV` unset → selects paper vars |
+| `from_env_missing_paper_key_errors` | `PAPER_ALPACA_KEY` unset → `Err` |
+| `from_env_missing_live_key_errors` | `LIVE_ALPACA_KEY` unset → `Err` |
+| `from_env_live_no_double_slash` | Live endpoint with trailing slash → no double `/v2/` |
 | `env_label_paper` / `env_label_live` | `env_label()` returns correct static str |
 
 ### `client.rs` — 14 tests (all in `tests/client_tests.rs`)

--- a/run.sh
+++ b/run.sh
@@ -8,39 +8,29 @@ cd "$SCRIPT_DIR"
 usage() {
     echo "Usage: $0 [--paper | --live]"
     echo ""
-    echo "  --paper   Run against the paper trading environment (default)"
-    echo "  --live    Run against the live trading environment (real money)"
+    echo "  --paper   Run against the paper trading environment (simulated funds)"
+    echo "  --live    Run against the live trading environment (real money — default)"
     exit 1
 }
 
-ENV_OVERRIDE=""
+PAPER_FLAG=""
 for arg in "$@"; do
     case "$arg" in
-        --paper) ENV_OVERRIDE="paper" ;;
-        --live)  ENV_OVERRIDE="live" ;;
+        --paper) PAPER_FLAG="--paper" ;;
+        --live)  ;;  # live is the default; accepted for backwards compatibility
         --help|-h) usage ;;
         *) echo "Unknown argument: $arg"; usage ;;
     esac
 done
 
-# Load credentials
+# Load credentials from .env if present (developer convenience)
 if [ -f .env ]; then
     set -a
     source .env
     set +a
-else
-    echo "Error: .env file not found."
-    echo "Copy .env.example to .env and fill in your Alpaca API credentials."
-    exit 1
 fi
 
-# CLI flag overrides .env value; fall back to paper if neither is set
-if [ -n "$ENV_OVERRIDE" ]; then
-    ALPACA_ENV="$ENV_OVERRIDE"
-else
-    ALPACA_ENV="${ALPACA_ENV:-paper}"
-fi
-export ALPACA_ENV
-
-echo "Starting alpaca-trader-rs [$ALPACA_ENV]…"
-cargo run --release --bin alpaca-trader
+ENV_LABEL="live"
+[ -n "$PAPER_FLAG" ] && ENV_LABEL="paper"
+echo "Starting alpaca-trader-rs [$ENV_LABEL]…"
+cargo run --release --bin alpaca-trader -- $PAPER_FLAG

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,26 @@ mod tests {
     }
 }
 
+/// Credentials resolved from env vars, OS keychain, or an interactive prompt.
+///
+/// Produced by the binary-crate's `credentials::resolve()` and consumed by
+/// [`AlpacaConfig::from_credentials`].
+#[derive(Debug, Clone)]
+pub struct ResolvedCredentials {
+    /// Raw endpoint URL (without `/v2` normalisation).
+    ///
+    /// For live trading this is typically `https://api.alpaca.markets`.
+    /// For paper trading it is `https://paper-api.alpaca.markets/v2` (already
+    /// contains `/v2` — [`AlpacaConfig::from_credentials`] handles both forms).
+    pub endpoint: String,
+    /// Alpaca API key ID (`APCA-API-KEY-ID` header value).
+    pub key: String,
+    /// Alpaca API secret key (`APCA-API-SECRET-KEY` header value).
+    pub secret: String,
+    /// Which trading environment these credentials belong to.
+    pub env: AlpacaEnv,
+}
+
 /// Selects which Alpaca trading environment to connect to.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AlpacaEnv {
@@ -189,6 +209,33 @@ impl AlpacaConfig {
                 })
             }
         }
+    }
+
+    /// Build configuration from pre-resolved credentials.
+    ///
+    /// Applies the same URL normalisation as [`AlpacaConfig::from_env`]:
+    /// live endpoints have `/v2` appended; paper endpoints are used as-is
+    /// (with any trailing slash stripped).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the endpoint string is empty.
+    pub fn from_credentials(creds: ResolvedCredentials) -> Result<Self> {
+        if creds.endpoint.is_empty() {
+            return Err(anyhow::anyhow!("endpoint must not be empty"));
+        }
+        let base_url = match creds.env {
+            AlpacaEnv::Live => {
+                format!("{}/v2", creds.endpoint.trim_end_matches('/'))
+            }
+            AlpacaEnv::Paper => creds.endpoint.trim_end_matches('/').to_string(),
+        };
+        Ok(Self {
+            base_url,
+            key: creds.key,
+            secret: creds.secret,
+            env: creds.env,
+        })
     }
 
     /// Returns a short uppercase label for the current environment.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 //! Runtime configuration loaded from environment variables.
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 
 #[cfg(test)]
 mod tests {
@@ -7,7 +7,6 @@ mod tests {
 
     fn paper_vars(endpoint: &str) -> Vec<(&'static str, Option<String>)> {
         vec![
-            ("ALPACA_ENV", Some("paper".into())),
             ("PAPER_ALPACA_ENDPOINT", Some(endpoint.into())),
             ("PAPER_ALPACA_KEY", Some("PKTEST000".into())),
             ("PAPER_ALPACA_SECRET", Some("secret000".into())),
@@ -16,7 +15,6 @@ mod tests {
 
     fn live_vars(endpoint: &str) -> Vec<(&'static str, Option<String>)> {
         vec![
-            ("ALPACA_ENV", Some("live".into())),
             ("LIVE_ALPACA_ENDPOINT", Some(endpoint.into())),
             ("LIVE_ALPACA_KEY", Some("AKTEST000".into())),
             ("LIVE_ALPACA_SECRET", Some("secret000".into())),
@@ -48,7 +46,7 @@ mod tests {
     #[test]
     fn from_env_paper_selects_paper_vars() {
         temp_env::with_vars(paper_vars("https://paper-api.alpaca.markets/v2"), || {
-            let cfg = AlpacaConfig::from_env().unwrap();
+            let cfg = AlpacaConfig::from_env(AlpacaEnv::Paper).unwrap();
             assert_eq!(cfg.env, AlpacaEnv::Paper);
             assert_eq!(cfg.base_url, "https://paper-api.alpaca.markets/v2");
             assert_eq!(cfg.key, "PKTEST000");
@@ -59,7 +57,7 @@ mod tests {
     #[test]
     fn from_env_paper_trailing_slash_stripped() {
         temp_env::with_vars(paper_vars("https://paper-api.alpaca.markets/v2/"), || {
-            let cfg = AlpacaConfig::from_env().unwrap();
+            let cfg = AlpacaConfig::from_env(AlpacaEnv::Paper).unwrap();
             assert_eq!(cfg.base_url, "https://paper-api.alpaca.markets/v2");
         });
     }
@@ -67,7 +65,7 @@ mod tests {
     #[test]
     fn from_env_live_appends_v2() {
         temp_env::with_vars(live_vars("https://api.alpaca.markets"), || {
-            let cfg = AlpacaConfig::from_env().unwrap();
+            let cfg = AlpacaConfig::from_env(AlpacaEnv::Live).unwrap();
             assert_eq!(cfg.env, AlpacaEnv::Live);
             assert_eq!(cfg.base_url, "https://api.alpaca.markets/v2");
         });
@@ -76,25 +74,8 @@ mod tests {
     #[test]
     fn from_env_live_no_double_slash() {
         temp_env::with_vars(live_vars("https://api.alpaca.markets/"), || {
-            let cfg = AlpacaConfig::from_env().unwrap();
+            let cfg = AlpacaConfig::from_env(AlpacaEnv::Live).unwrap();
             assert_eq!(cfg.base_url, "https://api.alpaca.markets/v2");
-        });
-    }
-
-    #[test]
-    fn from_env_defaults_to_paper_when_unset() {
-        let mut vars = paper_vars("https://paper-api.alpaca.markets/v2");
-        vars[0] = ("ALPACA_ENV", None); // unset ALPACA_ENV
-        temp_env::with_vars(vars, || {
-            let cfg = AlpacaConfig::from_env().unwrap();
-            assert_eq!(cfg.env, AlpacaEnv::Paper);
-        });
-    }
-
-    #[test]
-    fn from_env_unknown_value_errors() {
-        temp_env::with_vars([("ALPACA_ENV", Some("staging".to_string()))], || {
-            assert!(AlpacaConfig::from_env().is_err());
         });
     }
 
@@ -102,7 +83,6 @@ mod tests {
     fn from_env_missing_paper_key_errors() {
         temp_env::with_vars(
             [
-                ("ALPACA_ENV", Some("paper".to_string())),
                 (
                     "PAPER_ALPACA_ENDPOINT",
                     Some("https://paper-api.alpaca.markets/v2".to_string()),
@@ -111,7 +91,24 @@ mod tests {
                 ("PAPER_ALPACA_SECRET", Some("secret".to_string())),
             ],
             || {
-                assert!(AlpacaConfig::from_env().is_err());
+                assert!(AlpacaConfig::from_env(AlpacaEnv::Paper).is_err());
+            },
+        );
+    }
+
+    #[test]
+    fn from_env_missing_live_key_errors() {
+        temp_env::with_vars(
+            [
+                (
+                    "LIVE_ALPACA_ENDPOINT",
+                    Some("https://api.alpaca.markets".to_string()),
+                ),
+                ("LIVE_ALPACA_KEY", None),
+                ("LIVE_ALPACA_SECRET", Some("secret".to_string())),
+            ],
+            || {
+                assert!(AlpacaConfig::from_env(AlpacaEnv::Live).is_err());
             },
         );
     }
@@ -146,23 +143,22 @@ pub struct AlpacaConfig {
 }
 
 impl AlpacaConfig {
-    /// Load configuration from environment variables.
+    /// Load configuration from environment variables for the specified environment.
     ///
-    /// Reads `ALPACA_ENV` (defaults to `"paper"`) then picks the matching set
-    /// of variables:
+    /// Only the variables for the requested environment are read and validated —
+    /// the opposing set is ignored entirely. The environment is determined by the
+    /// `--paper` CLI flag: pass [`AlpacaEnv::Paper`] when `--paper` is supplied,
+    /// or [`AlpacaEnv::Live`] otherwise (the default).
     ///
     /// | Env | Variables required |
     /// |-----|--------------------|
-    /// | `paper` | `PAPER_ALPACA_ENDPOINT`, `PAPER_ALPACA_KEY`, `PAPER_ALPACA_SECRET` |
-    /// | `live`  | `LIVE_ALPACA_ENDPOINT`,  `LIVE_ALPACA_KEY`,  `LIVE_ALPACA_SECRET`  |
+    /// | [`AlpacaEnv::Paper`] | `PAPER_ALPACA_ENDPOINT`, `PAPER_ALPACA_KEY`, `PAPER_ALPACA_SECRET` |
+    /// | [`AlpacaEnv::Live`]  | `LIVE_ALPACA_ENDPOINT`,  `LIVE_ALPACA_KEY`,  `LIVE_ALPACA_SECRET`  |
     ///
-    /// Returns an error if any required variable is missing or if `ALPACA_ENV`
-    /// is set to an unrecognised value.
-    pub fn from_env() -> Result<Self> {
-        let env_label = std::env::var("ALPACA_ENV").unwrap_or_else(|_| "paper".into());
-
-        match env_label.to_lowercase().as_str() {
-            "live" => {
+    /// Returns an error if any required variable for the chosen environment is missing.
+    pub fn from_env(env: AlpacaEnv) -> Result<Self> {
+        match env {
+            AlpacaEnv::Live => {
                 let endpoint = std::env::var("LIVE_ALPACA_ENDPOINT")
                     .context("LIVE_ALPACA_ENDPOINT not set")?;
                 let key = std::env::var("LIVE_ALPACA_KEY").context("LIVE_ALPACA_KEY not set")?;
@@ -177,7 +173,7 @@ impl AlpacaConfig {
                     env: AlpacaEnv::Live,
                 })
             }
-            "paper" => {
+            AlpacaEnv::Paper => {
                 let endpoint = std::env::var("PAPER_ALPACA_ENDPOINT")
                     .context("PAPER_ALPACA_ENDPOINT not set")?;
                 let key = std::env::var("PAPER_ALPACA_KEY").context("PAPER_ALPACA_KEY not set")?;
@@ -192,10 +188,6 @@ impl AlpacaConfig {
                     env: AlpacaEnv::Paper,
                 })
             }
-            other => Err(anyhow!(
-                "Unknown ALPACA_ENV value: '{}'. Use 'paper' or 'live'.",
-                other
-            )),
         }
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -172,14 +172,22 @@ pub fn reset(env: AlpacaEnv) {
     // ── Report env var sources ────────────────────────────────────────────────
     // dotenvy::dotenv() is called before reset() in main, so vars from .env
     // files are already in the environment at this point.
-    let has_unified = std::env::var("ALPACA_API_KEY").ok().filter(|s| !s.is_empty()).is_some()
-        && std::env::var("ALPACA_API_SECRET").ok().filter(|s| !s.is_empty()).is_some();
-    let has_prefixed =
-        std::env::var(format!("{env_prefix}_KEY")).ok().filter(|s| !s.is_empty()).is_some()
-            && std::env::var(format!("{env_prefix}_SECRET"))
-                .ok()
-                .filter(|s| !s.is_empty())
-                .is_some();
+    let has_unified = std::env::var("ALPACA_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_some()
+        && std::env::var("ALPACA_API_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .is_some();
+    let has_prefixed = std::env::var(format!("{env_prefix}_KEY"))
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_some()
+        && std::env::var(format!("{env_prefix}_SECRET"))
+            .ok()
+            .filter(|s| !s.is_empty())
+            .is_some();
 
     if has_unified {
         eprintln!(
@@ -232,7 +240,6 @@ pub fn reset(env: AlpacaEnv) {
         } else {
             eprintln!("✓ {env_label} credentials removed from keychain.");
         }
-        return;
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -159,6 +159,63 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
     })
 }
 
+/// Delete stored keychain credentials for `env` and exit.
+///
+/// Prints a status message to stderr. On platforms without keychain support,
+/// prints an informational message and returns without error.
+pub fn reset(env: AlpacaEnv) {
+    let (kr_prefix, env_label) = match env {
+        AlpacaEnv::Live => ("live", "live"),
+        AlpacaEnv::Paper => ("paper", "paper"),
+    };
+
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    {
+        let key_user = format!("{kr_prefix}-api-key");
+        let secret_user = format!("{kr_prefix}-api-secret");
+        let mut removed = 0u8;
+        let mut any_error = false;
+
+        for user in [&key_user, &secret_user] {
+            match keyring::Entry::new(SERVICE, user) {
+                Ok(entry) => match entry.delete_credential() {
+                    Ok(()) => removed += 1,
+                    Err(keyring::Error::NoEntry) => {}
+                    Err(e) => {
+                        eprintln!("Warning: could not remove {user} from keychain: {e}");
+                        any_error = true;
+                    }
+                },
+                Err(e) => {
+                    eprintln!("Warning: keychain init error for {user}: {e}");
+                    any_error = true;
+                }
+            }
+        }
+
+        if any_error {
+            eprintln!("Some entries could not be removed. You may need to remove them manually.");
+        } else if removed == 0 {
+            eprintln!("No {env_label} credentials found in keychain (nothing to remove).");
+        } else {
+            eprintln!("✓ {env_label} credentials removed from keychain.");
+        }
+        return;
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        let _ = kr_prefix;
+        eprintln!("Keychain storage is not supported on this platform — nothing to reset.");
+        eprintln!(
+            "To clear credentials, unset the {}_ALPACA_KEY / {}_ALPACA_SECRET \
+             environment variables.",
+            env_label.to_uppercase(),
+            env_label.to_uppercase()
+        );
+    }
+}
+
 // ── Keychain helpers (compiled only on supported platforms) ───────────────────
 
 /// Distinguishes between "entry not found" and a hard backend error.

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -36,8 +36,8 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
         AlpacaEnv::Paper => "paper",
     };
 
-    let endpoint = std::env::var(format!("{prefix}_ENDPOINT"))
-        .unwrap_or_else(|_| default_ep.to_string());
+    let endpoint =
+        std::env::var(format!("{prefix}_ENDPOINT")).unwrap_or_else(|_| default_ep.to_string());
 
     // ── Step 1: environment variables ─────────────────────────────────────────
     let env_key = std::env::var(format!("{prefix}_KEY"))
@@ -48,8 +48,16 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
         .filter(|s| !s.is_empty());
 
     if let (Some(key), Some(secret)) = (env_key, env_secret) {
-        tracing::debug!(env = env_label, "credentials loaded from environment variables");
-        return Ok(ResolvedCredentials { endpoint, key, secret, env });
+        tracing::debug!(
+            env = env_label,
+            "credentials loaded from environment variables"
+        );
+        return Ok(ResolvedCredentials {
+            endpoint,
+            key,
+            secret,
+            env,
+        });
     }
 
     // ── Step 2: OS keychain ────────────────────────────────────────────────────
@@ -61,7 +69,12 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
     match try_keychain_load(kr_prefix) {
         Ok(Some((key, secret))) => {
             tracing::debug!(env = env_label, "credentials loaded from OS keychain");
-            return Ok(ResolvedCredentials { endpoint, key, secret, env });
+            return Ok(ResolvedCredentials {
+                endpoint,
+                key,
+                secret,
+                env,
+            });
         }
         Ok(None) => {
             // Not stored yet — fall through to interactive prompt.
@@ -96,14 +109,8 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
     eprintln!("Visit https://app.alpaca.markets to generate API credentials.");
     eprintln!();
 
-    let key_prompt = format!(
-        "{} API Key   (APCA-API-KEY-ID): ",
-        env_label.to_uppercase()
-    );
-    let secret_prompt = format!(
-        "{} API Secret:                  ",
-        env_label.to_uppercase()
-    );
+    let key_prompt = format!("{} API Key   (APCA-API-KEY-ID): ", env_label.to_uppercase());
+    let secret_prompt = format!("{} API Secret:                  ", env_label.to_uppercase());
 
     let key = rpassword::prompt_password(key_prompt)?;
     let secret = rpassword::prompt_password(secret_prompt)?;
@@ -119,7 +126,12 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
     }
 
     eprintln!();
-    Ok(ResolvedCredentials { endpoint, key, secret, env })
+    Ok(ResolvedCredentials {
+        endpoint,
+        key,
+        secret,
+        env,
+    })
 }
 
 // ── Keychain helpers (compiled only on supported platforms) ───────────────────
@@ -161,7 +173,9 @@ fn load_one_entry(user: &str) -> Result<Option<String>, KeychainStatus> {
         Err(keyring::Error::NoStorageAccess(e) | keyring::Error::PlatformFailure(e)) => {
             Err(KeychainStatus::Unavailable(e.to_string()))
         }
-        Err(e) => Err(KeychainStatus::Hard(anyhow::anyhow!("keychain read error: {e}"))),
+        Err(e) => Err(KeychainStatus::Hard(anyhow::anyhow!(
+            "keychain read error: {e}"
+        ))),
     }
 }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -2,11 +2,13 @@
 //!
 //! Resolution order (highest → lowest priority):
 //!
-//! 1. **Environment variables** (`{ENV}_ALPACA_KEY` / `{ENV}_ALPACA_SECRET`) —
-//!    populated by `.env` via `dotenvy`, shell exports, CI secrets, or Docker.
-//! 2. **OS-native keychain** (macOS Keychain Access, Windows Credential Store,
+//! 1. **`ALPACA_API_KEY` + `ALPACA_API_SECRET`** — unified pair; ideal for CI,
+//!    Docker, and systemd where a single key pair is configured.
+//! 2. **`{ENV}_ALPACA_KEY` + `{ENV}_ALPACA_SECRET`** — per-environment vars
+//!    (`LIVE_*` or `PAPER_*`); developer `.env` files and multi-environment setups.
+//! 3. **OS-native keychain** (macOS Keychain Access, Windows Credential Store,
 //!    Linux kernel keyutils) — no C-library dependency on any platform.
-//! 3. **Interactive TTY prompt** via `rpassword` — runs once on first launch
+//! 4. **Interactive TTY prompt** via `rpassword` — runs once on first launch
 //!    and offers to persist credentials in the OS keychain.
 //!
 //! Call [`resolve`] **before** `enable_raw_mode()` — it may print to stderr
@@ -39,7 +41,30 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
     let endpoint =
         std::env::var(format!("{prefix}_ENDPOINT")).unwrap_or_else(|_| default_ep.to_string());
 
-    // ── Step 1: environment variables ─────────────────────────────────────────
+    // ── Step 1a: unified env vars (ALPACA_API_KEY / ALPACA_API_SECRET) ─────────
+    // These take priority and work regardless of live/paper mode — ideal for CI,
+    // Docker, and systemd where a single key pair is configured.
+    let unified_key = std::env::var("ALPACA_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let unified_secret = std::env::var("ALPACA_API_SECRET")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    if let (Some(key), Some(secret)) = (unified_key, unified_secret) {
+        tracing::debug!(
+            env = env_label,
+            "credentials loaded from ALPACA_API_KEY / ALPACA_API_SECRET"
+        );
+        return Ok(ResolvedCredentials {
+            endpoint,
+            key,
+            secret,
+            env,
+        });
+    }
+
+    // ── Step 1b: per-environment env vars ({ENV}_ALPACA_KEY / _SECRET) ─────────
     let env_key = std::env::var(format!("{prefix}_KEY"))
         .ok()
         .filter(|s| !s.is_empty());
@@ -205,4 +230,227 @@ fn save_keychain_pair(prefix: &str, key: &str, secret: &str) -> Result<()> {
         .and_then(|e| e.set_password(secret))
         .map_err(|e| anyhow::anyhow!("keychain write error (secret): {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: clear all credential env vars around a test closure.
+    fn with_no_env_creds<F: FnOnce()>(f: F) {
+        temp_env::with_vars(
+            [
+                ("ALPACA_API_KEY", None::<&str>),
+                ("ALPACA_API_SECRET", None::<&str>),
+                ("LIVE_ALPACA_KEY", None::<&str>),
+                ("LIVE_ALPACA_SECRET", None::<&str>),
+                ("PAPER_ALPACA_KEY", None::<&str>),
+                ("PAPER_ALPACA_SECRET", None::<&str>),
+                ("LIVE_ALPACA_ENDPOINT", None::<&str>),
+                ("PAPER_ALPACA_ENDPOINT", None::<&str>),
+            ],
+            f,
+        );
+    }
+
+    // ── Unified env var tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn unified_vars_resolve_for_live() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("unified-key")),
+                    ("ALPACA_API_SECRET", Some("unified-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.key, "unified-key");
+                    assert_eq!(creds.secret, "unified-secret");
+                    assert!(matches!(creds.env, AlpacaEnv::Live));
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn unified_vars_resolve_for_paper() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("unified-key")),
+                    ("ALPACA_API_SECRET", Some("unified-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Paper).unwrap();
+                    assert_eq!(creds.key, "unified-key");
+                    assert_eq!(creds.secret, "unified-secret");
+                    assert!(matches!(creds.env, AlpacaEnv::Paper));
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn unified_vars_use_default_live_endpoint() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("k")),
+                    ("ALPACA_API_SECRET", Some("s")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.endpoint, DEFAULT_LIVE_ENDPOINT);
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn unified_vars_use_default_paper_endpoint() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("k")),
+                    ("ALPACA_API_SECRET", Some("s")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Paper).unwrap();
+                    assert_eq!(creds.endpoint, DEFAULT_PAPER_ENDPOINT);
+                },
+            );
+        });
+    }
+
+    // ── Per-environment env var tests ─────────────────────────────────────────
+
+    #[test]
+    fn live_prefixed_vars_resolve() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("LIVE_ALPACA_KEY", Some("live-key")),
+                    ("LIVE_ALPACA_SECRET", Some("live-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.key, "live-key");
+                    assert_eq!(creds.secret, "live-secret");
+                    assert!(matches!(creds.env, AlpacaEnv::Live));
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn paper_prefixed_vars_resolve() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("PAPER_ALPACA_KEY", Some("paper-key")),
+                    ("PAPER_ALPACA_SECRET", Some("paper-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Paper).unwrap();
+                    assert_eq!(creds.key, "paper-key");
+                    assert_eq!(creds.secret, "paper-secret");
+                    assert!(matches!(creds.env, AlpacaEnv::Paper));
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn unified_vars_take_priority_over_prefixed() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("unified-key")),
+                    ("ALPACA_API_SECRET", Some("unified-secret")),
+                    ("LIVE_ALPACA_KEY", Some("live-key")),
+                    ("LIVE_ALPACA_SECRET", Some("live-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.key, "unified-key");
+                    assert_eq!(creds.secret, "unified-secret");
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn custom_endpoint_from_env_is_used() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("k")),
+                    ("ALPACA_API_SECRET", Some("s")),
+                    ("LIVE_ALPACA_ENDPOINT", Some("https://custom.example.com")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.endpoint, "https://custom.example.com");
+                },
+            );
+        });
+    }
+
+    // ── Empty value filtering ─────────────────────────────────────────────────
+
+    #[test]
+    fn empty_unified_key_falls_through_to_prefixed() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("")),
+                    ("ALPACA_API_SECRET", Some("secret")),
+                    ("LIVE_ALPACA_KEY", Some("live-key")),
+                    ("LIVE_ALPACA_SECRET", Some("live-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.key, "live-key");
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn empty_unified_secret_falls_through_to_prefixed() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("ALPACA_API_KEY", Some("some-key")),
+                    ("ALPACA_API_SECRET", Some("")),
+                    ("LIVE_ALPACA_KEY", Some("live-key")),
+                    ("LIVE_ALPACA_SECRET", Some("live-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Live).unwrap();
+                    assert_eq!(creds.key, "live-key");
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn live_prefixed_vars_not_used_for_paper() {
+        with_no_env_creds(|| {
+            temp_env::with_vars(
+                [
+                    ("LIVE_ALPACA_KEY", Some("live-key")),
+                    ("LIVE_ALPACA_SECRET", Some("live-secret")),
+                    ("PAPER_ALPACA_KEY", Some("paper-key")),
+                    ("PAPER_ALPACA_SECRET", Some("paper-secret")),
+                ],
+                || {
+                    let creds = resolve(AlpacaEnv::Paper).unwrap();
+                    assert_eq!(creds.key, "paper-key");
+                    assert_eq!(creds.secret, "paper-secret");
+                },
+            );
+        });
+    }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,0 +1,194 @@
+//! Tiered credential resolution for Alpaca API keys.
+//!
+//! Resolution order (highest → lowest priority):
+//!
+//! 1. **Environment variables** (`{ENV}_ALPACA_KEY` / `{ENV}_ALPACA_SECRET`) —
+//!    populated by `.env` via `dotenvy`, shell exports, CI secrets, or Docker.
+//! 2. **OS-native keychain** (macOS Keychain Access, Windows Credential Store,
+//!    Linux kernel keyutils) — no C-library dependency on any platform.
+//! 3. **Interactive TTY prompt** via `rpassword` — runs once on first launch
+//!    and offers to persist credentials in the OS keychain.
+//!
+//! Call [`resolve`] **before** `enable_raw_mode()` — it may print to stderr
+//! and read from stdin.
+
+use std::io::{self, BufRead as _, IsTerminal as _};
+
+use anyhow::{bail, Result};
+
+use crate::config::{AlpacaEnv, ResolvedCredentials};
+
+const SERVICE: &str = "alpaca-trader-rs";
+
+const DEFAULT_LIVE_ENDPOINT: &str = "https://api.alpaca.markets";
+const DEFAULT_PAPER_ENDPOINT: &str = "https://paper-api.alpaca.markets/v2";
+
+/// Resolve credentials for `env` using the tiered lookup strategy.
+///
+/// Must be called **before** `enable_raw_mode()`.
+pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
+    let (prefix, kr_prefix, default_ep) = match env {
+        AlpacaEnv::Live => ("LIVE_ALPACA", "live", DEFAULT_LIVE_ENDPOINT),
+        AlpacaEnv::Paper => ("PAPER_ALPACA", "paper", DEFAULT_PAPER_ENDPOINT),
+    };
+    let env_label = match env {
+        AlpacaEnv::Live => "live",
+        AlpacaEnv::Paper => "paper",
+    };
+
+    let endpoint = std::env::var(format!("{prefix}_ENDPOINT"))
+        .unwrap_or_else(|_| default_ep.to_string());
+
+    // ── Step 1: environment variables ─────────────────────────────────────────
+    let env_key = std::env::var(format!("{prefix}_KEY"))
+        .ok()
+        .filter(|s| !s.is_empty());
+    let env_secret = std::env::var(format!("{prefix}_SECRET"))
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    if let (Some(key), Some(secret)) = (env_key, env_secret) {
+        tracing::debug!(env = env_label, "credentials loaded from environment variables");
+        return Ok(ResolvedCredentials { endpoint, key, secret, env });
+    }
+
+    // ── Step 2: OS keychain ────────────────────────────────────────────────────
+    // keychain_usable is true when the keychain backend is present and healthy.
+    // On unsupported platforms the entire block is compiled away.
+    let mut keychain_usable = false;
+
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    match try_keychain_load(kr_prefix) {
+        Ok(Some((key, secret))) => {
+            tracing::debug!(env = env_label, "credentials loaded from OS keychain");
+            return Ok(ResolvedCredentials { endpoint, key, secret, env });
+        }
+        Ok(None) => {
+            // Not stored yet — fall through to interactive prompt.
+            keychain_usable = true;
+        }
+        Err(KeychainStatus::Unavailable(msg)) => {
+            eprintln!(
+                "Warning: OS keychain unavailable ({msg}) — \
+                 credentials will not be persisted."
+            );
+            // keychain_usable remains false
+        }
+        Err(KeychainStatus::Hard(e)) => return Err(e),
+    }
+
+    // Suppress unused-variable warning on platforms without keychain support.
+    let _ = keychain_usable;
+
+    // ── Step 3: interactive TTY prompt ─────────────────────────────────────────
+    if !io::stdin().is_terminal() {
+        bail!(
+            "No {env_label} Alpaca credentials found and no interactive terminal is available.\n\
+             Set {prefix}_KEY and {prefix}_SECRET in your environment or .env file."
+        );
+    }
+
+    eprintln!();
+    eprintln!("No {env_label} Alpaca credentials found.");
+    if matches!(env, AlpacaEnv::Live) {
+        eprintln!("⚠️  Live trading uses real money. Proceed with care.");
+    }
+    eprintln!("Visit https://app.alpaca.markets to generate API credentials.");
+    eprintln!();
+
+    let key_prompt = format!(
+        "{} API Key   (APCA-API-KEY-ID): ",
+        env_label.to_uppercase()
+    );
+    let secret_prompt = format!(
+        "{} API Secret:                  ",
+        env_label.to_uppercase()
+    );
+
+    let key = rpassword::prompt_password(key_prompt)?;
+    let secret = rpassword::prompt_password(secret_prompt)?;
+
+    if key.trim().is_empty() || secret.trim().is_empty() {
+        bail!("API key and secret must not be empty.");
+    }
+
+    // ── Step 4: offer to save to keychain ─────────────────────────────────────
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    if keychain_usable {
+        offer_keychain_save(kr_prefix, &key, &secret);
+    }
+
+    eprintln!();
+    Ok(ResolvedCredentials { endpoint, key, secret, env })
+}
+
+// ── Keychain helpers (compiled only on supported platforms) ───────────────────
+
+/// Distinguishes between "entry not found" and a hard backend error.
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+enum KeychainStatus {
+    /// The keychain is locked or the backend is unavailable.
+    Unavailable(String),
+    /// An unexpected hard error occurred.
+    Hard(anyhow::Error),
+}
+
+/// Try to read a key+secret pair from the OS keychain.
+///
+/// Returns:
+/// - `Ok(Some(_))` — credentials found
+/// - `Ok(None)` — entry absent (`NoEntry`); first-run, safe to prompt
+/// - `Err(KeychainStatus::Unavailable)` — keychain locked/inaccessible; warn and prompt without saving
+/// - `Err(KeychainStatus::Hard)` — unexpected error; propagate to caller
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+fn try_keychain_load(prefix: &str) -> Result<Option<(String, String)>, KeychainStatus> {
+    let key = load_one_entry(&format!("{prefix}-api-key"))?;
+    let secret = load_one_entry(&format!("{prefix}-api-secret"))?;
+    match (key, secret) {
+        (Some(k), Some(s)) => Ok(Some((k, s))),
+        _ => Ok(None), // one or both absent — first run
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+fn load_one_entry(user: &str) -> Result<Option<String>, KeychainStatus> {
+    let entry = keyring::Entry::new(SERVICE, user)
+        .map_err(|e| KeychainStatus::Hard(anyhow::anyhow!("keyring init error: {e}")))?;
+
+    match entry.get_password() {
+        Ok(v) => Ok(Some(v)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(keyring::Error::NoStorageAccess(e) | keyring::Error::PlatformFailure(e)) => {
+            Err(KeychainStatus::Unavailable(e.to_string()))
+        }
+        Err(e) => Err(KeychainStatus::Hard(anyhow::anyhow!("keychain read error: {e}"))),
+    }
+}
+
+/// Prompt the user to save credentials to the OS keychain.
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+fn offer_keychain_save(prefix: &str, key: &str, secret: &str) {
+    eprint!("Store credentials in OS keychain for future logins? [Y/n]: ");
+    let mut answer = String::new();
+    if io::stdin().lock().read_line(&mut answer).is_err() {
+        return;
+    }
+    if !(answer.trim().is_empty() || answer.trim().eq_ignore_ascii_case("y")) {
+        return;
+    }
+    match save_keychain_pair(prefix, key, secret) {
+        Ok(()) => eprintln!("✓ Credentials saved to keychain."),
+        Err(e) => eprintln!("Warning: could not save to keychain: {e}"),
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+fn save_keychain_pair(prefix: &str, key: &str, secret: &str) -> Result<()> {
+    keyring::Entry::new(SERVICE, &format!("{prefix}-api-key"))
+        .and_then(|e| e.set_password(key))
+        .map_err(|e| anyhow::anyhow!("keychain write error (key): {e}"))?;
+    keyring::Entry::new(SERVICE, &format!("{prefix}-api-secret"))
+        .and_then(|e| e.set_password(secret))
+        .map_err(|e| anyhow::anyhow!("keychain write error (secret): {e}"))?;
+    Ok(())
+}

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -164,11 +164,39 @@ pub fn resolve(env: AlpacaEnv) -> Result<ResolvedCredentials> {
 /// Prints a status message to stderr. On platforms without keychain support,
 /// prints an informational message and returns without error.
 pub fn reset(env: AlpacaEnv) {
-    let (kr_prefix, env_label) = match env {
-        AlpacaEnv::Live => ("live", "live"),
-        AlpacaEnv::Paper => ("paper", "paper"),
+    let (kr_prefix, env_label, env_prefix) = match env {
+        AlpacaEnv::Live => ("live", "live", "LIVE_ALPACA"),
+        AlpacaEnv::Paper => ("paper", "paper", "PAPER_ALPACA"),
     };
 
+    // ── Report env var sources ────────────────────────────────────────────────
+    // dotenvy::dotenv() is called before reset() in main, so vars from .env
+    // files are already in the environment at this point.
+    let has_unified = std::env::var("ALPACA_API_KEY").ok().filter(|s| !s.is_empty()).is_some()
+        && std::env::var("ALPACA_API_SECRET").ok().filter(|s| !s.is_empty()).is_some();
+    let has_prefixed =
+        std::env::var(format!("{env_prefix}_KEY")).ok().filter(|s| !s.is_empty()).is_some()
+            && std::env::var(format!("{env_prefix}_SECRET"))
+                .ok()
+                .filter(|s| !s.is_empty())
+                .is_some();
+
+    if has_unified {
+        eprintln!(
+            "Note: ALPACA_API_KEY / ALPACA_API_SECRET are set in your environment or a .env file."
+        );
+        eprintln!("      To stop using them, remove or unset those variables.");
+    }
+    if has_prefixed {
+        eprintln!(
+            "Note: {env_prefix}_KEY / {env_prefix}_SECRET are set in your environment or a .env file."
+        );
+        eprintln!(
+            "      To stop using them, remove or unset those variables (check ~/.env or .env)."
+        );
+    }
+
+    // ── Remove keychain entries ───────────────────────────────────────────────
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     {
         let key_user = format!("{kr_prefix}-api-key");
@@ -196,7 +224,11 @@ pub fn reset(env: AlpacaEnv) {
         if any_error {
             eprintln!("Some entries could not be removed. You may need to remove them manually.");
         } else if removed == 0 {
-            eprintln!("No {env_label} credentials found in keychain (nothing to remove).");
+            if !has_unified && !has_prefixed {
+                eprintln!("No {env_label} credentials found in keychain or environment (nothing to remove).");
+            } else {
+                eprintln!("No {env_label} credentials found in keychain (see env var note above).");
+            }
         } else {
             eprintln!("✓ {env_label} credentials removed from keychain.");
         }
@@ -206,13 +238,13 @@ pub fn reset(env: AlpacaEnv) {
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         let _ = kr_prefix;
-        eprintln!("Keychain storage is not supported on this platform — nothing to reset.");
-        eprintln!(
-            "To clear credentials, unset the {}_ALPACA_KEY / {}_ALPACA_SECRET \
-             environment variables.",
-            env_label.to_uppercase(),
-            env_label.to_uppercase()
-        );
+        if !has_unified && !has_prefixed {
+            eprintln!("Keychain storage is not supported on this platform — nothing to reset.");
+            eprintln!(
+                "To clear credentials, unset the {env_prefix}_KEY / {env_prefix}_SECRET \
+                 environment variables."
+            );
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
+use clap::Parser;
 use crossterm::{
     event::EnableMouseCapture,
     execute,
@@ -11,7 +12,24 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use tokio::sync::{mpsc, watch, Notify};
 use tokio_util::sync::CancellationToken;
 
-use alpaca_trader_rs::{client::AlpacaClient, config::AlpacaConfig, events::Event};
+use alpaca_trader_rs::{
+    client::AlpacaClient,
+    config::{AlpacaConfig, AlpacaEnv},
+    events::Event,
+};
+
+/// Alpaca Markets TUI trading terminal.
+///
+/// Connects to the **live** account by default. Pass `--paper` to use the
+/// paper-trading environment (simulated funds, no real money at risk).
+#[derive(Parser)]
+#[command(version, about)]
+struct Args {
+    /// Connect to the paper-trading environment (simulated funds).
+    /// Omit to use the live account (real money — default).
+    #[arg(long)]
+    paper: bool,
+}
 
 // Bridge library modules into the binary crate so sub-modules can use `crate::config` etc.
 mod client {
@@ -42,6 +60,8 @@ use update::update;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
     dotenvy::dotenv().ok();
 
     // ── Logging — must come before enable_raw_mode() ───────────────────────────
@@ -52,10 +72,25 @@ async fn main() -> anyhow::Result<()> {
         nb
     });
 
-    let config = AlpacaConfig::from_env().map_err(|e| {
+    let env = if args.paper {
+        AlpacaEnv::Paper
+    } else {
+        AlpacaEnv::Live
+    };
+
+    let config = AlpacaConfig::from_env(env).map_err(|e| {
         tracing::error!(error = %e, "configuration error");
         eprintln!("Configuration error: {e}");
-        eprintln!("Copy .env.example to .env and fill in your Alpaca API credentials.");
+        if args.paper {
+            eprintln!(
+                "Set PAPER_ALPACA_ENDPOINT, PAPER_ALPACA_KEY and PAPER_ALPACA_SECRET in your environment or .env file."
+            );
+        } else {
+            eprintln!(
+                "Set LIVE_ALPACA_ENDPOINT, LIVE_ALPACA_KEY and LIVE_ALPACA_SECRET in your environment or .env file."
+            );
+            eprintln!("Use --paper to connect to the paper-trading environment instead.");
+        }
         e
     })?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ mod types {
 }
 
 mod app;
+mod credentials;
 mod handlers;
 mod input;
 mod ui;
@@ -78,19 +79,16 @@ async fn main() -> anyhow::Result<()> {
         AlpacaEnv::Live
     };
 
-    let config = AlpacaConfig::from_env(env).map_err(|e| {
+    // Resolve credentials before entering raw-mode (may print/prompt to terminal).
+    let creds = credentials::resolve(env).map_err(|e| {
+        tracing::error!(error = %e, "credential resolution failed");
+        eprintln!("Error: {e}");
+        e
+    })?;
+
+    let config = AlpacaConfig::from_credentials(creds).map_err(|e| {
         tracing::error!(error = %e, "configuration error");
         eprintln!("Configuration error: {e}");
-        if args.paper {
-            eprintln!(
-                "Set PAPER_ALPACA_ENDPOINT, PAPER_ALPACA_KEY and PAPER_ALPACA_SECRET in your environment or .env file."
-            );
-        } else {
-            eprintln!(
-                "Set LIVE_ALPACA_ENDPOINT, LIVE_ALPACA_KEY and LIVE_ALPACA_SECRET in your environment or .env file."
-            );
-            eprintln!("Use --paper to connect to the paper-trading environment instead.");
-        }
         e
     })?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ struct Args {
     /// Omit to use the live account (real money — default).
     #[arg(long)]
     paper: bool,
+
+    /// Delete stored keychain credentials for the given environment and exit.
+    ///
+    /// Example: `alpaca-trader --reset paper` or `alpaca-trader --reset live`
+    #[arg(long, value_name = "ENV", value_parser = ["paper", "live"])]
+    reset: Option<String>,
 }
 
 // Bridge library modules into the binary crate so sub-modules can use `crate::config` etc.
@@ -64,6 +70,17 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     dotenvy::dotenv().ok();
+
+    // ── --reset: delete keychain credentials and exit ──────────────────────────
+    if let Some(ref env_str) = args.reset {
+        let env = if env_str == "paper" {
+            AlpacaEnv::Paper
+        } else {
+            AlpacaEnv::Live
+        };
+        credentials::reset(env);
+        return Ok(());
+    }
 
     // ── Logging — must come before enable_raw_mode() ───────────────────────────
     let _log_guard = alpaca_trader_rs::logging::init().unwrap_or_else(|e| {


### PR DESCRIPTION
## Summary

Closes #43

This PR implements the full scope of issue #43:

### 1. Replace `ALPACA_ENV` with `--paper` flag

- **Breaking**: live account is now the default (previously paper was default)
- `alpaca-trader` → live account
- `alpaca-trader --paper` → paper/simulation account
- `ALPACA_ENV` env var is completely removed; setting it has no effect
- `run.sh` updated to use `--paper` / `--live` flags instead

### 2. OS-native keychain credential storage + first-run provisioning

Tiered resolution: **env vars → OS keychain → interactive TTY prompt → offer to save**

- **`src/credentials.rs`** — new binary-crate module handling all credential resolution
  - Env vars (`LIVE_ALPACA_KEY`, etc.) checked first for CI / scripted use
  - OS-native keychain via `keyring` v3 with **no C-library dependency** on any platform:
    - macOS: Keychain Access (`apple-native`)
    - Windows: Credential Store (`windows-native`)
    - Linux: kernel keyutils (`linux-native`) — cross-compiles cleanly from macOS CI runners
  - First-run: interactive TTY prompt via `rpassword` v7 (opens `/dev/tty` directly, unaffected by TUI raw mode)
  - After successful first-run entry, prompts to save to OS keychain (default: yes)
  - Graceful degradation when keychain unavailable (locked, WSL, headless CI) — warns and continues session-only
  - Clear error when running headless with no credentials configured anywhere

- **`src/config.rs`** — added `ResolvedCredentials` struct and `AlpacaConfig::from_credentials()` constructor
- **`src/main.rs`** — calls `credentials::resolve(env)` *before* `enable_raw_mode()` (correct ordering preserved)

### Changelog / Docs

- `CHANGELOG.md`: added `[0.3.0] — unreleased` section; cleaned up orphaned duplicate v0.1.0 content
- `docs/README.md`: removed `ALPACA_ENV` table row; documented `--paper` flag
- Crate version bumped to `0.3.0`

### Tests

All 187 existing tests pass (42 lib + 126 binary + 19 HTTP integration). No regressions.