### PR TITLE
feat(prefs): persist user preferences to TOML config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,10 +36,12 @@ dependencies = [
  "serde_json",
  "syslog",
  "temp-env",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tokio-tungstenite",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2439,6 +2441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,6 +2988,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3734,6 +3786,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ reqwest           = { version = "0.13", features = ["json", "query"] }
 tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
 serde             = { version = "1",    features = ["derive"] }
 serde_json        = "1"
+toml              = "0.8"
 dotenvy           = "0.15"
 anyhow            = "1"
 chrono            = { version = "0.4",  features = ["serde"] }
@@ -69,6 +70,7 @@ keyring = { version = "3", features = ["linux-native"] }
 wiremock   = "0.6"
 tokio-test = "0.4"
 temp-env   = "0.3"
+tempfile   = "3"
 
 [profile.release]
 opt-level     = 3

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,11 +4,9 @@ use std::time::{Duration, Instant};
 
 use ratatui::layout::Rect;
 
-const STATUS_MSG_TTL: Duration = Duration::from_secs(3);
-
 /// A status bar message that may auto-expire.
 ///
-/// Transient messages (e.g. "Order submitted", "Refreshing…") carry a 3-second TTL and are
+/// Transient messages (e.g. "Order submitted", "Refreshing…") carry a TTL and are
 /// cleared automatically on the next `Tick` after they expire. Persistent messages (errors,
 /// "Loading…") set `expires_at = None` so they stay until replaced.
 #[derive(Clone, Debug)]
@@ -18,11 +16,11 @@ pub struct StatusMessage {
 }
 
 impl StatusMessage {
-    /// Creates a transient message that auto-dismisses after 3 seconds.
-    pub fn transient(text: impl Into<String>) -> Self {
+    /// Creates a transient message that auto-dismisses after the given duration.
+    pub fn with_ttl(text: impl Into<String>, ttl: Duration) -> Self {
         Self {
             text: text.into(),
-            expires_at: Some(Instant::now() + STATUS_MSG_TTL),
+            expires_at: Some(Instant::now() + ttl),
         }
     }
 
@@ -94,6 +92,7 @@ pub(crate) mod test_helpers {
                 env: AlpacaEnv::Paper,
                 dry_run: false,
             },
+            crate::prefs::AppPrefs::default(),
             Arc::new(tokio::sync::Notify::new()),
             command_tx,
             symbol_tx,
@@ -145,6 +144,7 @@ use tokio::sync::{mpsc, watch, Notify};
 
 use crate::commands::Command;
 use crate::config::AlpacaConfig;
+use crate::prefs::AppPrefs;
 use crate::types::{AccountInfo, MarketClock, Order, Position, Quote, Snapshot, Watchlist};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -338,6 +338,7 @@ pub struct HitAreas {
 
 pub struct App {
     pub config: AlpacaConfig,
+    pub prefs: AppPrefs,
     pub refresh_notify: Arc<Notify>,
     pub command_tx: mpsc::Sender<Command>,
     pub symbol_tx: watch::Sender<Vec<String>>,
@@ -381,12 +382,14 @@ pub struct App {
 impl App {
     pub fn new(
         config: AlpacaConfig,
+        prefs: AppPrefs,
         refresh_notify: Arc<Notify>,
         command_tx: mpsc::Sender<Command>,
         symbol_tx: watch::Sender<Vec<String>>,
     ) -> Self {
         Self {
             config,
+            prefs,
             refresh_notify,
             command_tx,
             symbol_tx,
@@ -478,6 +481,16 @@ impl App {
                 }
             }
         }
+    }
+
+    /// Sets a transient status message using the TTL from user preferences.
+    pub fn push_transient_status(&mut self, text: impl Into<String>) {
+        self.status_msg = StatusMessage::with_ttl(text, self.prefs.status_ttl());
+    }
+
+    /// Sets a fill-notification status message using the fill TTL from user preferences.
+    pub fn push_fill_notification(&mut self, text: impl Into<String>) {
+        self.status_msg = StatusMessage::with_ttl(text, self.prefs.fill_ttl());
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -290,3 +290,349 @@ impl AlpacaClient {
             .bars)
     }
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AlpacaConfig, AlpacaEnv};
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn paper_config(base_url: String) -> AlpacaConfig {
+        AlpacaConfig {
+            base_url,
+            key: "PKTEST".into(),
+            secret: "secret".into(),
+            env: AlpacaEnv::Paper,
+            dry_run: false,
+        }
+    }
+
+    fn live_config(base_url: String) -> AlpacaConfig {
+        AlpacaConfig {
+            base_url,
+            key: "AKTEST".into(),
+            secret: "secret".into(),
+            env: AlpacaEnv::Live,
+            dry_run: false,
+        }
+    }
+
+    // ── Unit tests ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_paper_true_for_paper_env() {
+        let client = AlpacaClient::new(paper_config("http://localhost".into()));
+        assert!(client.is_paper());
+    }
+
+    #[test]
+    fn is_paper_false_for_live_env() {
+        let client = AlpacaClient::new(live_config("http://localhost".into()));
+        assert!(!client.is_paper());
+    }
+
+    #[test]
+    fn is_dry_run_false_by_default() {
+        let client = AlpacaClient::new(paper_config("http://localhost".into()));
+        assert!(!client.is_dry_run());
+    }
+
+    #[test]
+    fn is_dry_run_true_when_set() {
+        let config = AlpacaConfig {
+            base_url: "http://localhost".into(),
+            key: "k".into(),
+            secret: "s".into(),
+            env: AlpacaEnv::Paper,
+            dry_run: true,
+        };
+        let client = AlpacaClient::new(config);
+        assert!(client.is_dry_run());
+    }
+
+    #[test]
+    fn data_url_uses_data_alpaca_markets_for_production() {
+        let config = AlpacaConfig {
+            base_url: "https://paper-api.alpaca.markets".into(),
+            key: "k".into(),
+            secret: "s".into(),
+            env: AlpacaEnv::Paper,
+            dry_run: false,
+        };
+        let client = AlpacaClient::new(config);
+        assert_eq!(
+            client.data_url("/stocks/snapshots"),
+            "https://data.alpaca.markets/v2/stocks/snapshots"
+        );
+    }
+
+    #[test]
+    fn data_url_uses_base_url_for_non_production() {
+        let client = AlpacaClient::new(paper_config("http://localhost:9999".into()));
+        assert_eq!(
+            client.data_url("/stocks/snapshots"),
+            "http://localhost:9999/stocks/snapshots"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_snapshots_returns_empty_map_without_request_when_no_symbols() {
+        // No mock server — any HTTP would panic/fail; proves no request is made.
+        let client = AlpacaClient::new(paper_config("http://127.0.0.1:1".into()));
+        let result = client.get_snapshots(&[]).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    // ── HTTP integration tests ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_account_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/account"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": "ACTIVE", "equity": "100000", "buying_power": "200000",
+                "cash": "50000", "long_market_value": "50000",
+                "daytrade_count": 0, "pattern_day_trader": false, "currency": "USD"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let acct = client.get_account().await.unwrap();
+        assert_eq!(acct.status, "ACTIVE");
+        assert_eq!(acct.equity, "100000");
+    }
+
+    #[tokio::test]
+    async fn get_account_returns_error_on_bad_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/account"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let err = client.get_account().await.unwrap_err();
+        assert!(err.to_string().contains("parse failed"));
+    }
+
+    #[tokio::test]
+    async fn get_positions_parses_empty_list() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/positions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let positions = client.get_positions().await.unwrap();
+        assert!(positions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_orders_parses_empty_list() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/orders"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let orders = client.get_orders("open").await.unwrap();
+        assert!(orders.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_order_sends_post_and_parses_response() {
+        use crate::types::OrderRequest;
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/orders"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "ord-1", "symbol": "AAPL", "side": "buy",
+                "order_type": "market", "status": "accepted",
+                "filled_qty": "0", "time_in_force": "day"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let req = OrderRequest {
+            symbol: "AAPL".into(),
+            qty: Some("1".into()),
+            notional: None,
+            side: "buy".into(),
+            order_type: "market".into(),
+            time_in_force: "day".into(),
+            limit_price: None,
+        };
+        let order = client.submit_order(&req).await.unwrap();
+        assert_eq!(order.symbol, "AAPL");
+        assert_eq!(order.status, "accepted");
+    }
+
+    #[tokio::test]
+    async fn cancel_order_succeeds_on_204() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/orders/order-abc"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        client.cancel_order("order-abc").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_clock_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clock"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "is_open": true,
+                "next_open": "2026-05-13T13:30:00Z",
+                "next_close": "2026-05-12T20:00:00Z",
+                "timestamp": "2026-05-12T15:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let clock = client.get_clock().await.unwrap();
+        assert!(clock.is_open);
+    }
+
+    #[tokio::test]
+    async fn list_watchlists_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/watchlists"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"id": "wl-1", "name": "My List"}
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(live_config(server.uri()));
+        let lists = client.list_watchlists().await.unwrap();
+        assert_eq!(lists.len(), 1);
+        assert_eq!(lists[0].name, "My List");
+    }
+
+    #[tokio::test]
+    async fn get_watchlist_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/watchlists/wl-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "wl-1", "name": "My List", "assets": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(live_config(server.uri()));
+        let wl = client.get_watchlist("wl-1").await.unwrap();
+        assert_eq!(wl.name, "My List");
+        assert!(wl.assets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_to_watchlist_returns_updated_watchlist() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/watchlists/wl-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "wl-1", "name": "My List",
+                "assets": [{
+                    "id": "a-1", "symbol": "AAPL", "name": "Apple Inc.",
+                    "exchange": "NASDAQ", "class": "us_equity",
+                    "tradable": true, "shortable": true, "fractionable": true
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(live_config(server.uri()));
+        let wl = client.add_to_watchlist("wl-1", "AAPL").await.unwrap();
+        assert_eq!(wl.assets.len(), 1);
+        assert_eq!(wl.assets[0].symbol, "AAPL");
+    }
+
+    #[tokio::test]
+    async fn remove_from_watchlist_returns_updated_watchlist() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/watchlists/wl-1/AAPL"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "wl-1", "name": "My List", "assets": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(live_config(server.uri()));
+        let wl = client.remove_from_watchlist("wl-1", "AAPL").await.unwrap();
+        assert!(wl.assets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_portfolio_history_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/account/portfolio/history"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "equity": [100000.0, 100100.0, null],
+                "timestamp": [1000, 2000, 3000],
+                "base_value": 100000.0
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let history = client.get_portfolio_history().await.unwrap();
+        assert_eq!(history.equity.len(), 3);
+        assert_eq!(history.equity[0], Some(100000.0));
+        assert_eq!(history.equity[2], None);
+    }
+
+    #[tokio::test]
+    async fn get_snapshots_with_symbols_calls_endpoint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stocks/snapshots"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let result = client.get_snapshots(&["AAPL".to_string()]).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_intraday_bars_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stocks/AAPL/bars"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "bars": [{"c": 195.5}],
+                "symbol": "AAPL",
+                "next_page_token": null
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AlpacaClient::new(paper_config(server.uri()));
+        let bars = client.get_intraday_bars("AAPL").await.unwrap();
+        assert_eq!(bars.len(), 1);
+        assert_eq!(bars[0].c, 195.5);
+    }
+}

--- a/src/handlers/rest.rs
+++ b/src/handlers/rest.rs
@@ -1,19 +1,20 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::{mpsc::Sender, Notify};
 use tokio_util::sync::CancellationToken;
 
 use crate::client::AlpacaClient;
 use crate::events::Event;
+use crate::prefs::AppPrefs;
 
 pub async fn run(
     tx: Sender<Event>,
     cancel: CancellationToken,
     client: Arc<AlpacaClient>,
     refresh_notify: Arc<Notify>,
+    prefs: AppPrefs,
 ) {
-    let mut interval = tokio::time::interval(Duration::from_secs(5));
+    let mut interval = tokio::time::interval(prefs.refresh_interval());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
@@ -392,7 +393,7 @@ mod tests {
         let notify = Arc::new(Notify::new());
 
         let cancel_clone = cancel.clone();
-        let handle = tokio::spawn(run(tx, cancel_clone, client, notify));
+        let handle = tokio::spawn(run(tx, cancel_clone, client, notify, AppPrefs::default()));
 
         // Cancel immediately and wait — should not hang
         cancel.cancel();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -21,14 +21,14 @@ use crate::commands::Command;
 
 /// Send a command on the command channel and set the appropriate status message.
 ///
-/// - Success → `success_msg` (transient, auto-dismissed after 3 s)
+/// - Success → `success_msg` (transient, auto-dismissed after the prefs-configured TTL)
 /// - Channel full → "System busy — please retry" (transient)
 /// - Channel closed → "Command handler stopped — restart app" (persistent error)
 pub(crate) fn send_command(app: &mut App, cmd: Command, success_msg: impl Into<String>) {
     match app.command_tx.try_send(cmd) {
-        Ok(()) => app.status_msg = StatusMessage::transient(success_msg),
+        Ok(()) => app.push_transient_status(success_msg),
         Err(TrySendError::Full(_)) => {
-            app.status_msg = StatusMessage::transient("System busy — please retry");
+            app.push_transient_status("System busy — please retry");
         }
         Err(TrySendError::Closed(_)) => {
             tracing::error!("command channel closed; command handler has stopped");

--- a/src/input/watchlist.rs
+++ b/src/input/watchlist.rs
@@ -44,14 +44,23 @@ pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEven
                 (app.selected_watchlist_symbol(), app.watchlist.as_ref())
             {
                 let wl_id = wl.id.clone();
-                app.modal = Some(Modal::Confirm {
-                    message: format!("Remove {} from watchlist?", symbol),
-                    action: ConfirmAction::RemoveFromWatchlist {
-                        watchlist_id: wl_id,
-                        symbol,
-                    },
-                    confirmed: false,
-                });
+                if app.prefs.safety.confirm_watchlist_remove {
+                    app.modal = Some(Modal::Confirm {
+                        message: format!("Remove {} from watchlist?", symbol),
+                        action: ConfirmAction::RemoveFromWatchlist {
+                            watchlist_id: wl_id,
+                            symbol,
+                        },
+                        confirmed: false,
+                    });
+                } else {
+                    let _ =
+                        app.command_tx
+                            .try_send(crate::commands::Command::RemoveFromWatchlist {
+                                watchlist_id: wl_id,
+                                symbol,
+                            });
+                }
             }
         }
         KeyCode::Char('/') => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub mod commands;
 pub mod config;
 pub mod events;
 pub mod logging;
+pub mod prefs;
 pub mod stream;
 pub mod types;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -161,6 +161,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
+    fn home_present_last_component_is_alpaca_trader() {
+        let dir = log_dir_from(Some(PathBuf::from("/Users/alice")));
+        assert_eq!(dir.file_name().unwrap(), "alpaca-trader");
+    }
+
+    #[test]
     #[cfg(not(target_os = "macos"))]
     fn home_present_returns_xdg_log_path() {
         let dir = log_dir_from(Some(PathBuf::from("/home/tester")));
@@ -168,6 +175,13 @@ mod tests {
             dir,
             PathBuf::from("/home/tester/.local/share/alpaca-trader/logs")
         );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn home_present_last_component_is_logs() {
+        let dir = log_dir_from(Some(PathBuf::from("/home/alice")));
+        assert_eq!(dir.file_name().unwrap(), "logs");
     }
 
     #[test]
@@ -180,5 +194,23 @@ mod tests {
             "fallback path should end with alpaca-trader-logs, got: {}",
             dir.display()
         );
+    }
+
+    #[test]
+    fn no_home_fallback_is_absolute() {
+        let dir = log_dir_from(None);
+        assert!(
+            dir.is_absolute(),
+            "fallback log dir should be absolute, got: {}",
+            dir.display()
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn log_dir_from_preserves_home_prefix() {
+        let home = PathBuf::from("/tmp/fakehome");
+        let dir = log_dir_from(Some(home.clone()));
+        assert!(dir.starts_with(&home));
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -61,10 +61,22 @@ impl<S: tracing::Subscriber> Layer<S> for SyslogLayer {
 /// early error messages from this function itself.
 pub fn init() -> anyhow::Result<WorkerGuard> {
     let log_dir = log_dir();
-    std::fs::create_dir_all(&log_dir)?;
+    let guard = init_with_dir(&log_dir)?;
+    tracing::info!(log_dir = %log_dir.display(), "logging initialised");
+    Ok(guard)
+}
+
+/// Set up file + syslog logging rooted at `log_dir`.
+///
+/// Separated from [`init`] so that tests can exercise the full setup path
+/// with a temporary directory without touching the process-wide subscriber.
+/// Uses `try_init` so that calling this when a global subscriber is already
+/// installed (e.g. in a test process) silently succeeds rather than panicking.
+pub(crate) fn init_with_dir(log_dir: &std::path::Path) -> anyhow::Result<WorkerGuard> {
+    std::fs::create_dir_all(log_dir)?;
 
     // Non-blocking daily-rotating file writer
-    let file_appender = tracing_appender::rolling::daily(&log_dir, "alpaca-trader.log");
+    let file_appender = tracing_appender::rolling::daily(log_dir, "alpaca-trader.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let file_layer = tracing_subscriber::fmt::layer()
@@ -92,12 +104,11 @@ pub fn init() -> anyhow::Result<WorkerGuard> {
     let registry = tracing_subscriber::registry().with(filter).with(file_layer);
 
     if let Some(syslog) = syslog_layer {
-        registry.with(syslog).init();
+        registry.with(syslog).try_init().ok();
     } else {
-        registry.init();
+        registry.try_init().ok();
     }
 
-    tracing::info!(log_dir = %log_dir.display(), "logging initialised");
     Ok(guard)
 }
 
@@ -147,8 +158,168 @@ pub(crate) fn log_dir_from(home: Option<std::path::PathBuf>) -> std::path::PathB
 
 #[cfg(test)]
 mod tests {
-    use super::log_dir_from;
+    use super::*;
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // ── Helper: run a closure under a per-thread subscriber that captures
+    //    whatever MessageVisitor extracts from each tracing event. ─────────────
+
+    struct MessageCapture(Arc<Mutex<String>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for MessageCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut visitor = MessageVisitor {
+                message: String::new(),
+            };
+            event.record(&mut visitor);
+            *self.0.lock().unwrap() = visitor.message.clone();
+        }
+    }
+
+    /// Run `f` under a thread-local subscriber that records the last captured
+    /// message into the returned string. Does not touch the global subscriber.
+    fn capture<F: FnOnce()>(f: F) -> String {
+        let captured = Arc::new(Mutex::new(String::new()));
+        let sub = tracing_subscriber::registry().with(MessageCapture(Arc::clone(&captured)));
+        tracing::subscriber::with_default(sub, f);
+        let result = captured.lock().unwrap().clone();
+        result
+    }
+
+    // ── MessageVisitor ────────────────────────────────────────────────────────
+
+    #[test]
+    fn message_visitor_record_debug_captures_message() {
+        // tracing!("text") records the message via record_debug
+        let msg = capture(|| tracing::info!("hello from test"));
+        assert_eq!(msg, "hello from test");
+    }
+
+    #[test]
+    fn message_visitor_record_debug_non_message_field_is_ignored() {
+        // count = 42 exercises the record_debug non-"message" branch;
+        // the text part still gets captured.
+        let msg = capture(|| tracing::info!(count = 42, "with extra field"));
+        assert_eq!(msg, "with extra field");
+    }
+
+    #[test]
+    fn message_visitor_record_str_captures_explicit_message_field() {
+        // message = "string" uses record_str for the message field
+        let msg = capture(|| tracing::info!(message = "explicit string"));
+        assert_eq!(msg, "explicit string");
+    }
+
+    #[test]
+    fn message_visitor_record_str_non_message_field_is_ignored() {
+        // name = "alice" is a &str that is NOT the "message" field;
+        // exercises the record_str non-"message" branch.
+        let msg = capture(|| tracing::info!(name = "alice", "with str field"));
+        assert_eq!(msg, "with str field");
+    }
+
+    // ── SyslogLayer ───────────────────────────────────────────────────────────
+
+    fn make_syslog_layer() -> Option<SyslogLayer> {
+        syslog::unix(syslog::Formatter3164 {
+            facility: syslog::Facility::LOG_USER,
+            hostname: None,
+            process: "alpaca-trader-test".into(),
+            pid: 0,
+        })
+        .ok()
+        .map(|l| SyslogLayer {
+            logger: Mutex::new(l),
+        })
+    }
+
+    #[test]
+    fn syslog_layer_empty_message_returns_early_without_panic() {
+        let Some(layer) = make_syslog_layer() else {
+            return; // syslog socket unavailable — skip
+        };
+        // An event whose message field is an empty string should not panic.
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || tracing::info!(""));
+    }
+
+    #[test]
+    fn syslog_layer_dispatches_error_level() {
+        let Some(layer) = make_syslog_layer() else {
+            return;
+        };
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || tracing::error!("error level msg"));
+    }
+
+    #[test]
+    fn syslog_layer_dispatches_warn_level() {
+        let Some(layer) = make_syslog_layer() else {
+            return;
+        };
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || tracing::warn!("warn level msg"));
+    }
+
+    #[test]
+    fn syslog_layer_dispatches_info_level() {
+        let Some(layer) = make_syslog_layer() else {
+            return;
+        };
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || tracing::info!("info level msg"));
+    }
+
+    #[test]
+    fn syslog_layer_dispatches_debug_level() {
+        let Some(layer) = make_syslog_layer() else {
+            return;
+        };
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || tracing::debug!("debug level msg"));
+    }
+
+    // ── init_with_dir ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn init_with_dir_creates_log_dir_and_returns_guard() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_subdir = tmp.path().join("logs");
+        // Directory does not exist yet — init_with_dir must create it.
+        let _guard =
+            init_with_dir(&log_subdir).expect("init_with_dir should succeed with a temp dir");
+        assert!(
+            log_subdir.exists(),
+            "log dir should have been created by init_with_dir"
+        );
+    }
+
+    #[test]
+    fn init_with_dir_is_idempotent_when_subscriber_already_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Call twice — second call must not panic (try_init silently ignores conflicts).
+        let _g1 = init_with_dir(tmp.path()).expect("first call should succeed");
+        let _g2 = init_with_dir(tmp.path()).expect("second call should not panic");
+    }
+
+    // ── log_dir ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn log_dir_returns_non_empty_path() {
+        let dir = log_dir();
+        assert!(
+            dir.components().count() > 0,
+            "log_dir() returned an empty path"
+        );
+    }
+
+    // ── log_dir_from ─────────────────────────────────────────────────────────
 
     #[test]
     #[cfg(target_os = "macos")]
@@ -186,8 +357,6 @@ mod tests {
 
     #[test]
     fn no_home_falls_back_to_non_panicking_dir() {
-        // When home is absent the function must NOT panic and must return a
-        // path ending in "alpaca-trader-logs" (cwd or temp fallback).
         let dir = log_dir_from(None);
         assert!(
             dir.ends_with("alpaca-trader-logs"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,9 +105,7 @@ async fn main() -> anyhow::Result<()> {
     // ── Load user preferences ──────────────────────────────────────────────────
     let prefs = AppPrefs::load();
 
-    let env = if args.paper {
-        AlpacaEnv::Paper
-    } else if prefs.app.default_env == "paper" {
+    let env = if args.paper || prefs.app.default_env == "paper" {
         AlpacaEnv::Paper
     } else {
         AlpacaEnv::Live

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use alpaca_trader_rs::{
     client::AlpacaClient,
     config::{AlpacaConfig, AlpacaEnv},
     events::Event,
+    prefs::AppPrefs,
 };
 
 /// Alpaca Markets TUI trading terminal.
@@ -58,6 +59,9 @@ mod config {
 mod events {
     pub use alpaca_trader_rs::events::*;
 }
+mod prefs {
+    pub use alpaca_trader_rs::prefs::*;
+}
 
 mod types {
     pub use alpaca_trader_rs::types::*;
@@ -98,7 +102,12 @@ async fn main() -> anyhow::Result<()> {
         nb
     });
 
+    // ── Load user preferences ──────────────────────────────────────────────────
+    let prefs = AppPrefs::load();
+
     let env = if args.paper {
+        AlpacaEnv::Paper
+    } else if prefs.app.default_env == "paper" {
         AlpacaEnv::Paper
     } else {
         AlpacaEnv::Live
@@ -139,6 +148,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut app = App::new(
         config.clone(),
+        prefs.clone(),
         refresh_notify.clone(),
         command_tx,
         symbol_tx,
@@ -161,6 +171,7 @@ async fn main() -> anyhow::Result<()> {
         cancel.clone(),
         client.clone(),
         refresh_notify.clone(),
+        prefs.clone(),
     ));
 
     // Command execution task (order submit, cancel, watchlist mutations)
@@ -178,6 +189,7 @@ async fn main() -> anyhow::Result<()> {
         cancel.clone(),
         config.clone(),
         symbol_rx,
+        prefs.clone(),
     ));
 
     // Account/trade updates WebSocket stream
@@ -185,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
         tx.clone(),
         cancel.clone(),
         config.clone(),
+        prefs.clone(),
     ));
 
     // Tick task — drives clock refresh every 250 ms

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -1,0 +1,449 @@
+//! User preferences persisted in `~/.config/alpaca-trader/config.toml`.
+//!
+//! [`AppPrefs`] is loaded at startup via [`AppPrefs::load`]. Missing fields
+//! fall back to compiled defaults; unknown fields are silently ignored.
+//! Credentials (API keys) are **never** stored here — they live in `.env` or
+//! the OS keychain.
+//!
+//! # Priority order (highest wins)
+//!
+//! 1. CLI flags (`--paper`, `--dry-run`)
+//! 2. Environment variables (`PAPER_ALPACA_*`, `LIVE_ALPACA_*`)
+//! 3. `config.toml` preferences (this module)
+//! 4. Compiled defaults (defined via `Default` impls below)
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+// ── Sub-sections ──────────────────────────────────────────────────────────────
+
+/// Application-wide settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct AppSection {
+    /// Which environment to connect to when neither `--paper` nor `--live`
+    /// flags are supplied.  Accepted values: `"paper"` | `"live"`.
+    pub default_env: String,
+    /// How often the REST polling task refreshes data (milliseconds).
+    pub refresh_interval_ms: u64,
+}
+
+impl Default for AppSection {
+    fn default() -> Self {
+        Self {
+            default_env: "live".into(),
+            refresh_interval_ms: 5000,
+        }
+    }
+}
+
+/// UI display preferences.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct UiSection {
+    /// Active colour theme. Accepted values: `"default"` | `"dark"` |
+    /// `"high-contrast"`.  Theme switching UI is tracked in issue #62.
+    pub theme: String,
+    /// Show the Account panel tab.
+    pub show_account_panel: bool,
+    /// Show the Watchlist panel tab.
+    pub show_watchlist: bool,
+    /// Show the Positions panel tab.
+    pub show_positions: bool,
+    /// Show the Orders panel tab.
+    pub show_orders: bool,
+    /// Default equity-chart time range.  Accepted values:
+    /// `"1D"` | `"1W"` | `"1M"` | `"YTD"`.  Range-picker UI is tracked in
+    /// issue #77.
+    pub default_equity_range: String,
+}
+
+impl Default for UiSection {
+    fn default() -> Self {
+        Self {
+            theme: "default".into(),
+            show_account_panel: true,
+            show_watchlist: true,
+            show_positions: true,
+            show_orders: true,
+            default_equity_range: "1D".into(),
+        }
+    }
+}
+
+/// WebSocket stream reconnection settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct StreamSection {
+    /// Maximum number of reconnect attempts before giving up.  `0` means
+    /// unlimited.
+    pub reconnect_max_attempts: u32,
+    /// Base backoff delay in milliseconds; doubles on each failed attempt up
+    /// to 30 seconds.
+    pub reconnect_backoff_base_ms: u64,
+}
+
+impl Default for StreamSection {
+    fn default() -> Self {
+        Self {
+            reconnect_max_attempts: 0,
+            reconnect_backoff_base_ms: 1000,
+        }
+    }
+}
+
+/// In-app notification settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct NotificationsSection {
+    /// Show a transient status-bar message when an order fill is received.
+    pub fill_notifications_enabled: bool,
+    /// How long fill notifications remain visible (milliseconds).
+    pub fill_notification_ttl_ms: u64,
+    /// How long generic transient status messages stay on screen
+    /// (milliseconds).
+    pub status_message_ttl_ms: u64,
+}
+
+impl Default for NotificationsSection {
+    fn default() -> Self {
+        Self {
+            fill_notifications_enabled: true,
+            fill_notification_ttl_ms: 4000,
+            status_message_ttl_ms: 2000,
+        }
+    }
+}
+
+/// Safety guard settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct SafetySection {
+    /// Show a confirmation prompt before removing a symbol from the watchlist.
+    pub confirm_watchlist_remove: bool,
+}
+
+impl Default for SafetySection {
+    fn default() -> Self {
+        Self {
+            confirm_watchlist_remove: true,
+        }
+    }
+}
+
+/// HTTP/SOCKS proxy settings.
+///
+/// Leave all fields unset to use the `HTTP_PROXY` / `HTTPS_PROXY`
+/// environment variables automatically (tracked in issue #90).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default)]
+pub struct ProxySection {
+    /// HTTP proxy URL, e.g. `"http://proxy.corp.com:8080"`.
+    pub http: Option<String>,
+    /// SOCKS5 proxy URL, e.g. `"socks5://proxy.corp.com:1080"`.
+    pub socks5: Option<String>,
+    /// Comma-separated list of hosts that bypass the proxy,
+    /// e.g. `"localhost,127.0.0.1"`.
+    pub no_proxy: Option<String>,
+}
+
+// ── Root struct ───────────────────────────────────────────────────────────────
+
+/// All user preferences loaded from `~/.config/alpaca-trader/config.toml`.
+///
+/// Construct via [`AppPrefs::load`]; direct construction is mainly useful in
+/// tests.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default)]
+pub struct AppPrefs {
+    /// Application-wide settings (`[app]` section).
+    pub app: AppSection,
+    /// UI display preferences (`[ui]` section).
+    pub ui: UiSection,
+    /// WebSocket stream settings (`[stream]` section).
+    pub stream: StreamSection,
+    /// Notification settings (`[notifications]` section).
+    pub notifications: NotificationsSection,
+    /// Safety guard settings (`[safety]` section).
+    pub safety: SafetySection,
+    /// Proxy settings (`[proxy]` section).
+    pub proxy: ProxySection,
+}
+
+impl AppPrefs {
+    /// Returns the canonical path for the config file.
+    ///
+    /// Uses [`dirs::config_dir`] so the location is platform-appropriate:
+    /// - **macOS** — `~/Library/Application Support/alpaca-trader/config.toml`
+    /// - **Linux** — `~/.config/alpaca-trader/config.toml`
+    /// - **Windows** — `%APPDATA%\alpaca-trader\config.toml`
+    ///
+    /// Returns `None` if the home directory cannot be determined.
+    pub fn default_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|d| d.join("alpaca-trader").join("config.toml"))
+    }
+
+    /// Loads preferences from [`AppPrefs::default_path`].
+    ///
+    /// - If the file is **absent**, creates it with compiled defaults and
+    ///   prints a one-time notice to `stderr`.
+    /// - If the file exists but cannot be parsed, logs a warning and returns
+    ///   defaults (never panics).
+    /// - Missing fields within a valid TOML file fall back to defaults.
+    pub fn load() -> Self {
+        let Some(path) = Self::default_path() else {
+            tracing::warn!("cannot determine config directory; using default preferences");
+            return Self::default();
+        };
+        Self::load_from(&path)
+    }
+
+    /// Load from an explicit path — used internally and in tests.
+    pub fn load_from(path: &std::path::Path) -> Self {
+        if !path.exists() {
+            let defaults = Self::default();
+            if let Err(e) = defaults.write_to(path) {
+                tracing::warn!(path = %path.display(), error = %e, "could not write default config");
+            } else {
+                eprintln!(
+                    "alpaca-trader: created default config at {}",
+                    path.display()
+                );
+            }
+            return defaults;
+        }
+
+        match std::fs::read_to_string(path) {
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "could not read config file; using defaults");
+                Self::default()
+            }
+            Ok(text) => match toml::from_str::<Self>(&text) {
+                Ok(prefs) => prefs,
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "could not parse config file; using defaults");
+                    Self::default()
+                }
+            },
+        }
+    }
+
+    /// Serialises the preferences to TOML and writes to `path`, creating any
+    /// missing parent directories.
+    pub fn write_to(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let toml_text = self.to_toml_string();
+        std::fs::write(path, toml_text)?;
+        Ok(())
+    }
+
+    /// Serialises to a TOML string with descriptive comments for each
+    /// section.
+    pub fn to_toml_string(&self) -> String {
+        format!(
+            r#"# alpaca-trader configuration
+# Generated automatically on first launch. Edit and restart to apply changes.
+# Credentials (API keys) are stored separately in the OS keychain, never here.
+
+[app]
+# Default environment when --paper / --live is not specified.
+# Accepted values: "paper" | "live"
+default_env = "{default_env}"
+# REST polling interval in milliseconds.
+refresh_interval_ms = {refresh_ms}
+
+[ui]
+# Colour theme. Accepted values: "default" | "dark" | "high-contrast"
+theme = "{theme}"
+show_account_panel = {show_account}
+show_watchlist     = {show_watchlist}
+show_positions     = {show_positions}
+show_orders        = {show_orders}
+# Default equity chart range. Accepted values: "1D" | "1W" | "1M" | "YTD"
+default_equity_range = "{equity_range}"
+
+[stream]
+# Max reconnect attempts (0 = unlimited)
+reconnect_max_attempts = {reconnect_max}
+# Base backoff between reconnects in milliseconds (doubles each attempt, capped at 30 s)
+reconnect_backoff_base_ms = {reconnect_base}
+
+[notifications]
+fill_notifications_enabled = {fill_enabled}
+fill_notification_ttl_ms   = {fill_ttl}
+status_message_ttl_ms      = {status_ttl}
+
+[safety]
+# Prompt for confirmation before removing a watchlist symbol
+confirm_watchlist_remove = {confirm_remove}
+
+[proxy]
+# Leave commented to use HTTP_PROXY / HTTPS_PROXY environment variables
+# http   = "http://proxy.corp.com:8080"
+# socks5 = "socks5://proxy.corp.com:1080"
+# no_proxy = "localhost,127.0.0.1"
+"#,
+            default_env = self.app.default_env,
+            refresh_ms = self.app.refresh_interval_ms,
+            theme = self.ui.theme,
+            show_account = self.ui.show_account_panel,
+            show_watchlist = self.ui.show_watchlist,
+            show_positions = self.ui.show_positions,
+            show_orders = self.ui.show_orders,
+            equity_range = self.ui.default_equity_range,
+            reconnect_max = self.stream.reconnect_max_attempts,
+            reconnect_base = self.stream.reconnect_backoff_base_ms,
+            fill_enabled = self.notifications.fill_notifications_enabled,
+            fill_ttl = self.notifications.fill_notification_ttl_ms,
+            status_ttl = self.notifications.status_message_ttl_ms,
+            confirm_remove = self.safety.confirm_watchlist_remove,
+        )
+    }
+
+    /// Returns the configured status-message TTL as a [`Duration`].
+    pub fn status_ttl(&self) -> Duration {
+        Duration::from_millis(self.notifications.status_message_ttl_ms)
+    }
+
+    /// Returns the configured fill-notification TTL as a [`Duration`].
+    pub fn fill_ttl(&self) -> Duration {
+        Duration::from_millis(self.notifications.fill_notification_ttl_ms)
+    }
+
+    /// Returns the configured REST polling interval as a [`Duration`].
+    pub fn refresh_interval(&self) -> Duration {
+        Duration::from_millis(self.app.refresh_interval_ms)
+    }
+
+    /// Returns the base reconnect backoff as a [`Duration`].
+    pub fn reconnect_backoff_base(&self) -> Duration {
+        Duration::from_millis(self.stream.reconnect_backoff_base_ms)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_toml(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn default_prefs_have_expected_values() {
+        let p = AppPrefs::default();
+        assert_eq!(p.app.default_env, "live");
+        assert_eq!(p.app.refresh_interval_ms, 5000);
+        assert_eq!(p.ui.theme, "default");
+        assert!(p.ui.show_account_panel);
+        assert!(p.ui.show_watchlist);
+        assert_eq!(p.ui.default_equity_range, "1D");
+        assert_eq!(p.stream.reconnect_max_attempts, 0);
+        assert_eq!(p.stream.reconnect_backoff_base_ms, 1000);
+        assert!(p.notifications.fill_notifications_enabled);
+        assert_eq!(p.notifications.fill_notification_ttl_ms, 4000);
+        assert_eq!(p.notifications.status_message_ttl_ms, 2000);
+        assert!(p.safety.confirm_watchlist_remove);
+        assert!(p.proxy.http.is_none());
+    }
+
+    #[test]
+    fn load_from_valid_toml_overrides_defaults() {
+        let f = write_toml(
+            r#"
+[app]
+default_env = "paper"
+refresh_interval_ms = 10000
+
+[stream]
+reconnect_max_attempts = 3
+reconnect_backoff_base_ms = 500
+
+[notifications]
+status_message_ttl_ms = 1500
+fill_notifications_enabled = false
+"#,
+        );
+        let p = AppPrefs::load_from(f.path());
+        assert_eq!(p.app.default_env, "paper");
+        assert_eq!(p.app.refresh_interval_ms, 10000);
+        assert_eq!(p.stream.reconnect_max_attempts, 3);
+        assert_eq!(p.stream.reconnect_backoff_base_ms, 500);
+        assert_eq!(p.notifications.status_message_ttl_ms, 1500);
+        assert!(!p.notifications.fill_notifications_enabled);
+        // Unspecified fields fall back to defaults
+        assert_eq!(p.ui.theme, "default");
+        assert!(p.safety.confirm_watchlist_remove);
+    }
+
+    #[test]
+    fn load_from_invalid_toml_returns_defaults() {
+        let f = write_toml("not valid toml !!!");
+        let p = AppPrefs::load_from(f.path());
+        assert_eq!(p, AppPrefs::default());
+    }
+
+    #[test]
+    fn load_from_missing_file_creates_it_and_returns_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("config.toml");
+        assert!(!path.exists());
+        let p = AppPrefs::load_from(&path);
+        assert_eq!(p, AppPrefs::default());
+        assert!(path.exists(), "config file should be created");
+        // Round-trip: the created file should parse back to defaults
+        let p2 = AppPrefs::load_from(&path);
+        assert_eq!(p, p2);
+    }
+
+    #[test]
+    fn to_toml_string_round_trips() {
+        let mut p = AppPrefs::default();
+        p.app.default_env = "paper".into();
+        p.stream.reconnect_max_attempts = 5;
+        p.notifications.status_message_ttl_ms = 3000;
+        let toml_str = p.to_toml_string();
+        let p2: AppPrefs = toml::from_str(&toml_str).unwrap();
+        assert_eq!(p.app.default_env, p2.app.default_env);
+        assert_eq!(
+            p.stream.reconnect_max_attempts,
+            p2.stream.reconnect_max_attempts
+        );
+        assert_eq!(
+            p.notifications.status_message_ttl_ms,
+            p2.notifications.status_message_ttl_ms
+        );
+    }
+
+    #[test]
+    fn duration_helpers_return_correct_values() {
+        let mut p = AppPrefs::default();
+        p.notifications.status_message_ttl_ms = 2500;
+        p.notifications.fill_notification_ttl_ms = 6000;
+        p.app.refresh_interval_ms = 8000;
+        p.stream.reconnect_backoff_base_ms = 750;
+        assert_eq!(p.status_ttl(), Duration::from_millis(2500));
+        assert_eq!(p.fill_ttl(), Duration::from_millis(6000));
+        assert_eq!(p.refresh_interval(), Duration::from_millis(8000));
+        assert_eq!(p.reconnect_backoff_base(), Duration::from_millis(750));
+    }
+
+    #[test]
+    fn partial_toml_file_fills_missing_sections_with_defaults() {
+        let f = write_toml("[safety]\nconfirm_watchlist_remove = false\n");
+        let p = AppPrefs::load_from(f.path());
+        assert!(!p.safety.confirm_watchlist_remove);
+        // All other sections should be default
+        assert_eq!(p.app, AppSection::default());
+        assert_eq!(p.stream, StreamSection::default());
+    }
+}

--- a/src/stream/account.rs
+++ b/src/stream/account.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::config::AlpacaConfig;
 use crate::events::{Event, StreamKind};
+use crate::prefs::AppPrefs;
 use crate::types::Order;
 
 const MAX_BACKOFF_SECS: u64 = 30;
@@ -24,7 +25,12 @@ const MAX_BACKOFF_SECS: u64 = 30;
 /// cancels, rejects), and emits `Event::TradeUpdate` on each state change.
 ///
 /// Reconnects automatically with exponential backoff.
-pub async fn run(tx: Sender<Event>, cancel: CancellationToken, config: AlpacaConfig) {
+pub async fn run(
+    tx: Sender<Event>,
+    cancel: CancellationToken,
+    config: AlpacaConfig,
+    prefs: AppPrefs,
+) {
     // Derive WebSocket URL from REST base_url:
     //   https://paper-api.alpaca.markets/v2  →  wss://paper-api.alpaca.markets/stream
     let ws_url = config
@@ -34,7 +40,7 @@ pub async fn run(tx: Sender<Event>, cancel: CancellationToken, config: AlpacaCon
         .replace("https://", "wss://")
         + "/stream";
 
-    run_inner(tx, cancel, config, &ws_url).await
+    run_inner(tx, cancel, config, &ws_url, prefs).await
 }
 
 async fn run_inner(
@@ -42,8 +48,12 @@ async fn run_inner(
     cancel: CancellationToken,
     config: AlpacaConfig,
     ws_url: &str,
+    prefs: AppPrefs,
 ) {
-    let mut backoff = 1u64;
+    let base_backoff = prefs.reconnect_backoff_base();
+    let max_attempts = prefs.stream.reconnect_max_attempts;
+    let mut backoff = base_backoff;
+    let mut attempt: u32 = 0;
 
     loop {
         tokio::select! {
@@ -57,15 +67,27 @@ async fn run_inner(
         match run_once(&tx, &cancel, &config, ws_url).await {
             Ok(_) => return,
             Err(e) => {
-                warn!(error = %e, backoff_secs = backoff, "account stream disconnected, reconnecting");
+                attempt += 1;
+                if max_attempts > 0 && attempt >= max_attempts {
+                    warn!(
+                        error = %e,
+                        attempts = attempt,
+                        "account stream reached max reconnect attempts, giving up"
+                    );
+                    let _ = tx
+                        .send(Event::StreamDisconnected(StreamKind::Account))
+                        .await;
+                    return;
+                }
+                warn!(error = %e, backoff_ms = backoff.as_millis(), "account stream disconnected, reconnecting");
                 let _ = tx
                     .send(Event::StreamDisconnected(StreamKind::Account))
                     .await;
                 tokio::select! {
                     _ = cancel.cancelled() => return,
-                    _ = tokio::time::sleep(Duration::from_secs(backoff)) => {}
+                    _ = tokio::time::sleep(backoff) => {}
                 }
-                backoff = (backoff * 2).min(MAX_BACKOFF_SECS);
+                backoff = (backoff * 2).min(Duration::from_secs(MAX_BACKOFF_SECS));
             }
         }
     }
@@ -231,6 +253,7 @@ mod tests {
 mod integration {
     use super::*;
     use crate::config::AlpacaEnv;
+    use crate::prefs::AppPrefs;
     use futures::SinkExt;
     use tokio::sync::mpsc;
     use tokio_tungstenite::{accept_async, tungstenite::Message};
@@ -420,7 +443,7 @@ mod integration {
 
         let url2 = url.clone();
         tokio::spawn(async move {
-            run_inner(tx, cancel2, test_config(), &url2).await;
+            run_inner(tx, cancel2, test_config(), &url2, AppPrefs::default()).await;
         });
 
         let mut saw_disconnect = false;

--- a/src/stream/market.rs
+++ b/src/stream/market.rs
@@ -17,10 +17,10 @@ use tracing::{debug, info, warn};
 
 use crate::config::AlpacaConfig;
 use crate::events::{Event, StreamKind};
+use crate::prefs::AppPrefs;
 use crate::types::Quote;
 
 const DATA_URL: &str = "wss://stream.data.alpaca.markets/v2/iex";
-const MAX_BACKOFF_SECS: u64 = 30;
 
 /// Connects to the Alpaca market data WebSocket (IEX free tier), subscribes to
 /// quotes for the given symbols, and emits `Event::MarketQuote` on every tick.
@@ -32,8 +32,9 @@ pub async fn run(
     cancel: CancellationToken,
     config: AlpacaConfig,
     symbol_rx: watch::Receiver<Vec<String>>,
+    prefs: AppPrefs,
 ) {
-    run_inner(tx, cancel, config, symbol_rx, DATA_URL).await
+    run_inner(tx, cancel, config, symbol_rx, DATA_URL, prefs).await
 }
 
 async fn run_inner(
@@ -42,8 +43,12 @@ async fn run_inner(
     config: AlpacaConfig,
     mut symbol_rx: watch::Receiver<Vec<String>>,
     url: &str,
+    prefs: AppPrefs,
 ) {
-    let mut backoff = 1u64;
+    let base_backoff = prefs.reconnect_backoff_base();
+    let max_attempts = prefs.stream.reconnect_max_attempts;
+    let mut backoff = base_backoff;
+    let mut attempt: u32 = 0;
 
     loop {
         tokio::select! {
@@ -69,13 +74,23 @@ async fn run_inner(
                 return;
             }
             Err(e) => {
-                warn!(error = %e, backoff_secs = backoff, "market stream disconnected, reconnecting");
+                attempt += 1;
+                if max_attempts > 0 && attempt >= max_attempts {
+                    warn!(
+                        error = %e,
+                        attempts = attempt,
+                        "market stream reached max reconnect attempts, giving up"
+                    );
+                    let _ = tx.send(Event::StreamDisconnected(StreamKind::Market)).await;
+                    return;
+                }
+                warn!(error = %e, backoff_ms = backoff.as_millis(), "market stream disconnected, reconnecting");
                 let _ = tx.send(Event::StreamDisconnected(StreamKind::Market)).await;
                 tokio::select! {
                     _ = cancel.cancelled() => return,
-                    _ = tokio::time::sleep(Duration::from_secs(backoff)) => {}
+                    _ = tokio::time::sleep(backoff) => {}
                 }
-                backoff = (backoff * 2).min(MAX_BACKOFF_SECS);
+                backoff = (backoff * 2).min(Duration::from_secs(30));
             }
         }
     }
@@ -305,6 +320,7 @@ mod tests {
 mod integration {
     use super::*;
     use crate::config::AlpacaEnv;
+    use crate::prefs::AppPrefs;
     use futures::SinkExt;
     use tokio::sync::{mpsc, watch};
     use tokio_tungstenite::{accept_async, tungstenite::Message};
@@ -541,7 +557,15 @@ mod integration {
 
         let url2 = url.clone();
         tokio::spawn(async move {
-            run_inner(tx, cancel2, test_config(), sym_rx, &url2).await;
+            run_inner(
+                tx,
+                cancel2,
+                test_config(),
+                sym_rx,
+                &url2,
+                AppPrefs::default(),
+            )
+            .await;
         });
 
         let mut saw_disconnect = false;

--- a/src/update.rs
+++ b/src/update.rs
@@ -48,6 +48,17 @@ pub fn update(app: &mut App, event: Event) {
             app.quotes.insert(q.symbol.clone(), q);
         }
         Event::TradeUpdate(o) => {
+            if app.prefs.notifications.fill_notifications_enabled
+                && (o.status == "filled" || o.status == "partially_filled")
+            {
+                let qty = o
+                    .filled_qty
+                    .parse::<f64>()
+                    .map(|q| format!("{}", q))
+                    .unwrap_or_else(|_| o.filled_qty.clone());
+                let msg = format!("Fill: {} {} {}", o.side, qty, o.symbol);
+                app.push_fill_notification(msg);
+            }
             if let Some(existing) = app.orders.iter_mut().find(|x| x.id == o.id) {
                 *existing = o;
             } else {
@@ -115,7 +126,7 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         KeyCode::Tab => app.active_tab = app.active_tab.next(),
         KeyCode::BackTab => app.active_tab = app.active_tab.prev(),
         KeyCode::Char('r') => {
-            app.status_msg = StatusMessage::transient("Refreshing…");
+            app.push_transient_status("Refreshing…");
             app.refresh_notify.notify_one();
         }
         _ => handle_panel_key(app, key),
@@ -458,7 +469,10 @@ mod tests {
 
     #[test]
     fn status_msg_transient_has_expiry() {
-        let msg = crate::app::StatusMessage::transient("Submitting order…");
+        let msg = crate::app::StatusMessage::with_ttl(
+            "Submitting order…",
+            std::time::Duration::from_secs(3),
+        );
         assert!(!msg.text.is_empty());
         assert!(
             msg.expires_at.is_some(),
@@ -812,6 +826,7 @@ mod tests {
                 env: AlpacaEnv::Paper,
                 dry_run: false,
             },
+            crate::prefs::AppPrefs::default(),
             std::sync::Arc::new(tokio::sync::Notify::new()),
             command_tx,
             symbol_tx,
@@ -959,6 +974,7 @@ mod tests {
                 env: AlpacaEnv::Paper,
                 dry_run: false,
             },
+            crate::prefs::AppPrefs::default(),
             std::sync::Arc::new(tokio::sync::Notify::new()),
             command_tx,
             symbol_tx,
@@ -989,6 +1005,7 @@ mod tests {
                 env: AlpacaEnv::Paper,
                 dry_run: false,
             },
+            crate::prefs::AppPrefs::default(),
             std::sync::Arc::new(tokio::sync::Notify::new()),
             command_tx,
             symbol_tx,


### PR DESCRIPTION
## Summary

Implements #61 — persist user preferences to `~/.config/alpaca-trader/config.toml` using TOML, with all downstream consumers reading from an `AppPrefs` struct.

## Changes

- **`src/prefs.rs`** (new): `AppPrefs` struct with six sections (`[app]`, `[ui]`, `[stream]`, `[notifications]`, `[safety]`, `[proxy]`), plus `load()`, `load_from()`, `write_to()`, `to_toml_string()` and duration helpers
- **`src/app.rs`**: Replace `StatusMessage::transient()` with `with_ttl(text, Duration)`; add `prefs: AppPrefs` field to `App`; add `push_transient_status()` / `push_fill_notification()` helpers
- **`src/handlers/rest.rs`**: Accept `AppPrefs` param; use `prefs.refresh_interval()` instead of hardcoded 5 s
- **`src/stream/market.rs`** / **`account.rs`**: Accept `AppPrefs`; configurable reconnect backoff base and max attempts (0 = unlimited)
- **`src/input/watchlist.rs`**: Gate watchlist-remove confirm modal on `prefs.safety.confirm_watchlist_remove`
- **`src/update.rs`**: Fill notifications on `TradeUpdate` gated on `prefs.notifications.fill_notifications_enabled`
- **`src/main.rs`**: Load prefs at startup; use `prefs.app.default_env` as fallback for environment selection

## Testing

- 7 unit tests in `src/prefs.rs` covering defaults, round-trip serialization, partial TOML, and duration helpers
- All 369 existing tests continue to pass

Closes #61