### PR TITLE
feat(account): add Day P&L, Open P&L, and Account # to account panel (issue #52)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,35 @@ mod tests {
         assert!(!acc.pattern_day_trader);
         assert_eq!(acc.currency, "USD");
         assert!(acc.portfolio_value.is_none());
+        // New fields default to empty string when absent
+        assert_eq!(acc.last_equity, "");
+        assert_eq!(acc.account_number, "");
+    }
+
+    #[test]
+    fn account_info_deserializes_pl_and_account_number() {
+        let json = r#"{
+            "status": "ACTIVE",
+            "equity": "125432.18",
+            "last_equity": "124588.96",
+            "buying_power": "48210.00",
+            "cash": "48210.00",
+            "long_market_value": "77222.18",
+            "daytrade_count": 1,
+            "pattern_day_trader": false,
+            "currency": "USD",
+            "account_number": "PA1234567"
+        }"#;
+        let acc: AccountInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(acc.last_equity, "124588.96");
+        assert_eq!(acc.account_number, "PA1234567");
+        let equity: f64 = acc.equity.parse().unwrap();
+        let last: f64 = acc.last_equity.parse().unwrap();
+        let day_pl = equity - last;
+        assert!(
+            (day_pl - 843.22).abs() < 0.01,
+            "Day P&L should be ~843.22, got {day_pl}"
+        );
     }
 
     #[test]
@@ -271,6 +300,10 @@ pub struct AccountInfo {
     pub status: String,
     /// Total account equity as a dollar string.
     pub equity: String,
+    /// Account equity at the close of the previous trading day, as a dollar string.
+    /// Used to compute Day P&L.
+    #[serde(default)]
+    pub last_equity: String,
     /// Buying power available for new orders, as a dollar string.
     pub buying_power: String,
     /// Cash balance, as a dollar string.
@@ -286,6 +319,9 @@ pub struct AccountInfo {
     /// Total portfolio value; may be absent on some account types.
     #[serde(default)]
     pub portfolio_value: Option<String>,
+    /// Unique account identifier (e.g. `"PA1234567"` for paper accounts).
+    #[serde(default)]
+    pub account_number: String,
 }
 
 /// A single open or closed position held in the account.

--- a/src/ui/account.rs
+++ b/src/ui/account.rs
@@ -207,6 +207,53 @@ mod tests {
         assert_eq!(format_pl_amount(0.0), "+$0.00");
     }
 
+    // ── format_day_pl ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn format_day_pl_positive() {
+        assert_eq!(format_day_pl(843.22, 0.68), "+$843.22 (+0.68%)");
+    }
+
+    #[test]
+    fn format_day_pl_negative() {
+        assert_eq!(format_day_pl(-500.0, -1.0), "-$500.00 (-1.00%)");
+    }
+
+    // ── format_dollars ────────────────────────────────────────────────────────
+
+    #[test]
+    fn format_dollars_valid_float() {
+        assert_eq!(format_dollars("1000.5"), "1000.50");
+        assert_eq!(format_dollars("0"), "0.00");
+        assert_eq!(format_dollars("125432.18"), "125432.18");
+    }
+
+    #[test]
+    fn format_dollars_non_numeric_passthrough() {
+        assert_eq!(format_dollars("N/A"), "N/A");
+        assert_eq!(format_dollars(""), "");
+    }
+
+    // ── span helpers ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn label_span_contains_text() {
+        let span = label("  Portfolio Value  ");
+        assert_eq!(span.content, "  Portfolio Value  ");
+    }
+
+    #[test]
+    fn value_span_contains_text() {
+        let span = value("$1,000.00");
+        assert_eq!(span.content, "$1,000.00");
+    }
+
+    #[test]
+    fn spacer_span_is_three_spaces() {
+        let span = spacer();
+        assert_eq!(span.content, "   ");
+    }
+
     // ── compute_day_pl ────────────────────────────────────────────────────────
 
     #[test]

--- a/src/ui/account.rs
+++ b/src/ui/account.rs
@@ -7,6 +7,7 @@ use ratatui::{
 };
 
 use crate::app::App;
+use crate::types::Position;
 use crate::ui::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
@@ -34,34 +35,53 @@ fn render_summary(frame: &mut Frame, area: Rect, app: &App) {
         let cash = format!("${}", format_dollars(&acc.cash));
         let long_val = format!("${}", format_dollars(&acc.long_market_value));
 
+        // Day P&L
+        let day_pl_str = match compute_day_pl(&acc.equity, &acc.last_equity) {
+            Some((pl, pct)) => format_day_pl(pl, pct),
+            None => "—".into(),
+        };
+        let day_pl_style = theme::pnl_style(&day_pl_str);
+
+        // Open P&L
+        let open_pl = compute_open_pl(&app.positions);
+        let open_pl_str = format_pl_amount(open_pl);
+        let open_pl_style = theme::pnl_style(&open_pl_str);
+
+        // Account number (show dash if empty)
+        let account_num = if acc.account_number.is_empty() {
+            "—".into()
+        } else {
+            acc.account_number.clone()
+        };
+
         let lines = vec![
             Line::from(vec![
                 label("  Portfolio Value  "),
                 value(&equity),
                 spacer(),
-                label("  Account Status  "),
-                value(&acc.status),
+                label("  Day P&L    "),
+                Span::styled(day_pl_str, day_pl_style),
             ]),
             Line::from(vec![
                 label("  Buying Power    "),
                 value(&buying_power),
                 spacer(),
-                label("  Currency        "),
-                value(&acc.currency),
+                label("  Open P&L   "),
+                Span::styled(open_pl_str, open_pl_style),
             ]),
             Line::from(vec![
                 label("  Cash            "),
                 value(&cash),
                 spacer(),
-                label("  Day Trades      "),
-                value(&acc.daytrade_count.to_string()),
+                label("  Account #  "),
+                value(&account_num),
             ]),
             Line::from(vec![
                 label("  Long Mkt Value  "),
                 value(&long_val),
                 spacer(),
-                label("  PDT Flag        "),
-                value(if acc.pattern_day_trader { "YES" } else { "NO" }),
+                label("  Status     "),
+                value(&acc.status),
             ]),
         ];
 
@@ -95,6 +115,42 @@ fn render_sparkline(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(sparkline, area);
 }
 
+/// Compute Day P&L from equity and last_equity strings.
+/// Returns `None` if either string is non-numeric or last_equity is zero.
+pub fn compute_day_pl(equity: &str, last_equity: &str) -> Option<(f64, f64)> {
+    let eq = equity.parse::<f64>().ok()?;
+    let last = last_equity.parse::<f64>().ok()?;
+    if last == 0.0 {
+        return None;
+    }
+    let pl = eq - last;
+    let pct = pl / last * 100.0;
+    Some((pl, pct))
+}
+
+/// Compute total Open P&L as the sum of `unrealized_pl` across all positions.
+pub fn compute_open_pl(positions: &[Position]) -> f64 {
+    positions
+        .iter()
+        .filter_map(|p| p.unrealized_pl.parse::<f64>().ok())
+        .sum()
+}
+
+/// Format a P&L dollar amount with sign prefix: `"+$843.22"` or `"-$843.22"`.
+pub fn format_pl_amount(pl: f64) -> String {
+    if pl >= 0.0 {
+        format!("+${:.2}", pl)
+    } else {
+        format!("-${:.2}", pl.abs())
+    }
+}
+
+/// Format Day P&L with both dollar and percentage: `"+$843.22 (+0.68%)"`.
+fn format_day_pl(pl: f64, pct: f64) -> String {
+    let sign = if pl >= 0.0 { "+" } else { "-" };
+    format!("{}${:.2} ({}{:.2}%)", sign, pl.abs(), sign, pct.abs())
+}
+
 fn label(s: &str) -> Span<'static> {
     Span::styled(s.to_string(), Style::default().fg(theme::DIM))
 }
@@ -112,5 +168,94 @@ fn format_dollars(s: &str) -> String {
         format!("{:.2}", v)
     } else {
         s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Position;
+
+    fn make_position(unrealized_pl: &str) -> Position {
+        Position {
+            symbol: "AAPL".into(),
+            qty: "10".into(),
+            avg_entry_price: "100.00".into(),
+            current_price: "110.00".into(),
+            market_value: "1100.00".into(),
+            unrealized_pl: unrealized_pl.into(),
+            unrealized_plpc: "0.1".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        }
+    }
+
+    // ── format_pl_amount ──────────────────────────────────────────────────────
+
+    #[test]
+    fn format_pl_positive() {
+        assert_eq!(format_pl_amount(843.22), "+$843.22");
+    }
+
+    #[test]
+    fn format_pl_negative() {
+        assert_eq!(format_pl_amount(-123.45), "-$123.45");
+    }
+
+    #[test]
+    fn format_pl_zero() {
+        assert_eq!(format_pl_amount(0.0), "+$0.00");
+    }
+
+    // ── compute_day_pl ────────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_day_pl_positive() {
+        let (pl, pct) = compute_day_pl("125432.18", "124588.96").unwrap();
+        assert!((pl - 843.22).abs() < 0.01, "pl={pl}");
+        assert!((pct - 0.6767).abs() < 0.01, "pct={pct}");
+    }
+
+    #[test]
+    fn compute_day_pl_negative() {
+        let (pl, pct) = compute_day_pl("99000.00", "100000.00").unwrap();
+        assert!((pl - (-1000.0)).abs() < 0.01);
+        assert!((pct - (-1.0)).abs() < 0.01);
+    }
+
+    #[test]
+    fn compute_day_pl_zero_last_equity_returns_none() {
+        assert!(compute_day_pl("100000.00", "0").is_none());
+    }
+
+    #[test]
+    fn compute_day_pl_unparseable_returns_none() {
+        assert!(compute_day_pl("N/A", "100000").is_none());
+        assert!(compute_day_pl("100000", "N/A").is_none());
+    }
+
+    // ── compute_open_pl ───────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_open_pl_sums_all_positions() {
+        let positions = vec![
+            make_position("500.00"),
+            make_position("704.50"),
+            make_position("-200.00"),
+        ];
+        let result = compute_open_pl(&positions);
+        assert!((result - 1004.50).abs() < 0.01, "result={result}");
+    }
+
+    #[test]
+    fn compute_open_pl_empty_is_zero() {
+        assert_eq!(compute_open_pl(&[]), 0.0);
+    }
+
+    #[test]
+    fn compute_open_pl_skips_unparseable() {
+        let positions = vec![make_position("100.00"), make_position("N/A")];
+        let result = compute_open_pl(&positions);
+        assert!((result - 100.0).abs() < 0.01);
     }
 }


### PR DESCRIPTION
## Summary

Implements [#52](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/52) — adds Day P&L, Open P&L, and Account # to the Account panel. The equity curve sparkline was already in place and remains unchanged.

## Account Panel (new layout)

```
│   Portfolio Value    $125,432.18       Day P&L    +$843.22 (+0.68%)       │
│   Buying Power        $48,210.00       Open P&L   +$1,204.50              │
│   Cash                $48,210.00       Account #  PA1234567                │
│   Long Market Value   $77,222.18       Status     ACTIVE                   │
│                                                                             │
│  ── Today's Equity Curve ─────────────────────────────────────────────── │
│   ▁▂▃▄▄▅▄▅▆▆▅▄▃▄▅▆▇▇▆▅▄▃▂▃▄▅▆▆▇▇█▇▆▅▄▅▆▇▇▆▅▄▅▆                          │
```

Day P&L and Open P&L are green when positive, red when negative.

## Files Changed

- **`src/types.rs`** — Added `last_equity` and `account_number` fields to `AccountInfo` (both `#[serde(default)]`)
- **`src/ui/account.rs`** — Reworked summary rows; added `compute_day_pl()`, `compute_open_pl()`, `format_pl_amount()` helpers; added 10 unit tests

## P&L Computation

| Field | Source | Formula |
|-------|--------|---------|
| Day P&L | `AccountInfo.equity` - `AccountInfo.last_equity` | Shows dollar + % |
| Open P&L | Sum of `Position.unrealized_pl` | Shows dollar only |
| Account # | `AccountInfo.account_number` | Shows `—` if empty |

## Tests Added

- **`types::tests`**: `account_info_deserializes` updated + `account_info_deserializes_pl_and_account_number` (2 tests)
- **`ui::account::tests`**: `format_pl_positive/negative/zero`, `compute_day_pl_positive/negative/zero/unparseable`, `compute_open_pl_sums/empty/skips_unparseable` (10 tests)

All tests pass. Clippy clean. `rustfmt` applied.

Closes #52