### PR TITLE
feat(modal): add ↑/↓ arrow key navigation for dropdown fields (Side, Type, TIF)

### DIFF
--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -43,6 +43,18 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                     OrderField::TimeInForce => state.gtc_order = !state.gtc_order,
                     _ => {}
                 },
+                KeyCode::Up | KeyCode::Down => match state.focused_field {
+                    OrderField::Side => {
+                        state.side = if key.code == KeyCode::Up {
+                            state.side.cycle_prev()
+                        } else {
+                            state.side.cycle_next()
+                        };
+                    }
+                    OrderField::OrderType => state.market_order = !state.market_order,
+                    OrderField::TimeInForce => state.gtc_order = !state.gtc_order,
+                    _ => {}
+                },
                 KeyCode::Char(c) => match state.focused_field {
                     OrderField::Symbol => state.symbol.push(c),
                     OrderField::Qty if c.is_ascii_digit() || c == '.' => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1469,6 +1469,116 @@ mod tests {
     }
 
     #[test]
+    fn modal_side_down_arrow_cycles_forward() {
+        use crate::app::{OrderEntryState, OrderField, OrderSide};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::Side;
+        state.side = OrderSide::Buy;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Down));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.side == OrderSide::Sell),
+            "down arrow should cycle Buy → Sell"
+        );
+    }
+
+    #[test]
+    fn modal_side_up_arrow_cycles_backward() {
+        use crate::app::{OrderEntryState, OrderField, OrderSide};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::Side;
+        state.side = OrderSide::Sell;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Up));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.side == OrderSide::Buy),
+            "up arrow should cycle Sell → Buy"
+        );
+    }
+
+    #[test]
+    fn modal_order_type_down_arrow_toggles() {
+        use crate::app::{OrderEntryState, OrderField};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::OrderType;
+        state.market_order = false;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Down));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.market_order),
+            "down arrow on OrderType should toggle to market"
+        );
+    }
+
+    #[test]
+    fn modal_order_type_up_arrow_toggles() {
+        use crate::app::{OrderEntryState, OrderField};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::OrderType;
+        state.market_order = true;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Up));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if !s.market_order),
+            "up arrow on OrderType should toggle to limit"
+        );
+    }
+
+    #[test]
+    fn modal_tif_down_arrow_toggles() {
+        use crate::app::{OrderEntryState, OrderField};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::TimeInForce;
+        state.gtc_order = false;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Down));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.gtc_order),
+            "down arrow on TIF should toggle to GTC"
+        );
+    }
+
+    #[test]
+    fn modal_tif_up_arrow_toggles() {
+        use crate::app::{OrderEntryState, OrderField};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::TimeInForce;
+        state.gtc_order = true;
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Up));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if !s.gtc_order),
+            "up arrow on TIF should toggle to DAY"
+        );
+    }
+
+    #[test]
+    fn modal_up_down_on_text_field_is_noop() {
+        use crate::app::{OrderEntryState, OrderField};
+        let (mut app, _rx) = app_with_rx();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.focused_field = OrderField::Qty;
+        state.qty_input = "10".into();
+        app.modal = Some(Modal::OrderEntry(state));
+        update(&mut app, key(KeyCode::Down));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.qty_input == "10"),
+            "down arrow on text field should not modify input"
+        );
+        update(&mut app, key(KeyCode::Up));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.qty_input == "10"),
+            "up arrow on text field should not modify input"
+        );
+    }
+
+    #[test]
     fn order_entry_submit_sell_short_sends_correct_side() {
         use crate::app::{OrderEntryState, OrderField, OrderSide};
         use crate::types::AccountInfo;


### PR DESCRIPTION
Implements #56.

## Changes

**`src/input/modal.rs`** – Add `KeyCode::Up | KeyCode::Down` arm in the `Modal::OrderEntry` handler, mirroring the existing `Left | Right` behaviour:

| Field | ↓ (Down) | ↑ (Up) |
|---|---|---|
| Side | `cycle_next()` (Buy→Sell→SellShort→…) | `cycle_prev()` |
| OrderType | toggles market/limit | toggles market/limit |
| TimeInForce | toggles GTC/DAY | toggles GTC/DAY |
| Text fields (Symbol, Qty, Price) | no-op | no-op |

## Tests added (276 total, +7)

- `modal_side_down_arrow_cycles_forward`
- `modal_side_up_arrow_cycles_backward`
- `modal_order_type_down_arrow_toggles`
- `modal_order_type_up_arrow_toggles`
- `modal_tif_down_arrow_toggles`
- `modal_tif_up_arrow_toggles`
- `modal_up_down_on_text_field_is_noop`