### PR TITLE
ci(dependabot): ignore dtolnay/rust-toolchain version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
       day: "monday"
       time: "04:00"
     open-pull-requests-limit: 5
+    ignore:
+      # dtolnay/rust-toolchain is intentionally pinned to the project MSRV (1.88)
+      # in the MSRV CI job and must not be auto-bumped by dependabot.
+      - dependency-name: "dtolnay/rust-toolchain"
+        versions: ["*"]


### PR DESCRIPTION
## Problem

PR #46 bumped `dtolnay/rust-toolchain` from `1.88` → `1.100` in the MSRV CI job. Rust 1.100 does not exist (HTTP 404 from rust-lang.org), so the `MSRV (1.88)` job fails immediately when rustup tries to install it.

The current stable Rust is **1.94.1** — `1.100` is far in the future.

## Root Cause

The MSRV job intentionally pins `dtolnay/rust-toolchain` to the project's declared MSRV (`1.88`) to verify the codebase compiles on the minimum supported version. This is not a regular GitHub Actions dependency that should be auto-bumped.

## Fix

Add a dependabot ignore rule for `dtolnay/rust-toolchain` in the `github-actions` ecosystem so it is never auto-bumped again.

## Follow-up

Close PR #46 after this merges.