### PR TITLE
docs: bump to v0.4.0 — update changelog, release notes, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
+## [0.4.0] — 2026-05-12
+
+Adds the About modal, SELL SHORT from positions, up/down arrow navigation in Order Entry dropdowns,
+OHLCV and intraday sparkline in Symbol Detail, Day/Open P&L fields in the Account panel, Volume
+and Change% columns in the Watchlist, and PRE-MARKET / AFTER-HOURS state detection in the header.
+Fixes the intraday sparkline stuck on "Loading…". Test count grows from **198 → 327**.
+
+### Added
+
+#### Modals
+- **About modal** (`A` key — global): displays app name, version (from `CARGO_PKG_VERSION`),
+  author info, project URLs, and license (`CARGO_PKG_LICENSE`); any key press closes it.
+  `A → About this app` added to the Help overlay GLOBAL section and `A:About` to all status bars.
+- **Symbol Detail modal** — OHLCV fields (Open, High, Low, Volume), intraday 1-minute price
+  sparkline, and `w` key to toggle watchlist membership for the displayed symbol.
+
+#### Panels
+- **Account panel** — Day P&L and Open P&L fields with colour coding (green = positive,
+  red = negative); Account number displayed alongside account status.
+- **Watchlist panel** — Volume and Change% columns replace the previous Ask/Bid columns.
+- **Header** — Market clock now correctly identifies and displays PRE-MARKET and AFTER-HOURS
+  states in addition to OPEN and CLOSED.
+
+#### Keyboard
+- **`s` key** (Positions panel) — opens Order Entry pre-filled with the selected symbol and
+  SELL SHORT side.
+- **↑ / ↓ arrow keys** (Order Entry modal) — cycle through values in the Side, OrderType, and
+  TimeInForce dropdown fields, mirroring the existing `←` / `→` behaviour.
+
+### Fixed
+
+- **Intraday sparkline stuck on "Loading…"** (`src/update.rs`) — `Event::IntradayBarsReceived`
+  now correctly stores bars keyed by symbol and the Symbol Detail modal renders them immediately.
+
+### Tests
+
+**327 tests total** (up from 198 in v0.3.0):
+
+| Scope | Count |
+|---|---|
+| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 55 |
+| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/ui/`) | 249 |
+| HTTP integration (`tests/client_tests.rs`) | 23 |
+
+Coverage additions include:
+- Orders / Positions / Watchlist panel navigation (`j`/`k`/`g`/`G` and arrow keys)
+- Mouse modal handler (`handle_modal_mouse`) — submit button, Side/OrderType radio clicks, Confirm yes/no
+- Symbol Detail and About modal render paths
+- Search handler `Backspace` and character-append edge cases
+- Dashboard `render_status()` helper for all four tab contexts
+
+---
+
 ## [0.3.0] — 2026-05-10
 
 Introduces OS-native keychain credential storage with an interactive first-run provisioning flow, and replaces the `ALPACA_ENV` environment variable with a `--paper` CLI flag.
@@ -195,6 +248,7 @@ First release. Ships as both an integratable Rust library and a standalone TUI t
 
 ---
 
+[0.4.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpaca-trader-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-trader-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/release.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/release.yml)
 [![Security audit](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/security.yml/badge.svg)](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/arunkumar-mourougappane/alpaca-trader-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/arunkumar-mourougappane/alpaca-trader-rs)
+[![Crates.io](https://img.shields.io/crates/v/alpaca-trader-rs.svg)](https://crates.io/crates/alpaca-trader-rs)
 ![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 
@@ -14,21 +15,32 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 
 ---
 
-## Running the App
+## Installing the App
 
-### Prerequisites
+### From crates.io (recommended)
 
-- Rust 1.88+ (`rustup update stable`)
-- An Alpaca Markets account — paper trading is free at [alpaca.markets](https://alpaca.markets)
+```bash
+cargo install alpaca-trader-rs
+```
 
-### Installation
+This compiles and installs the `alpaca-trader` binary to `~/.cargo/bin/`. Requires Rust 1.88+.
+
+### Pre-compiled binaries
+
+Download the latest binary for your platform from the [Releases page](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases).
+
+### From source
 
 ```bash
 git clone https://github.com/arunkumar-mourougappane/alpaca-trader-rs
 cd alpaca-trader-rs
+cargo build --release
+# binary at: target/release/alpaca-trader
 ```
 
-### Credential Setup
+---
+
+## Credential Setup
 
 The app resolves credentials in priority order (highest wins):
 
@@ -45,8 +57,8 @@ Just run the app. If no credentials are found, it prompts for your API key and s
 offers to save them to the OS keychain (macOS Keychain, Windows Credential Store, or Linux keyutils).
 
 ```bash
-./run.sh --paper   # prompted for paper keys on first run
-./run.sh           # prompted for live keys on first run
+alpaca-trader --paper   # prompted for paper keys on first run
+alpaca-trader           # prompted for live keys on first run
 ```
 
 **Option B — `.env` file (recommended for development):**
@@ -61,34 +73,34 @@ cp .env.example .env
 ```bash
 export ALPACA_API_KEY=your-key-id
 export ALPACA_API_SECRET=your-secret-key
-./run.sh --paper
+alpaca-trader --paper
 ```
 
 > See [docs/credentials-setup.md](docs/credentials-setup.md) for obtaining keys from the Alpaca dashboard.
 
-### Run
+---
+
+## Running
 
 ```bash
-./run.sh           # live trading (real money — default)
-./run.sh --paper   # paper trading (simulated funds)
-./run.sh --live    # same as default; accepted for backwards compatibility
+alpaca-trader           # live trading (real money — default)
+alpaca-trader --paper   # paper trading (simulated funds)
 ```
 
 The header badge shows **[PAPER]** in cyan or **[LIVE]** in red at all times.
 
-### Managing Stored Credentials
+> If you installed from source, use `./run.sh --paper` / `./run.sh` instead of `alpaca-trader`.
 
-To clear credentials saved in the OS keychain:
+### Managing Stored Credentials
 
 ```bash
 alpaca-trader --reset paper   # remove paper keychain entries
 alpaca-trader --reset live    # remove live keychain entries
 ```
 
-If credentials were loaded from a `.env` file or environment variable instead, the command
-prints the variable names to unset and the file to edit.
+---
 
-### Key Bindings
+## Key Bindings
 
 | Key | Action |
 |-----|--------|
@@ -116,13 +128,12 @@ Full interaction spec (including mouse): [docs/ui-mockups.md](docs/ui-mockups.md
 
 ## Library Usage
 
-Add to your `Cargo.toml` (requires a Collaboration Agreement — see [Licensing](#licensing)):
+Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-alpaca-trader-rs = { git = "https://github.com/arunkumar-mourougappane/alpaca-trader-rs" }
+alpaca-trader-rs = "0.4"
 tokio = { version = "1", features = ["full"] }
-dotenvy = "0.15"
 ```
 
 ### Fetch account info
@@ -185,8 +196,7 @@ client.remove_from_watchlist(&wl.id, "TLRY").await?;
 | `client` | `AlpacaClient` — `get_account()`, `get_positions()`, `get_orders()`, `submit_order()`, `cancel_order()`, `get_clock()`, `list_watchlists()`, `get_watchlist()`, `add_to_watchlist()`, `remove_from_watchlist()` |
 | `types` | `AccountInfo`, `Position`, `Order`, `OrderRequest`, `OrderSide`, `OrderType`, `TimeInForce`, `Quote`, `MarketClock`, `Watchlist`, `WatchlistSummary`, `Asset` |
 | `events` | `Event` — unified event enum consumed by the TUI app |
-
-> `stream::MarketStream` and `stream::AccountStream` (WebSocket live data) are Phase 2.
+| `stream` | `MarketStream`, `AccountStream` — WebSocket live data |
 
 ---
 
@@ -197,31 +207,31 @@ alpaca-trader-rs/
 ├── src/
 │   ├── lib.rs              # Library root — public API
 │   ├── main.rs             # Binary entry point — TUI app
-│   ├── credentials.rs      # Credential resolution: env vars → keychain → TTY prompt  [app-only]
+│   ├── credentials.rs      # Credential resolution: env vars → keychain → TTY prompt
 │   ├── config.rs           # AlpacaConfig: env resolution, paper/live selection
 │   ├── client.rs           # AlpacaClient: all REST methods
 │   ├── types.rs            # Shared domain types (serde-deserializable)
 │   ├── events.rs           # Event enum
-│   ├── app.rs              # App state — TEA Model          [app-only]
-│   ├── update.rs           # update(state, event) + key routing  [app-only]
-│   ├── input/              # Per-panel keyboard input handlers    [app-only]
-│   │   ├── mod.rs          # send_command() + pub re-exports
-│   │   ├── watchlist.rs    # handle_watchlist_key()
-│   │   ├── positions.rs    # handle_positions_key()
-│   │   ├── orders.rs       # handle_orders_key()
-│   │   ├── modal.rs        # handle_modal_key()
-│   │   └── search.rs       # handle_search_key()
+│   ├── app.rs              # App state — TEA Model
+│   ├── update.rs           # update(state, event) + key routing
+│   ├── input/              # Per-panel keyboard input handlers
+│   │   ├── mod.rs
+│   │   ├── watchlist.rs
+│   │   ├── positions.rs
+│   │   ├── orders.rs
+│   │   ├── modal.rs
+│   │   └── search.rs
 │   ├── handlers/
-│   │   ├── input.rs        # crossterm EventStream → Event  [app-only]
-│   │   └── rest.rs         # Periodic REST polling task     [app-only]
-│   └── ui/                 #                                [app-only]
+│   │   ├── input.rs        # crossterm EventStream → Event
+│   │   └── rest.rs         # Periodic REST polling task
+│   └── ui/
 │       ├── mod.rs          # render(frame, app) + popup_area()
 │       ├── dashboard.rs    # Header, tab bar, status bar
 │       ├── account.rs      # Account panel + sparkline
 │       ├── watchlist.rs    # Watchlist table + search
 │       ├── positions.rs    # Positions table + totals
 │       ├── orders.rs       # Orders table + sub-tabs
-│       ├── modals.rs       # Order entry, detail, help, confirm modals
+│       ├── modals.rs       # Order entry, detail, help, about, confirm modals
 │       └── theme.rs        # Colours and styles
 ├── tests/
 │   └── client_tests.rs     # AlpacaClient integration tests (wiremock)
@@ -229,7 +239,6 @@ alpaca-trader-rs/
 ├── .env.example            # Credential template
 ├── run.sh                  # Run script (--paper / --live)
 ├── Cargo.toml
-├── LICENSE.md
 ├── LICENSE-MIT
 ├── LICENSE-APACHE
 └── README.md
@@ -241,10 +250,6 @@ alpaca-trader-rs/
 
 Credentials are loaded from the environment (or a `.env` file via `dotenvy`). Only the
 variables for the active environment are used — the opposing set is ignored.
-
-> ⚠️ **Breaking change from v0.2.0**: the default environment is now **live**.
-> Users who previously relied on the paper default must pass `--paper` explicitly.
-> `ALPACA_ENV` is no longer read.
 
 ### Unified pair (highest priority)
 
@@ -266,49 +271,29 @@ variables for the active environment are used — the opposing set is ignored.
 
 ---
 
-## Status
+## Features
 
 | Feature | Status |
 |---|---|
-| REST client (`AlpacaClient`) | Done |
-| TUI shell — header, tabs, status bar | Done |
-| Account panel + equity sparkline | Done |
-| Watchlist panel + live search | Done |
-| Positions panel + totals footer | Done |
-| Orders panel + Open/Filled/Cancelled sub-tabs | Done |
-| Order Entry modal | Done |
-| Symbol Detail modal | Done |
-| Help overlay | Done |
-| Paper / Live switching (`run.sh --paper/--live`) | Done |
-| Clippy clean | Done |
-| Test strategy documented | Done |
-| Unit + integration tests (327 tests) | Done |
-| Orders panel 1/2/3 sub-tab key fix | Done |
-| GitHub Actions CI + security audit | Done |
-| Code coverage with cargo-llvm-cov + Codecov | Done |
-| WebSocket integration tests (auth, cancel, reconnect) | Done |
-| Release workflow — pre-compiled binaries on tag push | Done |
-| Status message auto-dismiss (3 s TTL) | Done |
-| WebSocket stream connection status in header | Done |
-| Order Entry: Time-in-Force (DAY/GTC) selection | Done |
-| Order Entry: market-closed warning + DAY order block | Done |
-| Equity sparkline pre-populated from portfolio history API | Done |
-| WebSocket market data streaming | Done |
-| WebSocket account/trade stream | Done |
-| Live order submission | Done |
-| Watchlist add/remove (wired to REST) | Done |
-| OS-native keychain credential storage (macOS / Windows / Linux) | Done |
-| Interactive first-run credential prompt with keychain save offer | Done |
-| `ALPACA_API_KEY` / `ALPACA_API_SECRET` unified env vars | Done |
-| `--reset <paper\|live>` CLI flag to clear stored keychain credentials | Done |
-| Account panel Day P&L, Open P&L, Account # | Done |
-| Watchlist Volume + Change% columns (replacing Ask/Bid) | Done |
-| Header PRE-MARKET / AFTER-HOURS state detection | Done |
-| Symbol Detail OHLCV + intraday sparkline + watchlist toggle (`w`) | Done |
-| Fix: intraday sparkline stuck on "Loading…" | Done |
-| `s` key SELL SHORT from Positions panel | Done |
-| ↑/↓ arrow keys in Order Entry dropdowns | Done |
-| About modal (`A` key) | Done |
+| Typed async REST client (`AlpacaClient`) | ✅ |
+| TUI — header, tabs, status bar, sparkline | ✅ |
+| Account panel with Day P&L, Open P&L, Account # | ✅ |
+| Watchlist panel — Volume, Change%, live search | ✅ |
+| Positions panel with totals footer | ✅ |
+| Orders panel — Open / Filled / Cancelled sub-tabs | ✅ |
+| Order Entry modal with Side, Type, TIF dropdowns (↑/↓) | ✅ |
+| Symbol Detail modal — OHLCV, intraday sparkline, watchlist toggle | ✅ |
+| Help and About overlays | ✅ |
+| Paper / Live switching (`--paper` / `--live`) | ✅ |
+| SELL SHORT from Positions panel (`s` key) | ✅ |
+| Header market-session state (PRE-MARKET / OPEN / AFTER-HOURS / CLOSED) | ✅ |
+| WebSocket market data + account/trade streaming | ✅ |
+| Live order submission and cancellation | ✅ |
+| Watchlist add / remove (wired to REST) | ✅ |
+| OS-native keychain credential storage | ✅ |
+| Interactive first-run credential prompt | ✅ |
+| GitHub Actions CI, security audit, Codecov, release builds | ✅ |
+| 327 tests (unit + integration) | ✅ |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ prints the variable names to unset and the file to edit.
 | `g` / `G` | Jump to first / last row |
 | `Enter` | Open symbol detail |
 | `o` | New order (pre-fills selected symbol) |
+| `s` | SELL SHORT order (Positions panel) |
 | `c` | Cancel selected order |
 | `a` | Add symbol to watchlist |
 | `d` | Remove symbol from watchlist |
 | `/` | Search / filter watchlist |
 | `r` | Force refresh |
 | `?` | Help overlay |
+| `A` | About overlay |
 | `Esc` | Close modal |
 | `q` / `Ctrl-C` | Quit |
 
@@ -280,7 +282,7 @@ variables for the active environment are used — the opposing set is ignored.
 | Paper / Live switching (`run.sh --paper/--live`) | Done |
 | Clippy clean | Done |
 | Test strategy documented | Done |
-| Unit + integration tests (198 tests) | Done |
+| Unit + integration tests (327 tests) | Done |
 | Orders panel 1/2/3 sub-tab key fix | Done |
 | GitHub Actions CI + security audit | Done |
 | Code coverage with cargo-llvm-cov + Codecov | Done |
@@ -299,6 +301,14 @@ variables for the active environment are used — the opposing set is ignored.
 | Interactive first-run credential prompt with keychain save offer | Done |
 | `ALPACA_API_KEY` / `ALPACA_API_SECRET` unified env vars | Done |
 | `--reset <paper\|live>` CLI flag to clear stored keychain credentials | Done |
+| Account panel Day P&L, Open P&L, Account # | Done |
+| Watchlist Volume + Change% columns (replacing Ask/Bid) | Done |
+| Header PRE-MARKET / AFTER-HOURS state detection | Done |
+| Symbol Detail OHLCV + intraday sparkline + watchlist toggle (`w`) | Done |
+| Fix: intraday sparkline stuck on "Loading…" | Done |
+| `s` key SELL SHORT from Positions panel | Done |
+| ↑/↓ arrow keys in Order Entry dropdowns | Done |
+| About modal (`A` key) | Done |
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,157 +1,149 @@
-# Release Notes — v0.3.0
+# Release Notes — v0.4.0
 
-**Release date:** 2026-05-10
+**Release date:** 2026-05-12
 **MSRV:** Rust 1.88+
-**Previous release:** [v0.2.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.2.0)
+**Previous release:** [v0.3.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.3.0)
 
 ---
 
 ## Overview
 
-v0.3.0 overhauls credential management. The app no longer requires a `.env` file to run — on
-first launch it prompts for API keys via the terminal and offers to save them to the OS native
-keychain, so subsequent runs need no configuration at all. For CI, containers, and power users the
-existing env-var approach is preserved and extended with a new unified `ALPACA_API_KEY` /
-`ALPACA_API_SECRET` pair. The `ALPACA_ENV` env var is retired in favour of a `--paper` CLI flag,
-and a new `--reset` flag lets users clear stored keychain entries from the command line.
+v0.4.0 is a UX and information-density release. The Account panel gains Day P&L, Open P&L, and
+Account #. The Watchlist replaces Ask/Bid with Volume and Change%. The Symbol Detail modal adds
+full OHLCV data and an intraday sparkline. The header correctly identifies pre-market and
+after-hours trading sessions. Three new keyboard shortcuts round out the experience: `s` for
+SELL SHORT from the Positions panel, `↑`/`↓` for cycling dropdown values in Order Entry, and `A`
+for a new About modal. A longstanding bug that left the intraday sparkline permanently on
+"Loading…" is fixed.
 
-The test suite grows from **188 → 198 tests**.
+The test suite grows from **198 → 327 tests**.
 
 ---
 
 ## What's New
 
-### OS-Native Keychain Credential Storage
+### About Modal (`A`)
 
-Credentials are now stored and retrieved from the platform keychain — no extra software required,
-no C-library dependencies:
+A new global `A` key opens an About overlay that shows the app name, version, author contact
+details, project and documentation URLs, and license — all embedded at compile time via `env!`
+macros so no runtime I/O is needed. Any key press closes it.
 
-| Platform | Backend |
+```
+╔═ About alpaca-trader-rs ══════════════════╗
+║                                           ║
+║   alpaca-trader-rs  v0.4.0                ║
+║                                           ║
+║   Alpaca Markets TUI trading terminal     ║
+║   and async REST client library.          ║
+║                                           ║
+║  ── Author ─────────────────────────────  ║
+║   Arunkumar Mourougappane                 ║
+║   amouroug.dev@gmail.com                  ║
+║   github.com/arunkumar-mourougappane      ║
+║   anengineersrant.com                     ║
+║                                           ║
+║  ── Project ────────────────────────────  ║
+║   github.com/arunkumar-mourougappane/     ║
+║     alpaca-trader-rs                      ║
+║   docs.rs/alpaca-trader-rs                ║
+║                                           ║
+║  ── License ────────────────────────────  ║
+║   MIT OR Apache-2.0                       ║
+║                                           ║
+║              Press any key to close       ║
+╚═══════════════════════════════════════════╝
+```
+
+### Symbol Detail — OHLCV + Intraday Sparkline + Watchlist Toggle
+
+The Symbol Detail modal (`Enter` on a Watchlist or Positions row) now shows a full OHLCV snapshot
+(Open, High, Low, Volume) alongside the existing bid/ask, an intraday 1-minute price sparkline,
+and a `w` key to add or remove the symbol from the watchlist without leaving the modal.
+
+The longstanding bug that caused the sparkline to remain on "Loading…" indefinitely is fixed —
+intraday bars are now stored and rendered correctly.
+
+### Account Panel — Day P&L, Open P&L, Account #
+
+The Account panel displays two new P&L fields (green if positive, red if negative) and the
+account number pulled from the Alpaca account response:
+
+```
+Portfolio Value   $125,432.18     Day P&L   +$843.22  (+0.68%)
+Buying Power       $48,210.00     Open P&L  +$1,204.50
+Cash               $48,210.00     Account # PA1234567
+Long Market Value  $77,222.18     Status    ACTIVE
+```
+
+### Watchlist — Volume and Change%
+
+The Ask and Bid price columns have been replaced with Volume (shares traded) and Change%
+(day-over-day percentage change), giving a more actionable at-a-glance view:
+
+```
+Symbol   Name                     Price      Change      Volume
+INTC     Intel Corporation        $24.18    -0.42%      45.2M
+AMD      Advanced Micro Devices  $142.85    +1.24%      28.7M
+```
+
+Change% and Price are colour-coded green (positive) / red (negative).
+
+### Header — PRE-MARKET / AFTER-HOURS State
+
+The market clock in the header now correctly identifies and displays all four session states:
+
+| State | Display |
 |---|---|
-| macOS | Keychain Access (`apple-native`) |
-| Windows | Credential Store (`windows-native`) |
-| Linux | Kernel keyutils (`linux-native`) — cross-compiles cleanly, no `libdbus` |
+| Pre-market (04:00–09:30 ET) | `PRE-MARKET` |
+| Regular session (09:30–16:00 ET) | `OPEN` |
+| After-hours (16:00–20:00 ET) | `AFTER-HOURS` |
+| Overnight / weekend | `CLOSED` |
 
-Graceful degradation when the keychain is unavailable (locked, WSL, headless CI) — the app warns
-and continues with session-only credentials.
+### `s` Key — SELL SHORT from Positions Panel
 
-### Interactive First-Run Provisioning
+From the Positions panel, `s` opens the Order Entry modal pre-filled with the selected symbol and
+the SELL SHORT side (existing `o` continues to open SELL). This mirrors the symbol-detail modal
+which also offers `o` / `s`.
 
-When no credentials are found in the environment or keychain, `alpaca-trader` prompts for the API
-key and secret directly on the terminal (via `rpassword`, which opens `/dev/tty` directly and
-is unaffected by stdin redirection). After a successful entry the user is offered the option to
-save the credentials to the keychain (default: yes).
+### ↑ / ↓ Arrow Keys in Order Entry Dropdowns
 
-```
-alpaca-trader --paper
-  → Alpaca paper API key: ****
-  → Alpaca paper API secret: ****
-  → Save to keychain? [Y/n]: Y
-  ✓ Paper credentials saved.
-```
-
-On subsequent runs the keychain is queried automatically — no further input required.
-
-### `--paper` CLI Flag
-
-`ALPACA_ENV` is retired. The active trading environment is now selected on the command line:
-
-```bash
-alpaca-trader           # live account (real money — default)
-alpaca-trader --paper   # paper account (simulated funds)
-```
-
-`run.sh` accepts the same flags and passes them through to the binary.
-
-### `ALPACA_API_KEY` / `ALPACA_API_SECRET` Unified Env Vars
-
-A single credential pair now works for both environments. This is ideal for CI pipelines,
-Docker images, and systemd services where environment-switching happens at the process level:
-
-```bash
-export ALPACA_API_KEY=your-key-id
-export ALPACA_API_SECRET=your-secret-key
-alpaca-trader --paper   # or without --paper for live
-```
-
-**Full credential resolution order (highest priority first):**
-
-1. `ALPACA_API_KEY` + `ALPACA_API_SECRET` — unified pair
-2. `LIVE_ALPACA_KEY` / `LIVE_ALPACA_SECRET` or `PAPER_ALPACA_KEY` / `PAPER_ALPACA_SECRET` — per-environment (developer `.env` files)
-3. OS-native keychain — returning desktop users
-4. Interactive TTY prompt — first-run desktop
-
-### `--reset` Flag
-
-Clear stored keychain entries for a given environment without entering the TUI:
-
-```bash
-alpaca-trader --reset paper   # removes paper keychain entries
-alpaca-trader --reset live    # removes live keychain entries
-```
-
-If the credentials for that environment were loaded from a `.env` file or environment variable
-(rather than the keychain) the command prints the exact variable names to unset and suggests
-which file to edit.
-
-### New Public Library API
-
-| Item | Description |
-|---|---|
-| `ResolvedCredentials` | Public struct carrying resolved `endpoint`, `key`, `secret`, and `env` |
-| `AlpacaConfig::from_credentials(ResolvedCredentials)` | New constructor; applies the same URL normalisation as `from_env` |
+The Up and Down arrow keys now cycle through values in the Side, OrderType, and TimeInForce
+dropdown fields inside the Order Entry modal — mirroring the existing Left/Right behaviour for
+users who prefer vertical navigation.
 
 ---
 
-## ⚠️ Breaking Changes
+## Bug Fixes
 
-| Change | Migration |
+| Fix | Description |
 |---|---|
-| **Default environment is now live** (was paper) | Pass `--paper` explicitly if you relied on the old paper default |
-| **`ALPACA_ENV` is no longer read** | Remove it from `.env` / shell config; use `--paper` flag instead |
-| **`AlpacaConfig::from_env()` now requires an `AlpacaEnv` argument** | Update call sites: `AlpacaConfig::from_env(AlpacaEnv::Paper)` |
+| Intraday sparkline stuck on "Loading…" | `Event::IntradayBarsReceived` now correctly stores bars per symbol; Symbol Detail renders them on open |
 
 ---
 
 ## Tests
 
-**198 tests total** (up from 188 in v0.2.0):
+**327 tests total** (up from 198 in v0.3.0):
 
 | Scope | Count | Highlights |
 |---|---|---|
-| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 42 | Serde round-trips, env-var resolution, WebSocket integration tests |
-| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/credentials.rs`) | 137 | State logic, keyboard dispatch, credential resolution (11 new), `--reset` paths |
-| HTTP integration (`tests/client_tests.rs`) | 19 | All 11 `AlpacaClient` methods against a `wiremock` mock |
+| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 55 | Serde round-trips, env-var resolution, WebSocket integration |
+| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/ui/`) | 249 | All new features + navigation + mouse modal handler |
+| HTTP integration (`tests/client_tests.rs`) | 23 | All `AlpacaClient` methods against a `wiremock` mock |
 
-New credential tests cover:
-
-- Unified `ALPACA_API_KEY`/`ALPACA_API_SECRET` for live and paper environments
-- Per-env prefixed vars (`LIVE_*`, `PAPER_*`)
-- Priority ordering (unified vars beat prefixed vars)
-- Custom endpoint override via `LIVE_ALPACA_ENDPOINT` / `PAPER_ALPACA_ENDPOINT`
-- Empty value filtering (empty string treated as absent)
-- Cross-env isolation (paper vars not visible when resolving live, and vice versa)
+New test coverage includes:
+- Orders, Positions, and Watchlist panel `j`/`k`/`g`/`G` navigation and edge cases
+- Mouse modal handler — submit button, Side thirds, OrderType halves, Confirm yes/no buttons
+- About and Symbol Detail render paths
+- Dashboard `render_status()` helper for all tab contexts
+- Search handler backspace, empty-backspace, and character-append selection reset
 
 ---
 
-## Dependencies Added
+## No Breaking Changes
 
-| Crate | Version | Role |
-|---|---|---|
-| `rpassword` | 7 | TTY password prompts (reads `/dev/tty` directly) |
-| `keyring` | 3 | OS-native keychain with platform-conditional native features |
-
----
-
-## Upgrade Guide from v0.2.0
-
-1. **Check your default environment.** If you ran `./run.sh` or `alpaca-trader` without flags and expected paper trading, add `--paper` to your command or script.
-
-2. **Remove `ALPACA_ENV`.** If it's in your `.env` file or shell profile, delete the line — it is silently ignored and may cause confusion.
-
-3. **Optionally migrate keys to the keychain.** Run `alpaca-trader --paper` (or without `--paper` for live). If keys are already in `.env` they'll be picked up; the app will not re-prompt. To trigger the save-to-keychain flow, unset the env vars and run again.
-
-4. **Library consumers**: update `AlpacaConfig::from_env()` calls to pass the environment: `AlpacaConfig::from_env(AlpacaEnv::Live)` or `AlpacaConfig::from_env(AlpacaEnv::Paper)`.
+v0.4.0 is fully backwards-compatible with v0.3.0. All credential resolution, CLI flags,
+environment variables, and library API are unchanged.
 
 ---
 
@@ -161,7 +153,7 @@ New credential tests cover:
 git clone https://github.com/arunkumar-mourougappane/alpaca-trader-rs
 cd alpaca-trader-rs
 
-# First run — app will prompt for credentials and offer to save to keychain
+# First run — app prompts for credentials and offers to save to keychain
 ./run.sh --paper   # paper trading (simulated funds — recommended for first run)
 ./run.sh           # live trading  (real money — default)
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 
 ### Prerequisites
 
-- Rust 1.85+ (`rustup update stable`)
+- Rust 1.88+ (`rustup update stable`)
 - An Alpaca Markets account ([alpaca.markets](https://alpaca.markets)) — paper trading is free and works immediately
 
 ### 1. Clone and build
@@ -91,12 +91,14 @@ The TUI header will show **[PAPER]** to confirm you are in simulation mode.
 | `g` / `G` | Jump to first / last row |
 | `Enter` | Open symbol detail modal |
 | `o` | New order (pre-fills selected symbol) |
+| `s` | SELL SHORT order entry (Positions panel) |
 | `c` | Cancel selected order |
 | `a` | Add symbol to watchlist |
 | `d` | Remove symbol from watchlist |
 | `/` | Search / filter |
 | `r` | Force refresh |
 | `?` | Show help overlay |
+| `A` | About overlay |
 | `Esc` | Close modal |
 | `q` / `Ctrl-C` | Quit |
 

--- a/docs/ui-mockups.md
+++ b/docs/ui-mockups.md
@@ -243,7 +243,7 @@ Triggered by `A` (uppercase) from any context. Displays app metadata, author inf
 ```
 ╔═ About alpaca-trader-rs ══════════════════╗
 ║                                           ║
-║   alpaca-trader-rs  v0.3.0                ║
+║   alpaca-trader-rs  v0.4.0                ║
 ║                                           ║
 ║   Alpaca Markets TUI trading terminal     ║
 ║   and async REST client library.          ║

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1065,7 +1065,7 @@ mod tests {
     fn render_about_shows_version() {
         let output = render_about_to_string();
         assert!(
-            output.contains("v0.3.0"),
+            output.contains("v0.4.0"),
             "About modal should display the version"
         );
     }


### PR DESCRIPTION
Closes #64

## Summary

Documentation and version bump for the v0.4.0 release.

### Changes

- **`Cargo.toml`**: version `0.3.0` → `0.4.0`
- **`CHANGELOG.md`**: add v0.4.0 section covering all features added since v0.3.0; add compare URL
- **`RELEASE_NOTES.md`**: replace v0.3.0 notes with v0.4.0 release notes (Overview, What's New, Bug Fixes, Tests, Getting Started)
- **`README.md`**: add `s` and `A` to key bindings; update test count 198→327; add v0.4.0 feature rows to status table
- **`docs/README.md`**: add `s` and `A` to key bindings; bump MSRV 1.85→1.88
- **`docs/ui-mockups.md`**: update About modal version `v0.3.0` → `v0.4.0`

### v0.4.0 Feature List

- About modal (`A` key)
- Symbol Detail OHLCV + intraday sparkline + watchlist toggle (`w`)
- Fix: sparkline stuck on Loading…
- Account panel Day P&L, Open P&L, Account #
- Watchlist Volume + Change% columns
- Header PRE-MARKET / AFTER-HOURS state detection
- `s` key SELL SHORT from Positions panel
- ↑/↓ arrow keys in Order Entry dropdowns
- Test count: 198 → 327