### PR TITLE
docs: add CONTRIBUTING and CODE_OF_CONDUCT guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+amouroug.dev@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to alpaca-trader-rs
+
+First off, thank you for considering contributing to `alpaca-trader-rs`! It's people like you that make open source such a great community.
+
+Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the `alpaca-trader-rs` [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## Getting Started
+
+1. **Fork the repository** on GitHub.
+2. **Clone your fork** locally: `git clone https://github.com/YOUR_USERNAME/alpaca-trader-rs.git`
+3. **Set up credentials** following [docs/credentials-setup.md](docs/credentials-setup.md).
+4. **Create a branch** for your feature or bug fix: `git checkout -b my-new-feature`
+
+## Development Workflow
+
+### Rust Ecosystem Standards
+
+We rely on the standard Rust tooling to maintain code quality:
+
+*   **Formatting:** Run `cargo fmt` to format your code before committing. CI will fail if the code is not formatted.
+*   **Linting:** Run `cargo clippy -- -D warnings` to catch common mistakes and improve your Rust code. Please address all warnings.
+*   **Building:** `cargo build` should compile without errors.
+
+### Testing
+
+Tests are a crucial part of this project. **All new features and bug fixes must include tests.**
+
+*   Run the test suite locally: `cargo test`
+*   For an overview of our testing strategy, including mock patterns for the API client, please read [docs/testing.md](docs/testing.md).
+*   If you are fixing a bug, please write a test that reproduces the bug before fixing it, ensuring it fails first and then passes with your fix.
+
+### Architecture
+
+This application is built using a unidirectional data flow (TEA - The Elm Architecture) adapted for Rust.
+
+*   **State:** The `App` struct is the single source of truth.
+*   **Events:** The `Event` enum represents all possible state changes.
+*   **Update:** The `update` function handles state transitions based on incoming events.
+*   **View:** The UI is rendered purely as a function of the current state.
+
+Before contributing significant architectural changes or new UI panels, please familiarize yourself with [docs/architecture.md](docs/architecture.md) and [docs/ui-mockups.md](docs/ui-mockups.md).
+
+## Submitting a Pull Request
+
+1. **Commit your changes:** Write clear, concise commit messages.
+2. **Push to your fork:** `git push origin my-new-feature`
+3. **Open a Pull Request (PR):**
+    *   Describe the changes you've made in detail.
+    *   Link any relevant issues (e.g., "Fixes #123").
+    *   Ensure CI checks pass (formatting, clippy, tests, and security audits).
+    *   If your PR changes the UI or public API, ensure the relevant documentation in `docs/` or `README.md` is updated.
+
+## Licensing
+
+By contributing to `alpaca-trader-rs`, you agree that your contributions will be dual-licensed under the **MIT License** and the **Apache License, Version 2.0**, matching the rest of the project. See [docs/licensing.md](docs/licensing.md) for more details.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ variables for the active environment are used — the opposing set is ignored.
 
 ---
 
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
+
+---
+
 ## Licensing
 
 Licensed under either of


### PR DESCRIPTION
Introduce comprehensive contributor guidelines and a code of conduct to establish clear community standards and development workflows. Updated README to make these resources easily discoverable.