### PR TITLE
fix(watchlist): show informative message in paper trading mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -346,6 +346,9 @@ pub struct App {
     pub orders: Vec<Order>,
     pub quotes: HashMap<String, Quote>,
     pub watchlist: Option<Watchlist>,
+    /// Set to `true` when the paper trading endpoint signals that watchlists
+    /// are unsupported. Drives a persistent informational message in the UI.
+    pub watchlist_unavailable: bool,
     pub snapshots: HashMap<String, Snapshot>,
     pub clock: Option<MarketClock>,
     pub equity_history: Vec<u64>,
@@ -391,6 +394,7 @@ impl App {
             orders: Vec::new(),
             quotes: HashMap::new(),
             watchlist: None,
+            watchlist_unavailable: false,
             snapshots: HashMap::new(),
             clock: None,
             equity_history: Vec::new(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use reqwest::header::{HeaderMap, HeaderValue};
 
-use crate::config::AlpacaConfig;
+use crate::config::{AlpacaConfig, AlpacaEnv};
 use crate::types::{
     AccountInfo, BarsResponse, MarketClock, MinuteBar, Order, OrderRequest, PortfolioHistory,
     Position, Snapshot, Watchlist, WatchlistSummary,
@@ -27,6 +27,14 @@ impl AlpacaClient {
             http: reqwest::Client::new(),
             config,
         }
+    }
+
+    /// Returns `true` when this client is configured for the paper trading environment.
+    ///
+    /// Useful for skipping API calls that are unsupported on the paper endpoint
+    /// (e.g., `/v2/watchlists`).
+    pub fn is_paper(&self) -> bool {
+        self.config.env == AlpacaEnv::Paper
     }
 
     fn auth_headers(&self) -> Result<HeaderMap> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -58,7 +58,7 @@ pub enum Event {
     },
     /// Watchlists are not available in paper trading mode.
     ///
-    /// Emitted once when [`handlers::rest`] detects `client.is_paper()` so the
+    /// Emitted once when the REST handler detects `client.is_paper()` so the
     /// UI can display a clear, persistent explanation instead of "Loading…".
     WatchlistUnavailable,
     /// Periodic tick to trigger UI refresh / REST polls.

--- a/src/events.rs
+++ b/src/events.rs
@@ -56,6 +56,11 @@ pub enum Event {
         /// Close prices in integer cents, oldest first.
         bars: Vec<u64>,
     },
+    /// Watchlists are not available in paper trading mode.
+    ///
+    /// Emitted once when [`handlers::rest`] detects `client.is_paper()` so the
+    /// UI can display a clear, persistent explanation instead of "Loading…".
+    WatchlistUnavailable,
     /// Periodic tick to trigger UI refresh / REST polls.
     Tick,
     /// One-shot status message to display in the status bar.

--- a/src/handlers/rest.rs
+++ b/src/handlers/rest.rs
@@ -90,6 +90,10 @@ async fn poll_clock(client: &AlpacaClient, tx: &Sender<Event>) {
 }
 
 async fn poll_watchlist(client: &AlpacaClient, tx: &Sender<Event>) {
+    if client.is_paper() {
+        let _ = tx.send(Event::WatchlistUnavailable).await;
+        return;
+    }
     let summaries = match client.list_watchlists().await {
         Ok(s) => s,
         Err(e) => {
@@ -162,6 +166,15 @@ mod tests {
             key: "PKTEST".into(),
             secret: "secret".into(),
             env: AlpacaEnv::Paper,
+        }
+    }
+
+    fn live_test_config(base_url: String) -> AlpacaConfig {
+        AlpacaConfig {
+            base_url,
+            key: "AKTEST".into(),
+            secret: "secret".into(),
+            env: AlpacaEnv::Live,
         }
     }
 
@@ -240,7 +253,8 @@ mod tests {
         let server = MockServer::start().await;
         mount_all(&server).await;
 
-        let client = Arc::new(AlpacaClient::new(test_config(server.uri())));
+        // Use live config so the watchlist API call is made (paper mode skips it).
+        let client = Arc::new(AlpacaClient::new(live_test_config(server.uri())));
         let (tx, mut rx) = mpsc::channel(32);
         poll_once(tx, client).await;
 
@@ -582,7 +596,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = Arc::new(AlpacaClient::new(test_config(server.uri())));
+        // Use live config so the watchlist API call is actually made.
+        let client = Arc::new(AlpacaClient::new(live_test_config(server.uri())));
         let (tx, mut rx) = mpsc::channel(32);
         poll_watchlist(&client, &tx).await;
 
@@ -610,5 +625,37 @@ mod tests {
         assert!((daily.v - 1_234_567.0).abs() < 1.0);
         let prev = aapl.prev_daily_bar.as_ref().expect("prevDailyBar expected");
         assert!((prev.c - 170.0).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn poll_watchlist_in_paper_mode_emits_unavailable_without_http_call() {
+        // The mock server has no mounts — any HTTP hit would be an unexpected request.
+        let server = MockServer::start().await;
+
+        let client = Arc::new(AlpacaClient::new(test_config(server.uri())));
+        let (tx, mut rx) = mpsc::channel(32);
+        poll_watchlist(&client, &tx).await;
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::WatchlistUnavailable)),
+            "paper mode must emit WatchlistUnavailable"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::WatchlistUpdated(_))),
+            "paper mode must not emit WatchlistUpdated"
+        );
+
+        // No HTTP calls should have been made — wiremock records unexpected requests.
+        let unexpected = server.received_requests().await.unwrap();
+        assert!(
+            unexpected.is_empty(),
+            "paper mode must not make any HTTP requests, got: {unexpected:?}"
+        );
     }
 }

--- a/src/ui/watchlist.rs
+++ b/src/ui/watchlist.rs
@@ -25,6 +25,29 @@ pub fn format_volume(v: f64) -> String {
 }
 
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
+    if app.watchlist_unavailable {
+        let text = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Watchlists are not available in paper trading mode.",
+                Style::default().fg(theme::DIM),
+            )),
+            Line::from(Span::styled(
+                "  The Alpaca paper API does not support the /v2/watchlists endpoint.",
+                Style::default().fg(theme::DIM),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  To use watchlists, run without the --paper flag.",
+                Style::default().fg(theme::DIM),
+            )),
+        ];
+        let para =
+            Paragraph::new(text).block(Block::default().title(" Watchlist ").borders(Borders::ALL));
+        frame.render_widget(para, area);
+        return;
+    }
+
     let wl = match app.watchlist.clone() {
         Some(w) => w,
         None => {
@@ -235,6 +258,32 @@ mod tests {
         // No quotes, no snapshots — price and change% must show "—"
         let output = render_watchlist_to_string(&mut app);
         assert!(output.contains('—'), "expected em-dash when no price data");
+    }
+
+    #[test]
+    fn watchlist_unavailable_renders_paper_mode_message() {
+        let mut app = make_test_app();
+        app.watchlist_unavailable = true;
+        let output = render_watchlist_to_string(&mut app);
+        assert!(
+            output.contains("not available in paper trading mode"),
+            "expected paper mode message, got: {output}"
+        );
+        assert!(
+            output.contains("--paper"),
+            "expected hint about --paper flag, got: {output}"
+        );
+    }
+
+    #[test]
+    fn watchlist_unavailable_does_not_show_loading_message() {
+        let mut app = make_test_app();
+        app.watchlist_unavailable = true;
+        let output = render_watchlist_to_string(&mut app);
+        assert!(
+            !output.contains("Loading watchlist"),
+            "should not show loading message when unavailable"
+        );
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -41,6 +41,9 @@ pub fn update(app: &mut App, event: Event) {
             }
             app.watchlist = Some(w);
         }
+        Event::WatchlistUnavailable => {
+            app.watchlist_unavailable = true;
+        }
         Event::MarketQuote(q) => {
             app.quotes.insert(q.symbol.clone(), q);
         }
@@ -231,6 +234,22 @@ mod tests {
         update(&mut app, Event::WatchlistUpdated(wl));
         assert!(app.watchlist.is_some());
         assert_eq!(app.watchlist_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn watchlist_unavailable_sets_flag() {
+        let mut app = make_test_app();
+        assert!(!app.watchlist_unavailable);
+        update(&mut app, Event::WatchlistUnavailable);
+        assert!(app.watchlist_unavailable);
+    }
+
+    #[test]
+    fn watchlist_unavailable_is_idempotent() {
+        let mut app = make_test_app();
+        update(&mut app, Event::WatchlistUnavailable);
+        update(&mut app, Event::WatchlistUnavailable);
+        assert!(app.watchlist_unavailable);
     }
 
     #[test]

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -534,3 +534,27 @@ async fn get_intraday_bars_empty_returns_empty_vec() {
     let bars = client.get_intraday_bars("UNKNOWN").await.unwrap();
     assert!(bars.is_empty());
 }
+
+// ── is_paper ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn is_paper_returns_true_for_paper_env() {
+    let client = AlpacaClient::new(AlpacaConfig {
+        base_url: "http://localhost".into(),
+        key: "k".into(),
+        secret: "s".into(),
+        env: AlpacaEnv::Paper,
+    });
+    assert!(client.is_paper());
+}
+
+#[tokio::test]
+async fn is_paper_returns_false_for_live_env() {
+    let client = AlpacaClient::new(AlpacaConfig {
+        base_url: "http://localhost".into(),
+        key: "k".into(),
+        secret: "s".into(),
+        env: AlpacaEnv::Live,
+    });
+    assert!(!client.is_paper());
+}


### PR DESCRIPTION
## Summary

Fixes #59

The Alpaca paper API does not support `/v2/watchlists`. Previously `poll_watchlist()` silently failed, leaving the Watchlist panel stuck on "Loading watchlist…" indefinitely.

## Changes (Option A from issue)

- **`src/client.rs`** — Added `AlpacaClient::is_paper() -> bool`
- **`src/events.rs`** — Added `Event::WatchlistUnavailable` variant
- **`src/handlers/rest.rs`** — `poll_watchlist()` short-circuits with `WatchlistUnavailable` when in paper mode (no HTTP call made)
- **`src/app.rs`** — Added `watchlist_unavailable: bool` field
- **`src/update.rs`** — Handles `Event::WatchlistUnavailable` by setting the flag
- **`src/ui/watchlist.rs`** — Renders a clear persistent explanation when `watchlist_unavailable` is set

## UI Behaviour

```
┌─ Watchlist ─────────────────────────────────────────────────────────────────┐
│                                                                              │
│   Watchlists are not available in paper trading mode.                       │
│   The Alpaca paper API does not support the /v2/watchlists endpoint.        │
│                                                                              │
│   To use watchlists, run without the --paper flag.                          │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Tests

- `client.rs` — `is_paper()` returns `true`/`false` per env
- `handlers/rest.rs` — paper mode emits `WatchlistUnavailable` without making any HTTP requests; existing watchlist tests updated to use live config
- `update.rs` — `WatchlistUnavailable` sets `app.watchlist_unavailable`; idempotent
- `ui/watchlist.rs` — renders paper mode message; does not show "Loading watchlist…"

All 297 tests pass.