### PR TITLE
fix(update): redraw immediately on terminal resize

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -372,6 +372,9 @@ pub struct App {
 
     pub status_msg: StatusMessage,
     pub should_quit: bool,
+    /// Set to `true` by the `Event::Resize` handler to request an immediate
+    /// redraw before the next tick. Cleared by the main loop after drawing.
+    pub needs_redraw: bool,
 
     /// `true` while the market-data WebSocket is connected and authenticated.
     pub market_stream_ok: bool,
@@ -418,6 +421,7 @@ impl App {
             searching: false,
             status_msg: StatusMessage::persistent("Loading…"),
             should_quit: false,
+            needs_redraw: false,
             market_stream_ok: false,
             account_stream_ok: false,
             hit_areas: HitAreas::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,6 +229,14 @@ async fn main() -> anyhow::Result<()> {
             Some(event) => update(&mut app, event),
         }
 
+        // If the update requested an immediate redraw (e.g. terminal resize),
+        // draw again before blocking for the next event so the layout adapts
+        // right away instead of waiting for the next periodic tick.
+        if app.needs_redraw {
+            app.needs_redraw = false;
+            terminal.draw(|f| ui::render(f, &mut app))?;
+        }
+
         if app.should_quit {
             break;
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -13,7 +13,12 @@ pub fn update(app: &mut App, event: Event) {
     match event {
         Event::Input(key) => handle_key(app, key),
         Event::Mouse(m) => handle_mouse(app, m),
-        Event::Resize(_, _) => {}
+        Event::Resize(_, _) => {
+            // Ratatui re-layouts on the next draw, but without an explicit
+            // trigger the UI waits up to 250 ms for the next tick. Request
+            // an immediate redraw so the layout adapts right away.
+            app.needs_redraw = true;
+        }
 
         Event::AccountUpdated(a) => {
             app.account = Some(a);
@@ -195,6 +200,23 @@ mod tests {
     }
 
     // ── Data events ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn resize_event_sets_needs_redraw() {
+        let mut app = make_test_app();
+        assert!(!app.needs_redraw);
+        update(&mut app, Event::Resize(80, 24));
+        assert!(app.needs_redraw, "needs_redraw must be true after resize");
+    }
+
+    #[test]
+    fn resize_event_does_not_quit_or_change_state() {
+        let mut app = make_test_app();
+        update(&mut app, Event::Resize(120, 40));
+        assert!(!app.should_quit);
+        assert_eq!(app.active_tab, Tab::Account);
+        assert!(app.needs_redraw);
+    }
 
     #[test]
     fn account_updated_sets_account_and_pushes_equity() {


### PR DESCRIPTION
## Summary

Fixes #75

`Event::Resize(_, _)` was a silent no-op, leaving the UI potentially clipped after the user resizes their terminal. The layout would only update on the next periodic tick (up to 250 ms).

## Changes

- **`src/app.rs`**: Add `needs_redraw: bool` field to `App` (initialised to `false`)
- **`src/update.rs`**: Handle `Event::Resize` by setting `app.needs_redraw = true`
- **`src/main.rs`**: After each `update()` call, check `needs_redraw` and perform an immediate extra draw before blocking for the next event
- **Tests**: `resize_event_sets_needs_redraw` and `resize_event_does_not_quit_or_change_state`