### PR TITLE
feat: add Windows build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,12 @@ jobs:
           RUSTDOCFLAGS: "--cfg docsrs -D warnings"
 
   coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
+    name: Coverage (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -82,3 +86,4 @@ jobs:
       - uses: codecov/codecov-action@v6
         with:
           files: ./coverage.lcov
+          flags: ${{ runner.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ rpassword  = "7"
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender   = "0.2"
-syslog             = "7"
 dirs               = "6"
 
 # Platform-conditional keychain storage (no C-library dependency on any platform)
@@ -65,6 +64,9 @@ keyring = { version = "3", features = ["windows-native"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 # linux-native uses kernel keyutils — cross-compiles cleanly; no libdbus required
 keyring = { version = "3", features = ["linux-native"] }
+
+[target.'cfg(unix)'.dependencies]
+syslog = "7"
 
 [dev-dependencies]
 wiremock   = "0.6"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,11 +6,21 @@ coverage:
         threshold: 5%
     patch:
       default:
-        # Platform-specific code (Windows, macOS) is compiled conditionally and
-        # cannot be covered on the Linux CI runner. Allow patch coverage to be
-        # up to 20 percentage points below the overall project coverage.
         target: auto
-        threshold: 20%
+        threshold: 5%
+
+# Coverage is collected from both Linux and Windows runners so that
+# platform-specific code paths (#[cfg(unix)] and #[cfg(target_os = "windows")])
+# are each instrumented on their native OS.
+flags:
+  Linux:
+    paths:
+      - src/
+    carryforward: true
+  Windows:
+    paths:
+      - src/
+    carryforward: true
 
 ignore:
   - "src/main.rs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        # Platform-specific code (Windows, macOS) is compiled conditionally and
+        # cannot be covered on the Linux CI runner. Allow patch coverage to be
+        # up to 20 percentage points below the overall project coverage.
+        target: auto
+        threshold: 20%
+
+ignore:
+  - "src/main.rs"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -9,10 +9,12 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 
 // ── Syslog layer ──────────────────────────────────────────────────────────────
 
+#[cfg(unix)]
 struct MessageVisitor {
     message: String,
 }
 
+#[cfg(unix)]
 impl tracing::field::Visit for MessageVisitor {
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
         if field.name() == "message" {
@@ -177,14 +179,18 @@ pub(crate) fn log_dir_from(home: Option<std::path::PathBuf>) -> std::path::PathB
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    #[cfg(unix)]
     use std::sync::{Arc, Mutex};
+    #[cfg(unix)]
     use tracing_subscriber::layer::SubscriberExt;
 
     // ── Helper: run a closure under a per-thread subscriber that captures
     //    whatever MessageVisitor extracts from each tracing event. ─────────────
 
+    #[cfg(unix)]
     struct MessageCapture(Arc<Mutex<String>>);
 
+    #[cfg(unix)]
     impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for MessageCapture {
         fn on_event(
             &self,
@@ -201,6 +207,7 @@ mod tests {
 
     /// Run `f` under a thread-local subscriber that records the last captured
     /// message into the returned string. Does not touch the global subscriber.
+    #[cfg(unix)]
     fn capture<F: FnOnce()>(f: F) -> String {
         let captured = Arc::new(Mutex::new(String::new()));
         let sub = tracing_subscriber::registry().with(MessageCapture(Arc::clone(&captured)));
@@ -212,6 +219,7 @@ mod tests {
     // ── MessageVisitor ────────────────────────────────────────────────────────
 
     #[test]
+    #[cfg(unix)]
     fn message_visitor_record_debug_captures_message() {
         // tracing!("text") records the message via record_debug
         let msg = capture(|| tracing::info!("hello from test"));
@@ -219,6 +227,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn message_visitor_record_debug_non_message_field_is_ignored() {
         // count = 42 exercises the record_debug non-"message" branch;
         // the text part still gets captured.
@@ -227,6 +236,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn message_visitor_record_str_captures_explicit_message_field() {
         // message = "string" uses record_str for the message field
         let msg = capture(|| tracing::info!(message = "explicit string"));
@@ -234,6 +244,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn message_visitor_record_str_non_message_field_is_ignored() {
         // name = "alice" is a &str that is NOT the "message" field;
         // exercises the record_str non-"message" branch.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,8 +1,11 @@
 //! Application logging setup using `tracing` and `tracing-appender`.
+#[cfg(unix)]
 use std::sync::Mutex;
 
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+#[cfg(unix)]
+use tracing_subscriber::Layer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 // ── Syslog layer ──────────────────────────────────────────────────────────────
 
@@ -23,10 +26,12 @@ impl tracing::field::Visit for MessageVisitor {
     }
 }
 
+#[cfg(unix)]
 struct SyslogLayer {
     logger: Mutex<syslog::Logger<syslog::LoggerBackend, syslog::Formatter3164>>,
 }
 
+#[cfg(unix)]
 impl<S: tracing::Subscriber> Layer<S> for SyslogLayer {
     fn on_event(
         &self,
@@ -89,25 +94,31 @@ pub(crate) fn init_with_dir(log_dir: &std::path::Path) -> anyhow::Result<WorkerG
         EnvFilter::new("info,alpaca_trader_rs=debug,tokio=warn,crossterm=warn,ratatui=warn")
     });
 
-    // Optional syslog layer — silently skipped if the socket is unavailable
-    let syslog_layer = syslog::unix(syslog::Formatter3164 {
-        facility: syslog::Facility::LOG_USER,
-        hostname: None,
-        process: "alpaca-trader".into(),
-        pid: std::process::id(),
-    })
-    .ok()
-    .map(|logger| SyslogLayer {
-        logger: Mutex::new(logger),
-    });
-
     let registry = tracing_subscriber::registry().with(filter).with(file_layer);
 
-    if let Some(syslog) = syslog_layer {
-        registry.with(syslog).try_init().ok();
-    } else {
-        registry.try_init().ok();
+    #[cfg(unix)]
+    {
+        // Optional syslog layer — silently skipped if the socket is unavailable
+        let syslog_layer = syslog::unix(syslog::Formatter3164 {
+            facility: syslog::Facility::LOG_USER,
+            hostname: None,
+            process: "alpaca-trader".into(),
+            pid: std::process::id(),
+        })
+        .ok()
+        .map(|logger| SyslogLayer {
+            logger: Mutex::new(logger),
+        });
+
+        if let Some(syslog) = syslog_layer {
+            registry.with(syslog).try_init().ok();
+        } else {
+            registry.try_init().ok();
+        }
     }
+
+    #[cfg(not(unix))]
+    registry.try_init().ok();
 
     Ok(guard)
 }
@@ -129,7 +140,13 @@ pub(crate) fn log_dir_from(home: Option<std::path::PathBuf>) -> std::path::PathB
     #[cfg(target_os = "macos")]
     let platform_dir = home.map(|h| h.join("Library/Logs/alpaca-trader"));
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    let platform_dir = {
+        let _ = home; // unused on Windows; log dir comes from %LOCALAPPDATA%
+        dirs::data_local_dir().map(|d| d.join("alpaca-trader").join("logs"))
+    };
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     let platform_dir = home.map(|h| h.join(".local/share/alpaca-trader/logs"));
 
     if let Some(dir) = platform_dir {
@@ -226,6 +243,7 @@ mod tests {
 
     // ── SyslogLayer ───────────────────────────────────────────────────────────
 
+    #[cfg(unix)]
     fn make_syslog_layer() -> Option<SyslogLayer> {
         syslog::unix(syslog::Formatter3164 {
             facility: syslog::Facility::LOG_USER,
@@ -240,6 +258,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn syslog_layer_empty_message_returns_early_without_panic() {
         let Some(layer) = make_syslog_layer() else {
             return; // syslog socket unavailable — skip
@@ -250,6 +269,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn syslog_layer_dispatches_error_level() {
         let Some(layer) = make_syslog_layer() else {
             return;
@@ -259,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn syslog_layer_dispatches_warn_level() {
         let Some(layer) = make_syslog_layer() else {
             return;
@@ -268,6 +289,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn syslog_layer_dispatches_info_level() {
         let Some(layer) = make_syslog_layer() else {
             return;
@@ -277,6 +299,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn syslog_layer_dispatches_debug_level() {
         let Some(layer) = make_syslog_layer() else {
             return;
@@ -339,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     fn home_present_returns_xdg_log_path() {
         let dir = log_dir_from(Some(PathBuf::from("/home/tester")));
         assert_eq!(
@@ -349,9 +372,28 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     fn home_present_last_component_is_logs() {
         let dir = log_dir_from(Some(PathBuf::from("/home/alice")));
+        assert_eq!(dir.file_name().unwrap(), "logs");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn home_present_returns_windows_log_path() {
+        // On Windows the home parameter is ignored; log dir comes from %LOCALAPPDATA%
+        let dir = log_dir_from(Some(PathBuf::from("C:\\Users\\tester")));
+        let dir_str = dir.to_str().unwrap_or("");
+        assert!(
+            dir_str.contains("alpaca-trader"),
+            "expected alpaca-trader in Windows log path, got: {dir_str}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn home_present_last_component_is_logs_on_windows() {
+        let dir = log_dir_from(Some(PathBuf::from("C:\\Users\\alice")));
         assert_eq!(dir.file_name().unwrap(), "logs");
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -397,7 +397,10 @@ mod tests {
         assert_eq!(dir.file_name().unwrap(), "logs");
     }
 
+    // On Windows, log_dir_from(None) returns the %LOCALAPPDATA% path rather than
+    // the CWD/temp fallback because the Windows branch ignores the `home` argument.
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn no_home_falls_back_to_non_panicking_dir() {
         let dir = log_dir_from(None);
         assert!(
@@ -408,11 +411,30 @@ mod tests {
     }
 
     #[test]
-    fn no_home_fallback_is_absolute() {
+    #[cfg(target_os = "windows")]
+    fn no_home_returns_localappdata_dir_on_windows() {
+        // On Windows the home arg is unused; log dir comes from %LOCALAPPDATA%.
+        let dir = log_dir_from(None);
+        let dir_str = dir.to_str().unwrap_or("");
+        assert!(
+            dir_str.contains("alpaca-trader"),
+            "expected alpaca-trader in Windows log path, got: {dir_str}"
+        );
+        assert_eq!(
+            dir.file_name().unwrap(),
+            "logs",
+            "last component should be 'logs', got: {dir_str}"
+        );
+    }
+
+    #[test]
+    fn no_home_result_is_absolute() {
+        // Every platform must return an absolute path regardless of whether
+        // the home arg is None.
         let dir = log_dir_from(None);
         assert!(
             dir.is_absolute(),
-            "fallback log dir should be absolute, got: {}",
+            "log dir should be absolute, got: {}",
             dir.display()
         );
     }


### PR DESCRIPTION
## Summary

Implements issue #63 — full Windows support so the app compiles, passes tests, and ships as Windows binaries.

## Changes

### `Cargo.toml`
- Move `syslog = "7"` from `[dependencies]` to `[target.'cfg(unix)'.dependencies]` — syslog v7 uses Unix domain sockets and cannot compile on Windows

### `src/logging.rs`
- Gate `SyslogLayer` struct and its `Layer<S>` impl behind `#[cfg(unix)]`
- Gate `syslog::unix()` call inside `init_with_dir` behind `#[cfg(unix)]`; on non-unix the registry is initialised without a syslog layer
- Add Windows log directory path: `dirs::data_local_dir().join("alpaca-trader/logs")` (`%LOCALAPPDATA%\alpaca-trader\logs`)
- Narrow `#[cfg(not(target_os="macos"))]` tests to `#[cfg(all(not(target_os="macos"), not(target_os="windows")))]` so they no longer assert a Linux path on Windows
- Add two Windows-specific log dir tests gated behind `#[cfg(target_os="windows")]`
- Gate all `SyslogLayer` unit tests behind `#[cfg(unix)]`

### `.github/workflows/ci.yml`
- Add `windows-latest` to the test matrix so every PR is verified to compile and pass tests on Windows

### `.github/workflows/release.yml`
- Add `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` release targets so Windows `.zip` artifacts are uploaded on tag push

## Tests

All 447 tests pass on macOS. Windows-specific tests are gated behind `#[cfg(target_os="windows")]` and will run in CI.

Closes #63