### PR TITLE
feat(positions): add `s` key for SELL SHORT order entry and `s:Short` status bar hint

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -189,6 +189,43 @@ pub enum OrdersSubTab {
     Cancelled,
 }
 
+/// The side of an order: buy, sell (close long), or sell short (open short).
+#[derive(Debug, Clone, PartialEq)]
+pub enum OrderSide {
+    Buy,
+    Sell,
+    SellShort,
+}
+
+impl OrderSide {
+    /// Returns the next side in the cycle (used by left/right toggle in the order form).
+    pub fn cycle_next(&self) -> Self {
+        match self {
+            OrderSide::Buy => OrderSide::Sell,
+            OrderSide::Sell => OrderSide::SellShort,
+            OrderSide::SellShort => OrderSide::Buy,
+        }
+    }
+
+    /// Returns the previous side in the cycle.
+    pub fn cycle_prev(&self) -> Self {
+        match self {
+            OrderSide::Buy => OrderSide::SellShort,
+            OrderSide::Sell => OrderSide::Buy,
+            OrderSide::SellShort => OrderSide::Sell,
+        }
+    }
+
+    /// The wire value sent to the Alpaca API.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OrderSide::Buy => "buy",
+            OrderSide::Sell => "sell",
+            OrderSide::SellShort => "sell_short",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum OrderField {
     Symbol,
@@ -229,7 +266,7 @@ impl OrderField {
 #[derive(Debug, Clone)]
 pub struct OrderEntryState {
     pub symbol: String,
-    pub side_buy: bool,     // true = BUY, false = SELL
+    pub side: OrderSide,
     pub market_order: bool, // true = MARKET, false = LIMIT
     pub gtc_order: bool,    // true = GTC, false = DAY
     pub qty_input: String,
@@ -241,7 +278,7 @@ impl OrderEntryState {
     pub fn new(symbol: String) -> Self {
         Self {
             symbol,
-            side_buy: true,
+            side: OrderSide::Buy,
             market_order: false,
             gtc_order: false,
             qty_input: String::new(),

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -1,7 +1,9 @@
 use crossterm::event::KeyCode;
 
 use super::send_command;
-use crate::app::{App, ConfirmAction, Modal, OrderEntryState, OrderField, StatusMessage};
+use crate::app::{
+    App, ConfirmAction, Modal, OrderEntryState, OrderField, OrderSide, StatusMessage,
+};
 use crate::commands::Command;
 
 pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
@@ -30,7 +32,13 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 KeyCode::Tab => state.focused_field = state.focused_field.next(),
                 KeyCode::BackTab => state.focused_field = state.focused_field.prev(),
                 KeyCode::Left | KeyCode::Right => match state.focused_field {
-                    OrderField::Side => state.side_buy = !state.side_buy,
+                    OrderField::Side => {
+                        state.side = if key.code == KeyCode::Left {
+                            state.side.cycle_prev()
+                        } else {
+                            state.side.cycle_next()
+                        };
+                    }
                     OrderField::OrderType => state.market_order = !state.market_order,
                     OrderField::TimeInForce => state.gtc_order = !state.gtc_order,
                     _ => {}
@@ -45,9 +53,9 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                     }
                     OrderField::Side => {
                         if c == 'b' || c == 'B' {
-                            state.side_buy = true;
+                            state.side = OrderSide::Buy;
                         } else if c == 's' || c == 'S' {
-                            state.side_buy = false;
+                            state.side = OrderSide::Sell;
                         }
                     }
                     _ => {}
@@ -82,7 +90,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                             app,
                             Command::SubmitOrder {
                                 symbol: state.symbol.clone(),
-                                side: if state.side_buy { "buy" } else { "sell" }.into(),
+                                side: state.side.as_str().into(),
                                 order_type: if state.market_order {
                                     "market"
                                 } else {
@@ -121,7 +129,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
             }
             KeyCode::Char('s') => {
                 let mut state = OrderEntryState::new(symbol.clone());
-                state.side_buy = false;
+                state.side = OrderSide::Sell;
                 app.modal = Some(Modal::OrderEntry(state));
                 return;
             }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -133,8 +133,15 @@ fn handle_modal_mouse(app: &mut App, col: u16, row: u16) {
             OrderField::Side => {
                 if let Some(Modal::OrderEntry(ref mut state)) = app.modal {
                     state.focused_field = OrderField::Side;
-                    // Left half of the row → BUY, right half → SELL.
-                    state.side_buy = col < rect.x + rect.width / 2;
+                    // Left third → BUY, middle third → SELL, right third → SELL SHORT.
+                    let third = rect.width / 3;
+                    state.side = if col < rect.x + third {
+                        crate::app::OrderSide::Buy
+                    } else if col < rect.x + 2 * third {
+                        crate::app::OrderSide::Sell
+                    } else {
+                        crate::app::OrderSide::SellShort
+                    };
                 }
             }
             OrderField::OrderType => {

--- a/src/input/positions.rs
+++ b/src/input/positions.rs
@@ -1,6 +1,6 @@
 use crossterm::event::KeyCode;
 
-use crate::app::{App, Modal, OrderEntryState};
+use crate::app::{App, Modal, OrderEntryState, OrderSide};
 
 pub(crate) fn handle_positions_key(app: &mut App, key: crossterm::event::KeyEvent) {
     let len = app.positions.len();
@@ -28,7 +28,13 @@ pub(crate) fn handle_positions_key(app: &mut App, key: crossterm::event::KeyEven
         KeyCode::Char('o') => {
             let symbol = app.selected_position_symbol().unwrap_or_default();
             let mut state = OrderEntryState::new(symbol);
-            state.side_buy = false;
+            state.side = OrderSide::Sell;
+            app.modal = Some(Modal::OrderEntry(state));
+        }
+        KeyCode::Char('s') => {
+            let symbol = app.selected_position_symbol().unwrap_or_default();
+            let mut state = OrderEntryState::new(symbol);
+            state.side = OrderSide::SellShort;
             app.modal = Some(Modal::OrderEntry(state));
         }
         _ => {}

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -99,7 +99,7 @@ pub fn render_status(frame: &mut Frame, area: Rect, app: &App) {
         Tab::Watchlist => {
             " j/k:Navigate  Enter:Detail  o:Order  a:Add  d:Remove  /:Search  ?:Help  q:Quit"
         }
-        Tab::Positions => " j/k:Navigate  Enter:Detail  o:Close  ?:Help  q:Quit",
+        Tab::Positions => " j/k:Navigate  Enter:Detail  o:Close  s:Short  ?:Help  q:Quit",
         Tab::Orders => " j/k:Navigate  o:New  c:Cancel  1-3:Filter  ?:Help  q:Quit",
     };
 

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -180,9 +180,11 @@ fn render_order_entry(frame: &mut Frame, area: Rect, state: &OrderEntryState, ap
     // Side
     let side_line = Line::from(vec![
         Span::styled("  Side    ", Style::default().fg(theme::DIM)),
-        radio(state.side_buy, "BUY"),
+        radio(state.side == crate::app::OrderSide::Buy, "BUY"),
         Span::raw("  "),
-        radio(!state.side_buy, "SELL"),
+        radio(state.side == crate::app::OrderSide::Sell, "SELL"),
+        Span::raw("  "),
+        radio(state.side == crate::app::OrderSide::SellShort, "SELL SHORT"),
     ]);
     frame.render_widget(Paragraph::new(side_line), chunks[2]);
 
@@ -851,6 +853,68 @@ mod tests {
         assert!(
             output.contains("185.45"),
             "should display midpoint price from quote"
+        );
+    }
+
+    fn render_order_entry_to_string(app: &mut App, state: crate::app::OrderEntryState) -> String {
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let modal = Modal::OrderEntry(state);
+                render(frame, area, &modal, app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let width = buffer.area().width as usize;
+        let height = buffer.area().height as usize;
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_order_entry_buy_shows_buy_selected() {
+        use crate::app::{OrderEntryState, OrderSide};
+        let mut app = make_test_app();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.side = OrderSide::Buy;
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(output.contains("BUY"), "order entry should show BUY option");
+        assert!(
+            output.contains("SELL"),
+            "order entry should show SELL option"
+        );
+        assert!(
+            output.contains("SELL SHORT"),
+            "order entry should show SELL SHORT option"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_sell_short_shows_sell_short_selected() {
+        use crate::app::{OrderEntryState, OrderSide};
+        let mut app = make_test_app();
+        let mut state = OrderEntryState::new("TSLA".into());
+        state.side = OrderSide::SellShort;
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("SELL SHORT"),
+            "order entry with SellShort should display SELL SHORT option"
         );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1237,7 +1237,7 @@ mod tests {
         app.modal = Some(Modal::SymbolDetail("AAPL".into()));
         update(&mut app, key(KeyCode::Char('o')));
         assert!(
-            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "AAPL" && s.side_buy),
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "AAPL" && s.side == crate::app::OrderSide::Buy),
             "o key should open buy order entry for symbol"
         );
     }
@@ -1248,7 +1248,7 @@ mod tests {
         app.modal = Some(Modal::SymbolDetail("NVDA".into()));
         update(&mut app, key(KeyCode::Char('s')));
         assert!(
-            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "NVDA" && !s.side_buy),
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "NVDA" && s.side == crate::app::OrderSide::Sell),
             "s key should open sell order entry for symbol"
         );
     }
@@ -1391,6 +1391,106 @@ mod tests {
         assert!(
             app.modal.is_none(),
             "Enter with no selection should not open a modal"
+        );
+    }
+
+    #[test]
+    fn positions_o_opens_sell_order_entry() {
+        let (mut app, _rx) = positions_app();
+        update(&mut app, key(KeyCode::Char('o')));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "AAPL" && s.side == crate::app::OrderSide::Sell),
+            "o key in positions should open SELL order entry for selected symbol"
+        );
+    }
+
+    #[test]
+    fn positions_s_opens_sell_short_order_entry() {
+        let (mut app, _rx) = positions_app();
+        update(&mut app, key(KeyCode::Char('s')));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "AAPL" && s.side == crate::app::OrderSide::SellShort),
+            "s key in positions should open SELL SHORT order entry for selected symbol"
+        );
+    }
+
+    #[test]
+    fn order_side_cycle_next_wraps() {
+        use crate::app::OrderSide;
+        assert_eq!(OrderSide::Buy.cycle_next(), OrderSide::Sell);
+        assert_eq!(OrderSide::Sell.cycle_next(), OrderSide::SellShort);
+        assert_eq!(OrderSide::SellShort.cycle_next(), OrderSide::Buy);
+    }
+
+    #[test]
+    fn order_side_cycle_prev_wraps() {
+        use crate::app::OrderSide;
+        assert_eq!(OrderSide::Buy.cycle_prev(), OrderSide::SellShort);
+        assert_eq!(OrderSide::Sell.cycle_prev(), OrderSide::Buy);
+        assert_eq!(OrderSide::SellShort.cycle_prev(), OrderSide::Sell);
+    }
+
+    #[test]
+    fn order_side_as_str() {
+        use crate::app::OrderSide;
+        assert_eq!(OrderSide::Buy.as_str(), "buy");
+        assert_eq!(OrderSide::Sell.as_str(), "sell");
+        assert_eq!(OrderSide::SellShort.as_str(), "sell_short");
+    }
+
+    #[test]
+    fn modal_side_right_arrow_cycles_forward() {
+        use crate::app::{OrderEntryState, OrderField, OrderSide};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::Side;
+        state.side = OrderSide::Buy;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Right));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.side == OrderSide::Sell),
+            "right arrow should cycle Buy → Sell"
+        );
+    }
+
+    #[test]
+    fn modal_side_left_arrow_cycles_backward() {
+        use crate::app::{OrderEntryState, OrderField, OrderSide};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::Side;
+        state.side = OrderSide::Sell;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Left));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.side == OrderSide::Buy),
+            "left arrow should cycle Sell → Buy"
+        );
+    }
+
+    #[test]
+    fn order_entry_submit_sell_short_sends_correct_side() {
+        use crate::app::{OrderEntryState, OrderField, OrderSide};
+        use crate::types::AccountInfo;
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.account = Some(AccountInfo {
+            buying_power: "100000".into(),
+            ..Default::default()
+        });
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.side = OrderSide::SellShort;
+        state.focused_field = OrderField::Submit;
+        state.qty_input = "5".into();
+        state.price_input = "180.00".into();
+        app.modal = Some(Modal::OrderEntry(state));
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(app.modal.is_none(), "modal should close after submit");
+        let cmd = cmd_rx.try_recv().expect("command should be sent");
+        assert!(
+            matches!(cmd, Command::SubmitOrder { side, .. } if side == "sell_short"),
+            "expected sell_short side in SubmitOrder"
         );
     }
 }


### PR DESCRIPTION
Implements #55.

## Changes

- **`src/app.rs`** – New `OrderSide` enum (`Buy`, `Sell`, `SellShort`) with `cycle_next()`, `cycle_prev()`, and `as_str()`. Replaces `side_buy: bool` in `OrderEntryState` with `side: OrderSide`.

- **`src/input/positions.rs`** – Add `s` key handler → opens Order Entry pre-filled with `OrderSide::SellShort`. Update `o` handler to use `OrderSide::Sell`.

- **`src/input/modal.rs`** – Left/right arrow cycles through all three sides. `'b'`/`'s'` char keys set Buy/Sell. Submit sends `state.side.as_str()` (`"sell_short"` for shorts). `s` from SymbolDetail stays as `OrderSide::Sell` (close long).

- **`src/input/mouse.rs`** – Side click maps thirds of the row to Buy / Sell / SellShort.

- **`src/ui/dashboard.rs`** – Positions status bar now reads `o:Close  s:Short`.

- **`src/ui/modals.rs`** – Order Entry side row shows three radios: BUY / SELL / SELL SHORT.

## Tests added (269 total, +10)

- `OrderSide` cycle and `as_str` unit tests
- `positions_o_opens_sell_order_entry`
- `positions_s_opens_sell_short_order_entry`
- `modal_side_right_arrow_cycles_forward`
- `modal_side_left_arrow_cycles_backward`
- `order_entry_submit_sell_short_sends_correct_side`
- Render tests for BUY/SELL/SELL SHORT radio display