### PR TITLE
feat(symbol-detail): add OHLCV fields, intraday sparkline, and w:Toggle Watchlist

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -311,6 +311,8 @@ pub struct App {
     pub snapshots: HashMap<String, Snapshot>,
     pub clock: Option<MarketClock>,
     pub equity_history: Vec<u64>,
+    /// Intraday 1-minute close prices in cents, keyed by ticker symbol.
+    pub intraday_bars: HashMap<String, Vec<u64>>,
 
     pub active_tab: Tab,
     pub watchlist_state: TableState,
@@ -354,6 +356,7 @@ impl App {
             snapshots: HashMap::new(),
             clock: None,
             equity_history: Vec::new(),
+            intraday_bars: HashMap::new(),
             active_tab: Tab::Account,
             watchlist_state: TableState::default(),
             positions_state: TableState::default(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,8 +6,8 @@ use reqwest::header::{HeaderMap, HeaderValue};
 
 use crate::config::AlpacaConfig;
 use crate::types::{
-    AccountInfo, MarketClock, Order, OrderRequest, PortfolioHistory, Position, Snapshot, Watchlist,
-    WatchlistSummary,
+    AccountInfo, BarsResponse, MarketClock, MinuteBar, Order, OrderRequest, PortfolioHistory,
+    Position, Snapshot, Watchlist, WatchlistSummary,
 };
 
 /// Async HTTP client for the Alpaca Markets REST API.
@@ -245,5 +245,31 @@ impl AlpacaClient {
             .json::<HashMap<String, Snapshot>>()
             .await
             .context("GET /stocks/snapshots parse failed")
+    }
+
+    /// Fetch intraday 1-minute bars for a single symbol from the data API.
+    ///
+    /// Returns bars for the current UTC calendar date, IEX feed, oldest first.
+    /// The caller converts the raw bars to sparkline-ready `u64` cent values.
+    pub async fn get_intraday_bars(&self, symbol: &str) -> Result<Vec<MinuteBar>> {
+        use chrono::Utc;
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        Ok(self
+            .http
+            .get(self.data_url(&format!("/stocks/{symbol}/bars")))
+            .query(&[
+                ("timeframe", "1Min"),
+                ("start", today.as_str()),
+                ("feed", "iex"),
+                ("limit", "400"),
+            ])
+            .headers(self.auth_headers()?)
+            .send()
+            .await
+            .context("GET /stocks/{symbol}/bars request failed")?
+            .json::<BarsResponse>()
+            .await
+            .context("GET /stocks/{symbol}/bars parse failed")?
+            .bars)
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -36,4 +36,6 @@ pub enum Command {
         /// Ticker symbol to remove.
         symbol: String,
     },
+    /// Fetch intraday (1-minute) bars for the given ticker to populate the sparkline.
+    FetchIntradayBars(String),
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -47,6 +47,15 @@ pub enum Event {
     PortfolioHistoryLoaded(Vec<f64>),
     /// Latest market snapshots (daily bars + prev close) for watchlist symbols.
     SnapshotsUpdated(HashMap<String, Snapshot>),
+    /// Intraday 1-minute bar close prices (as cents) for a single symbol.
+    ///
+    /// Used to render the intraday sparkline inside the symbol-detail modal.
+    IntradayBarsReceived {
+        /// Ticker symbol these bars belong to.
+        symbol: String,
+        /// Close prices in integer cents, oldest first.
+        bars: Vec<u64>,
+    },
     /// Periodic tick to trigger UI refresh / REST polls.
     Tick,
     /// One-shot status message to display in the status bar.

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -147,6 +147,14 @@ async fn handle(cmd: Command, tx: &Sender<Event>, client: &AlpacaClient, refresh
                 }
                 Err(e) => {
                     warn!(error = %e, symbol = %symbol, "intraday bars fetch failed");
+                    // Emit an empty result so the UI transitions from "Loading…"
+                    // to "No data" rather than spinning forever.
+                    let _ = tx
+                        .send(Event::IntradayBarsReceived {
+                            symbol,
+                            bars: vec![],
+                        })
+                        .await;
                 }
             }
         }
@@ -411,7 +419,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_intraday_bars_api_error_does_not_emit_event() {
+    async fn fetch_intraday_bars_api_error_emits_empty_event() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/stocks/ERR/bars"))
@@ -432,11 +440,17 @@ mod tests {
         .await;
 
         let events = collect_events(&mut rx).await;
+        // On error an empty IntradayBarsReceived is emitted so the UI
+        // transitions from "Loading…" to "No intraday data available".
+        let received = events
+            .iter()
+            .find(|e| matches!(e, Event::IntradayBarsReceived { symbol, .. } if symbol == "ERR"));
         assert!(
-            !events
-                .iter()
-                .any(|e| matches!(e, Event::IntradayBarsReceived { .. })),
-            "error response should not emit IntradayBarsReceived"
+            received.is_some(),
+            "expected empty IntradayBarsReceived on error"
         );
+        if let Some(Event::IntradayBarsReceived { bars, .. }) = received {
+            assert!(bars.is_empty(), "error path should emit empty bars");
+        }
     }
 }

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -132,6 +132,24 @@ async fn handle(cmd: Command, tx: &Sender<Event>, client: &AlpacaClient, refresh
                 }
             }
         }
+
+        Command::FetchIntradayBars(symbol) => {
+            info!(symbol = %symbol, "fetching intraday bars");
+            match client.get_intraday_bars(&symbol).await {
+                Ok(bars) => {
+                    let cents: Vec<u64> = bars.iter().map(|b| (b.c * 100.0) as u64).collect();
+                    let _ = tx
+                        .send(Event::IntradayBarsReceived {
+                            symbol,
+                            bars: cents,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    warn!(error = %e, symbol = %symbol, "intraday bars fetch failed");
+                }
+            }
+        }
     }
 }
 
@@ -349,6 +367,76 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, Event::WatchlistUpdated(_))),
             "expected WatchlistUpdated event"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_intraday_bars_emits_intraday_bars_received() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stocks/AMD/bars"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "bars": [
+                    {"t": "2026-05-12T13:30:00Z", "o": 141.10, "h": 143.20, "l": 140.85, "c": 142.85, "v": 1000000},
+                    {"t": "2026-05-12T13:31:00Z", "o": 142.85, "h": 144.00, "l": 142.50, "c": 143.50, "v": 500000}
+                ],
+                "symbol": "AMD",
+                "next_page_token": null
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(test_config(server.uri()));
+        let (tx, mut rx) = mpsc::channel(16);
+        let notify = Arc::new(Notify::new());
+
+        execute_one(
+            Command::FetchIntradayBars("AMD".into()),
+            &tx,
+            &client,
+            &notify,
+        )
+        .await;
+
+        let events = collect_events(&mut rx).await;
+        let received = events
+            .iter()
+            .find(|e| matches!(e, Event::IntradayBarsReceived { symbol, .. } if symbol == "AMD"));
+        assert!(received.is_some(), "expected IntradayBarsReceived for AMD");
+        if let Some(Event::IntradayBarsReceived { bars, .. }) = received {
+            assert_eq!(bars.len(), 2);
+            assert_eq!(bars[0], 14285); // $142.85 → 14285 cents
+            assert_eq!(bars[1], 14350); // $143.50 → 14350 cents
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_intraday_bars_api_error_does_not_emit_event() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stocks/ERR/bars"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(test_config(server.uri()));
+        let (tx, mut rx) = mpsc::channel(16);
+        let notify = Arc::new(Notify::new());
+
+        execute_one(
+            Command::FetchIntradayBars("ERR".into()),
+            &tx,
+            &client,
+            &notify,
+        )
+        .await;
+
+        let events = collect_events(&mut rx).await;
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::IntradayBarsReceived { .. })),
+            "error response should not emit IntradayBarsReceived"
         );
     }
 }

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -1,7 +1,7 @@
 use crossterm::event::KeyCode;
 
 use super::send_command;
-use crate::app::{App, ConfirmAction, Modal, OrderField, StatusMessage};
+use crate::app::{App, ConfirmAction, Modal, OrderEntryState, OrderField, StatusMessage};
 use crate::commands::Command;
 
 pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
@@ -114,7 +114,51 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
             Some(Modal::OrderEntry(state))
         }
 
-        Modal::SymbolDetail(_) => None,
+        Modal::SymbolDetail(symbol) => match key.code {
+            KeyCode::Char('o') => {
+                app.modal = Some(Modal::OrderEntry(OrderEntryState::new(symbol.clone())));
+                return;
+            }
+            KeyCode::Char('s') => {
+                let mut state = OrderEntryState::new(symbol.clone());
+                state.side_buy = false;
+                app.modal = Some(Modal::OrderEntry(state));
+                return;
+            }
+            KeyCode::Char('w') => {
+                let in_watchlist = app
+                    .watchlist
+                    .as_ref()
+                    .map(|w| w.assets.iter().any(|a| a.symbol == symbol))
+                    .unwrap_or(false);
+                let wl_info = app
+                    .watchlist
+                    .as_ref()
+                    .map(|wl| (wl.id.clone(), in_watchlist));
+                if let Some((wl_id, remove)) = wl_info {
+                    let (cmd, msg) = if remove {
+                        (
+                            Command::RemoveFromWatchlist {
+                                watchlist_id: wl_id,
+                                symbol: symbol.clone(),
+                            },
+                            format!("Removing {}…", symbol),
+                        )
+                    } else {
+                        (
+                            Command::AddToWatchlist {
+                                watchlist_id: wl_id,
+                                symbol: symbol.clone(),
+                            },
+                            format!("Adding {}…", symbol),
+                        )
+                    };
+                    send_command(app, cmd, msg);
+                }
+                Some(Modal::SymbolDetail(symbol))
+            }
+            _ => Some(Modal::SymbolDetail(symbol)),
+        },
 
         Modal::Confirm {
             message,

--- a/src/input/positions.rs
+++ b/src/input/positions.rs
@@ -19,6 +19,9 @@ pub(crate) fn handle_positions_key(app: &mut App, key: crossterm::event::KeyEven
         }
         KeyCode::Enter => {
             if let Some(symbol) = app.selected_position_symbol() {
+                let _ = app
+                    .command_tx
+                    .try_send(crate::commands::Command::FetchIntradayBars(symbol.clone()));
                 app.modal = Some(Modal::SymbolDetail(symbol));
             }
         }

--- a/src/input/watchlist.rs
+++ b/src/input/watchlist.rs
@@ -20,6 +20,9 @@ pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEven
         }
         KeyCode::Enter => {
             if let Some(symbol) = app.selected_watchlist_symbol() {
+                let _ = app
+                    .command_tx
+                    .try_send(crate::commands::Command::FetchIntradayBars(symbol.clone()));
                 app.modal = Some(Modal::SymbolDetail(symbol));
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -610,10 +610,35 @@ pub struct Asset {
 /// A single OHLCV bar returned inside a [`Snapshot`].
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct SnapshotBar {
+    /// Opening price for this bar.
+    #[serde(default)]
+    pub o: f64,
+    /// High price for this bar.
+    #[serde(default)]
+    pub h: f64,
+    /// Low price for this bar.
+    #[serde(default)]
+    pub l: f64,
     /// Closing price for this bar.
     pub c: f64,
     /// Volume traded during this bar.
     pub v: f64,
+}
+
+/// A single 1-minute OHLCV bar from `GET /v2/stocks/{symbol}/bars`.
+///
+/// Only the close price is stored for use in the intraday sparkline.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MinuteBar {
+    /// Closing price for this 1-minute bar.
+    pub c: f64,
+}
+
+/// Response wrapper for `GET /v2/stocks/{symbol}/bars`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BarsResponse {
+    /// Ordered list of 1-minute bars for the requested symbol and date range.
+    pub bars: Vec<MinuteBar>,
 }
 
 /// Latest market snapshot for a symbol from `GET /v2/stocks/snapshots`.

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table},
+    widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Sparkline, Table},
     Frame,
 };
 
@@ -310,15 +310,21 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
 }
 
 fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) {
-    let popup = popup_area(area, 42, 55);
+    let popup = popup_area(area, 55, 88);
     frame.render_widget(Clear, popup);
 
-    let name = app
+    let asset = app
         .watchlist
         .as_ref()
-        .and_then(|w| w.assets.iter().find(|a| a.symbol == symbol))
-        .map(|a| a.name.as_str())
-        .unwrap_or(symbol);
+        .and_then(|w| w.assets.iter().find(|a| a.symbol == symbol));
+
+    let name = asset.map(|a| a.name.as_str()).unwrap_or(symbol);
+
+    let in_watchlist = app
+        .watchlist
+        .as_ref()
+        .map(|w| w.assets.iter().any(|a| a.symbol == symbol))
+        .unwrap_or(false);
 
     let block = Block::default()
         .title(format!(" {} — {} ", symbol, name))
@@ -329,33 +335,145 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
+    // ── Data ─────────────────────────────────────────────────────────────────
     let quote = app.quotes.get(symbol);
-    let ask = quote
-        .and_then(|q| q.ap)
+    let snapshot = app.snapshots.get(symbol);
+    let daily = snapshot.and_then(|s| s.daily_bar.as_ref());
+    let prev = snapshot.and_then(|s| s.prev_daily_bar.as_ref());
+
+    let price: Option<f64> = quote
+        .and_then(|q| match (q.ap, q.bp) {
+            (Some(a), Some(b)) => Some((a + b) / 2.0),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            _ => None,
+        })
+        .or_else(|| daily.map(|b| b.c));
+
+    let change_pct: Option<f64> = price.zip(prev.map(|b| b.c)).map(|(p, pc)| {
+        if pc != 0.0 {
+            (p - pc) / pc * 100.0
+        } else {
+            0.0
+        }
+    });
+
+    let price_str = price
         .map(|p| format!("${:.2}", p))
         .unwrap_or_else(|| "—".into());
-    let bid = quote
-        .and_then(|q| q.bp)
-        .map(|p| format!("${:.2}", p))
+    let change_str = change_pct
+        .map(|c| format!("{:+.2}%", c))
+        .unwrap_or_else(|| "—".into());
+    let value_style = change_pct
+        .map(|c| {
+            if c >= 0.0 {
+                Style::default().fg(theme::GREEN)
+            } else {
+                Style::default().fg(theme::RED)
+            }
+        })
+        .unwrap_or_else(theme::style_bold);
+
+    let open_str = daily
+        .map(|b| format!("${:.2}", b.o))
+        .unwrap_or_else(|| "—".into());
+    let high_str = daily
+        .map(|b| format!("${:.2}", b.h))
+        .unwrap_or_else(|| "—".into());
+    let low_str = daily
+        .map(|b| format!("${:.2}", b.l))
+        .unwrap_or_else(|| "—".into());
+    let vol_str = daily
+        .map(|b| crate::ui::watchlist::format_volume(b.v))
         .unwrap_or_else(|| "—".into());
 
-    let asset = app
-        .watchlist
-        .as_ref()
-        .and_then(|w| w.assets.iter().find(|a| a.symbol == symbol));
+    let wl_label = if in_watchlist {
+        "w:− Watchlist"
+    } else {
+        "w:+ Watchlist"
+    };
 
-    let lines = vec![
-        Line::from(vec![
-            Span::styled("  Ask Price  ", Style::default().fg(theme::DIM)),
-            Span::styled(ask, theme::style_bold()),
-        ]),
-        Line::from(vec![
-            Span::styled("  Bid Price  ", Style::default().fg(theme::DIM)),
-            Span::styled(bid, theme::style_bold()),
-        ]),
-        Line::from(vec![]),
-        Line::from(vec![
-            Span::styled("  Exchange   ", Style::default().fg(theme::DIM)),
+    // ── Layout ───────────────────────────────────────────────────────────────
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // blank
+            Constraint::Length(1), // price + change%
+            Constraint::Length(1), // open + high
+            Constraint::Length(1), // low + volume
+            Constraint::Length(1), // blank
+            Constraint::Length(1), // "── Intraday ──" label
+            Constraint::Length(3), // sparkline
+            Constraint::Length(1), // blank
+            Constraint::Length(1), // exchange + class
+            Constraint::Length(1), // tradable + shortable
+            Constraint::Length(1), // fractional + etb
+            Constraint::Min(0),    // filler
+            Constraint::Length(1), // footer
+        ])
+        .split(inner);
+
+    // ── OHLCV rows ───────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Price    ", Style::default().fg(theme::DIM)),
+            Span::styled(price_str, value_style),
+            Span::raw("   "),
+            Span::styled("Change    ", Style::default().fg(theme::DIM)),
+            Span::styled(change_str, value_style),
+        ])),
+        chunks[1],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Open     ", Style::default().fg(theme::DIM)),
+            Span::styled(open_str, theme::style_bold()),
+            Span::raw("   "),
+            Span::styled("High      ", Style::default().fg(theme::DIM)),
+            Span::styled(high_str, Style::default().fg(theme::GREEN)),
+        ])),
+        chunks[2],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Low      ", Style::default().fg(theme::DIM)),
+            Span::styled(low_str, Style::default().fg(theme::RED)),
+            Span::raw("   "),
+            Span::styled("Volume    ", Style::default().fg(theme::DIM)),
+            Span::styled(vol_str, theme::style_bold()),
+        ])),
+        chunks[3],
+    );
+
+    // ── Intraday sparkline ────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "  ── Intraday ──",
+            Style::default().fg(theme::DIM),
+        )])),
+        chunks[5],
+    );
+
+    let empty_bars: Vec<u64> = Vec::new();
+    let bars = app.intraday_bars.get(symbol).unwrap_or(&empty_bars);
+    if bars.is_empty() {
+        frame.render_widget(
+            Paragraph::new("  Loading…").style(Style::default().fg(theme::DIM)),
+            chunks[6],
+        );
+    } else {
+        frame.render_widget(
+            Sparkline::default()
+                .data(bars)
+                .style(Style::default().fg(theme::BRAND_CYAN)),
+            chunks[6],
+        );
+    }
+
+    // ── Asset flags ──────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Exchange ", Style::default().fg(theme::DIM)),
             Span::styled(
                 asset
                     .map(|a| a.exchange.as_str())
@@ -363,9 +481,8 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
                     .to_string(),
                 theme::style_bold(),
             ),
-        ]),
-        Line::from(vec![
-            Span::styled("  Class      ", Style::default().fg(theme::DIM)),
+            Span::raw("   "),
+            Span::styled("Class     ", Style::default().fg(theme::DIM)),
             Span::styled(
                 asset
                     .map(|a| a.asset_class.as_str())
@@ -373,39 +490,50 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
                     .to_string(),
                 theme::style_bold(),
             ),
-        ]),
-        Line::from(vec![
-            Span::styled("  Tradable   ", Style::default().fg(theme::DIM)),
+        ])),
+        chunks[8],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Tradable ", Style::default().fg(theme::DIM)),
             Span::styled(
                 flag(asset.map(|a| a.tradable).unwrap_or(false)),
                 Style::default().fg(theme::GREEN),
             ),
-            Span::styled("  Shortable  ", Style::default().fg(theme::DIM)),
+            Span::raw("   "),
+            Span::styled("Shortable ", Style::default().fg(theme::DIM)),
             Span::styled(
                 flag(asset.map(|a| a.shortable).unwrap_or(false)),
                 Style::default().fg(theme::GREEN),
             ),
-        ]),
-        Line::from(vec![
+        ])),
+        chunks[9],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
             Span::styled("  Fractional ", Style::default().fg(theme::DIM)),
             Span::styled(
                 flag(asset.map(|a| a.fractionable).unwrap_or(false)),
                 Style::default().fg(theme::GREEN),
             ),
-            Span::styled("  ETB        ", Style::default().fg(theme::DIM)),
+            Span::raw(" "),
+            Span::styled("ETB       ", Style::default().fg(theme::DIM)),
             Span::styled(
                 flag(asset.map(|a| a.easy_to_borrow).unwrap_or(false)),
                 Style::default().fg(theme::GREEN),
             ),
-        ]),
-        Line::from(vec![]),
-        Line::from(vec![Span::styled(
-            "  o:Buy  s:Sell  Esc:Close",
-            Style::default().fg(theme::DIM),
-        )]),
-    ];
+        ])),
+        chunks[10],
+    );
 
-    frame.render_widget(Paragraph::new(lines), inner);
+    // ── Footer ───────────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            format!("  o:Buy  s:Sell  {}  Esc:Close", wl_label),
+            Style::default().fg(theme::DIM),
+        )])),
+        chunks[12],
+    );
 }
 
 fn render_confirm(

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -454,20 +454,30 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
         chunks[5],
     );
 
-    let empty_bars: Vec<u64> = Vec::new();
-    let bars = app.intraday_bars.get(symbol).unwrap_or(&empty_bars);
-    if bars.is_empty() {
-        frame.render_widget(
-            Paragraph::new("  Loading…").style(Style::default().fg(theme::DIM)),
-            chunks[6],
-        );
-    } else {
-        frame.render_widget(
-            Sparkline::default()
-                .data(bars)
-                .style(Style::default().fg(theme::BRAND_CYAN)),
-            chunks[6],
-        );
+    match app.intraday_bars.get(symbol) {
+        None => {
+            // Command dispatched but response not yet received
+            frame.render_widget(
+                Paragraph::new("  Loading…").style(Style::default().fg(theme::DIM)),
+                chunks[6],
+            );
+        }
+        Some(bars) if bars.is_empty() => {
+            // Fetched but no bars (market closed, pre-market, or error)
+            frame.render_widget(
+                Paragraph::new("  No intraday data available")
+                    .style(Style::default().fg(theme::DIM)),
+                chunks[6],
+            );
+        }
+        Some(bars) => {
+            frame.render_widget(
+                Sparkline::default()
+                    .data(bars)
+                    .style(Style::default().fg(theme::BRAND_CYAN)),
+                chunks[6],
+            );
+        }
     }
 
     // ── Asset flags ──────────────────────────────────────────────────────────

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -684,3 +684,173 @@ fn estimate_total(state: &OrderEntryState) -> String {
         "—".into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{backend::TestBackend, Terminal};
+
+    use super::*;
+    use crate::app::test_helpers::{make_test_app, make_watchlist};
+
+    fn render_symbol_detail_to_string(app: &mut App, symbol: &str) -> String {
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_symbol_detail(frame, area, symbol, app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let width = buffer.area().width as usize;
+        let height = buffer.area().height as usize;
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_loading_when_no_bars_key() {
+        let mut app = make_test_app();
+        // No entry in intraday_bars → "Loading…"
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("Loading"),
+            "should show Loading when intraday_bars has no entry for symbol"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_no_data_when_bars_empty() {
+        let mut app = make_test_app();
+        app.intraday_bars.insert("AAPL".into(), vec![]);
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("No intraday data"),
+            "should show 'No intraday data available' when bars vec is empty"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_renders_sparkline_with_bars() {
+        let mut app = make_test_app();
+        app.intraday_bars
+            .insert("AAPL".into(), vec![15000, 15050, 15100, 15080, 15120]);
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        // The sparkline renders something other than "Loading" or "No intraday data"
+        assert!(
+            !output.contains("Loading"),
+            "should not show Loading when bars are present"
+        );
+        assert!(
+            !output.contains("No intraday data"),
+            "should not show no-data message when bars are present"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_ohlcv_labels() {
+        let mut app = make_test_app();
+        let output = render_symbol_detail_to_string(&mut app, "TSLA");
+        assert!(output.contains("Price"), "should show Price label");
+        assert!(output.contains("Open"), "should show Open label");
+        assert!(output.contains("High"), "should show High label");
+        assert!(output.contains("Low"), "should show Low label");
+        assert!(output.contains("Volume"), "should show Volume label");
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_footer_actions() {
+        let mut app = make_test_app();
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(output.contains("o:Buy"), "footer should contain buy action");
+        assert!(
+            output.contains("s:Sell"),
+            "footer should contain sell action"
+        );
+        assert!(
+            output.contains("Esc:Close"),
+            "footer should contain close hint"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_watchlist_label_not_in_watchlist() {
+        let mut app = make_test_app();
+        // AAPL is not in watchlist
+        app.watchlist = Some(make_watchlist(&["TSLA"]));
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("w:+"),
+            "footer should show 'w:+ Watchlist' when symbol not in watchlist"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_watchlist_label_in_watchlist() {
+        let mut app = make_test_app();
+        app.watchlist = Some(make_watchlist(&["AAPL", "TSLA"]));
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("w:\u{2212}") || output.contains("w:-"),
+            "footer should show 'w:− Watchlist' when symbol is in watchlist"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_uses_asset_name_in_title() {
+        let mut app = make_test_app();
+        app.watchlist = Some(make_watchlist(&["AAPL"]));
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        // The watchlist asset name is "AAPL Corp" per make_asset
+        assert!(
+            output.contains("AAPL Corp"),
+            "title should include asset name from watchlist"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_falls_back_to_symbol_as_name() {
+        let mut app = make_test_app();
+        // No watchlist entry → symbol is used as name
+        let output = render_symbol_detail_to_string(&mut app, "NVDA");
+        assert!(
+            output.contains("NVDA"),
+            "title should contain symbol when no asset info available"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_with_quote_shows_price() {
+        use crate::types::Quote;
+        let mut app = make_test_app();
+        app.quotes.insert(
+            "AAPL".into(),
+            Quote {
+                symbol: "AAPL".into(),
+                ap: Some(185.50),
+                bp: Some(185.40),
+                ..Default::default()
+            },
+        );
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        // Midpoint of 185.50 + 185.40 = 185.45
+        assert!(
+            output.contains("185.45"),
+            "should display midpoint price from quote"
+        );
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -68,6 +68,9 @@ pub fn update(app: &mut App, event: Event) {
         Event::SnapshotsUpdated(snapshots) => {
             app.snapshots = snapshots;
         }
+        Event::IntradayBarsReceived { symbol, bars } => {
+            app.intraday_bars.insert(symbol, bars);
+        }
         Event::Tick => {
             if let Some(exp) = app.status_msg.expires_at {
                 if exp <= Instant::now() {
@@ -1192,5 +1195,135 @@ mod tests {
 
         assert!(app.modal.is_none(), "modal should close on valid submit");
         cmd_rx.try_recv().expect("command should be sent");
+    }
+
+    // ── IntradayBarsReceived ──────────────────────────────────────────────────
+
+    #[test]
+    fn intraday_bars_received_stores_bars() {
+        let (mut app, _rx) = app_with_rx();
+        update(
+            &mut app,
+            Event::IntradayBarsReceived {
+                symbol: "AAPL".into(),
+                bars: vec![14200, 14215, 14198],
+            },
+        );
+        assert_eq!(
+            app.intraday_bars.get("AAPL"),
+            Some(&vec![14200u64, 14215, 14198])
+        );
+    }
+
+    #[test]
+    fn intraday_bars_received_overwrites_existing_bars() {
+        let (mut app, _rx) = app_with_rx();
+        app.intraday_bars.insert("AAPL".into(), vec![100, 200]);
+        update(
+            &mut app,
+            Event::IntradayBarsReceived {
+                symbol: "AAPL".into(),
+                bars: vec![300, 400, 500],
+            },
+        );
+        assert_eq!(app.intraday_bars.get("AAPL"), Some(&vec![300u64, 400, 500]));
+    }
+
+    // ── SymbolDetail modal key handling ───────────────────────────────────────
+
+    #[test]
+    fn symbol_detail_o_opens_order_entry() {
+        let (mut app, _rx) = app_with_rx();
+        app.modal = Some(Modal::SymbolDetail("AAPL".into()));
+        update(&mut app, key(KeyCode::Char('o')));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "AAPL" && s.side_buy),
+            "o key should open buy order entry for symbol"
+        );
+    }
+
+    #[test]
+    fn symbol_detail_s_opens_sell_order_entry() {
+        let (mut app, _rx) = app_with_rx();
+        app.modal = Some(Modal::SymbolDetail("NVDA".into()));
+        update(&mut app, key(KeyCode::Char('s')));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "NVDA" && !s.side_buy),
+            "s key should open sell order entry for symbol"
+        );
+    }
+
+    #[test]
+    fn symbol_detail_w_sends_add_watchlist_command() {
+        use crate::types::Watchlist;
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.watchlist = Some(Watchlist {
+            id: "wl-1".into(),
+            name: "Primary".into(),
+            assets: vec![],
+        });
+        app.modal = Some(Modal::SymbolDetail("AAPL".into()));
+        update(&mut app, key(KeyCode::Char('w')));
+        // Modal stays open
+        assert!(
+            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "AAPL"),
+            "w key should keep symbol detail modal open"
+        );
+        // Command dispatched
+        let cmd = cmd_rx.try_recv().expect("AddToWatchlist command expected");
+        assert!(
+            matches!(cmd, Command::AddToWatchlist { watchlist_id, symbol }
+                if watchlist_id == "wl-1" && symbol == "AAPL")
+        );
+    }
+
+    #[test]
+    fn symbol_detail_w_sends_remove_watchlist_command_when_in_watchlist() {
+        use crate::types::{Asset, Watchlist};
+        let (mut app, mut cmd_rx) = app_with_rx();
+        let asset = Asset {
+            id: "asset-1".into(),
+            symbol: "AAPL".into(),
+            name: "Apple Inc.".into(),
+            exchange: "NASDAQ".into(),
+            asset_class: "us_equity".into(),
+            tradable: true,
+            shortable: true,
+            fractionable: true,
+            easy_to_borrow: true,
+        };
+        app.watchlist = Some(Watchlist {
+            id: "wl-1".into(),
+            name: "Primary".into(),
+            assets: vec![asset],
+        });
+        app.modal = Some(Modal::SymbolDetail("AAPL".into()));
+        update(&mut app, key(KeyCode::Char('w')));
+        let cmd = cmd_rx
+            .try_recv()
+            .expect("RemoveFromWatchlist command expected");
+        assert!(
+            matches!(cmd, Command::RemoveFromWatchlist { watchlist_id, symbol }
+                if watchlist_id == "wl-1" && symbol == "AAPL")
+        );
+    }
+
+    #[test]
+    fn symbol_detail_other_key_keeps_modal_open() {
+        let (mut app, _rx) = app_with_rx();
+        app.modal = Some(Modal::SymbolDetail("TSLA".into()));
+        update(&mut app, key(KeyCode::Char('j')));
+        assert!(
+            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "TSLA"),
+            "unknown key should keep symbol detail modal open"
+        );
+    }
+
+    #[test]
+    fn symbol_detail_esc_closes_modal() {
+        let (mut app, _rx) = app_with_rx();
+        app.modal = Some(Modal::SymbolDetail("TSLA".into()));
+        update(&mut app, key(KeyCode::Esc));
+        assert!(app.modal.is_none(), "Esc should close the modal");
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1326,4 +1326,71 @@ mod tests {
         update(&mut app, key(KeyCode::Esc));
         assert!(app.modal.is_none(), "Esc should close the modal");
     }
+
+    #[test]
+    fn symbol_detail_w_with_no_watchlist_keeps_modal_open() {
+        // When there is no watchlist, pressing 'w' should keep the modal open
+        // without dispatching any command (covers the wl_info == None branch).
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.watchlist = None;
+        app.modal = Some(Modal::SymbolDetail("AAPL".into()));
+        update(&mut app, key(KeyCode::Char('w')));
+        assert!(
+            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "AAPL"),
+            "modal should remain open when no watchlist is set"
+        );
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no command should be dispatched without a watchlist"
+        );
+    }
+
+    // ── Positions panel key handling ─────────────────────────────────────────
+
+    fn positions_app() -> (App, tokio::sync::mpsc::Receiver<Command>) {
+        let (mut app, rx) = app_with_rx();
+        app.active_tab = Tab::Positions;
+        app.positions = vec![crate::types::Position {
+            symbol: "AAPL".into(),
+            qty: "10".into(),
+            avg_entry_price: "150.00".into(),
+            current_price: "155.00".into(),
+            market_value: "1550.00".into(),
+            unrealized_pl: "50.00".into(),
+            unrealized_plpc: "0.033".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        }];
+        app.positions_state.select(Some(0));
+        (app, rx)
+    }
+
+    #[test]
+    fn positions_enter_opens_symbol_detail_and_dispatches_fetch() {
+        let (mut app, mut cmd_rx) = positions_app();
+        update(&mut app, key(KeyCode::Enter));
+        assert!(
+            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "AAPL"),
+            "Enter on a position should open SymbolDetail for that symbol"
+        );
+        let cmd = cmd_rx
+            .try_recv()
+            .expect("FetchIntradayBars should be dispatched");
+        assert!(
+            matches!(cmd, Command::FetchIntradayBars(s) if s == "AAPL"),
+            "expected FetchIntradayBars for AAPL"
+        );
+    }
+
+    #[test]
+    fn positions_enter_with_no_selection_does_nothing() {
+        let (mut app, _rx) = app_with_rx();
+        app.active_tab = Tab::Positions;
+        app.positions_state.select(None);
+        update(&mut app, key(KeyCode::Enter));
+        assert!(
+            app.modal.is_none(),
+            "Enter with no selection should not open a modal"
+        );
+    }
 }

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -492,3 +492,45 @@ async fn get_snapshots_empty_symbols_returns_empty_map() {
     let result = client.get_snapshots(&[]).await.unwrap();
     assert!(result.is_empty());
 }
+
+#[tokio::test]
+async fn get_intraday_bars_returns_close_prices() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/stocks/AMD/bars"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bars": [
+                {"t": "2026-05-12T13:30:00Z", "o": 141.10, "h": 143.20, "l": 140.85, "c": 142.85, "v": 28700000},
+                {"t": "2026-05-12T13:31:00Z", "o": 142.85, "h": 144.00, "l": 142.50, "c": 143.50, "v": 15000000}
+            ],
+            "symbol": "AMD",
+            "next_page_token": null
+        })))
+        .mount(&server)
+        .await;
+
+    let client = AlpacaClient::new(test_config(server.uri()));
+    let bars = client.get_intraday_bars("AMD").await.unwrap();
+
+    assert_eq!(bars.len(), 2);
+    assert!((bars[0].c - 142.85).abs() < 0.01);
+    assert!((bars[1].c - 143.50).abs() < 0.01);
+}
+
+#[tokio::test]
+async fn get_intraday_bars_empty_returns_empty_vec() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/stocks/UNKNOWN/bars"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bars": [],
+            "symbol": "UNKNOWN",
+            "next_page_token": null
+        })))
+        .mount(&server)
+        .await;
+
+    let client = AlpacaClient::new(test_config(server.uri()));
+    let bars = client.get_intraday_bars("UNKNOWN").await.unwrap();
+    assert!(bars.is_empty());
+}


### PR DESCRIPTION
Closes #54

## Changes

### New types
- `SnapshotBar` extended with `o`, `h`, `l` fields (serde-defaulted)
- `MinuteBar` and `BarsResponse` for `GET /v2/stocks/{symbol}/bars`

### Data pipeline
- `Command::FetchIntradayBars(String)` dispatched when SymbolDetail modal opens
- `Event::IntradayBarsReceived { symbol, bars }` carries close prices in cents
- `App.intraday_bars: HashMap<String, Vec<u64>>` stores per-symbol sparkline data
- `AlpacaClient::get_intraday_bars()` fetches 1-minute IEX bars for today

### UI
- **Symbol Detail modal** redesigned with:
  - Price + Change% row (colour-coded vs prev close)
  - Open + High row (High in green)
  - Low + Volume row (Low in red)
  - Intraday Sparkline (cyan) with "Loading…" fallback
  - Exchange/Class, Tradable/Shortable, Fractional/ETB flags
  - Footer: `o:Buy  s:Sell  w:+/- Watchlist  Esc:Close`

### Interactions
- `o` → open buy OrderEntry for the symbol
- `s` → open sell OrderEntry for the symbol  
- `w` → toggle watchlist membership (add or remove, keep modal open)
- Any other key → keep modal open (was: close modal)

### Tests (+10)
- `IntradayBarsReceived` stores and overwrites bars in app state
- SymbolDetail: `o`/`s` open correct OrderEntry state, `w` dispatches correct command, others keep modal open, Esc closes
- `FetchIntradayBars` command: success emits cents-converted event, API error is silently swallowed
- `get_intraday_bars` client: parses bars array, handles empty response