### PR TITLE
chore(release): prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
+## [0.5.0] — 2026-05-18
+
+Adds a `--dry-run` mode, persistent user preferences, runtime colour-theme switching, Windows
+platform support, and braille line charts throughout the UI. Fixes paper-trading watchlist
+display, market-closed price data, and a silent resize event that left the UI clipped after
+terminal resize. Test count grows from **327 → 449**.
+
+### Added
+
+#### CLI
+- **`--dry-run` flag** — intercepts order submissions and shows them as `[DRY-RUN]` in the status
+  bar without transmitting to Alpaca. All read-only operations (account, positions, watchlist) still
+  hit the configured environment.
+
+#### User Preferences
+- **Persistent TOML config** (`src/prefs.rs`) — preferences are saved to the OS config directory
+  (`~/.config/alpaca-trader/prefs.toml` on Linux/macOS, `%APPDATA%\alpaca-trader\prefs.toml` on
+  Windows). Supported prefs: `app.default_env` (paper/live), `ui.theme`.
+
+#### UI
+- **Runtime colour-theme switching** (`T` key) — cycles between the available colour themes
+  without restarting; theme selection is persisted to `prefs.toml` automatically.
+- **Braille line charts** — equity and intraday price charts upgraded from `Sparkline` to ratatui
+  `Chart` with double-resolution braille canvas, giving a much sharper visual.
+
+#### Platform
+- **Windows support** — full CI matrix (`Test`, `Coverage`) now includes `windows-latest`;
+  platform-conditional code paths for log directory resolution, syslog (unix-only), and keychain.
+
+#### CI / Quality
+- **Windows code coverage** — `cargo-llvm-cov` runs on both `ubuntu-latest` and `windows-latest`;
+  both reports are merged in Codecov with `carryforward: true` flags (`Linux` / `Windows`).
+- **`codecov.yml`** — project and patch thresholds (5%), flag groups defined, `src/main.rs` ignored.
+
+### Fixed
+
+- **Terminal resize ignored** (`src/update.rs`) — `Event::Resize` now sets `app.needs_redraw =
+  true`; the main loop draws an extra frame immediately so the layout adapts without waiting for the
+  next tick (up to 250 ms).
+- **Watchlist paper-trading message** (`src/update.rs`) — a persistent "Watchlists unavailable in
+  paper mode" notice is now shown when the paper endpoint signals the watchlist API is unsupported.
+- **Watchlist price/Change% when market is closed** — REST snapshot data is now used to populate
+  Price and Change% columns even when the market is closed and live quotes are unavailable.
+- **`MessageVisitor` unused-struct warning on Windows** — `MessageVisitor` and all syslog-related
+  helpers are now gated to `#[cfg(unix)]`, eliminating the dead-code warning that failed
+  clippy `-D warnings` on Windows CI.
+
+### Tests
+
+**449 tests total** (up from 327 in v0.4.0):
+
+| Scope | Count |
+|---|---|
+| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 99 |
+| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/ui/`) | 320 |
+| HTTP integration (`tests/client_tests.rs`) | 29 |
+| Doc-tests | 1 |
+
+Coverage additions include:
+- `resize_event_sets_needs_redraw` and `resize_event_does_not_quit_or_change_state`
+- Logging module expanded to ~90% coverage (MessageVisitor, SyslogLayer, log-dir resolution)
+- Orders and Positions UI renderer unit tests
+- Client module improved coverage
+
+---
+
 ## [0.4.0] — 2026-05-12
 
 Adds the About modal, SELL SHORT from positions, up/down arrow navigation in Order Entry dropdowns,
@@ -248,6 +314,7 @@ First release. Ships as both an integratable Rust library and a standalone TUI t
 
 ---
 
+[0.5.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpaca-trader-rs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-trader-rs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ alpaca-trader --paper
 ```bash
 alpaca-trader           # live trading (real money — default)
 alpaca-trader --paper   # paper trading (simulated funds)
+alpaca-trader --dry-run # simulate order submissions (no real orders sent)
 ```
 
 The header badge shows **[PAPER]** in cyan or **[LIVE]** in red at all times.
@@ -120,6 +121,7 @@ alpaca-trader --reset live    # remove live keychain entries
 | `?` | Help overlay |
 | `A` | About overlay |
 | `Esc` | Close modal |
+| `T` | Toggle colour theme |
 | `q` / `Ctrl-C` | Quit |
 
 Full interaction spec (including mouse): [docs/ui-mockups.md](docs/ui-mockups.md)
@@ -132,7 +134,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-alpaca-trader-rs = "0.4"
+alpaca-trader-rs = "0.5"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -276,24 +278,29 @@ variables for the active environment are used — the opposing set is ignored.
 | Feature | Status |
 |---|---|
 | Typed async REST client (`AlpacaClient`) | ✅ |
-| TUI — header, tabs, status bar, sparkline | ✅ |
+| TUI — header, tabs, status bar, braille line charts | ✅ |
 | Account panel with Day P&L, Open P&L, Account # | ✅ |
 | Watchlist panel — Volume, Change%, live search | ✅ |
 | Positions panel with totals footer | ✅ |
 | Orders panel — Open / Filled / Cancelled sub-tabs | ✅ |
 | Order Entry modal with Side, Type, TIF dropdowns (↑/↓) | ✅ |
-| Symbol Detail modal — OHLCV, intraday sparkline, watchlist toggle | ✅ |
+| Symbol Detail modal — OHLCV, intraday chart, watchlist toggle | ✅ |
 | Help and About overlays | ✅ |
 | Paper / Live switching (`--paper` / `--live`) | ✅ |
+| `--dry-run` mode — simulate orders without sending to Alpaca | ✅ |
+| Persistent user preferences (TOML config file) | ✅ |
+| Runtime colour theme switching (`T` key) | ✅ |
 | SELL SHORT from Positions panel (`s` key) | ✅ |
 | Header market-session state (PRE-MARKET / OPEN / AFTER-HOURS / CLOSED) | ✅ |
+| Instant UI redraw on terminal resize | ✅ |
 | WebSocket market data + account/trade streaming | ✅ |
 | Live order submission and cancellation | ✅ |
 | Watchlist add / remove (wired to REST) | ✅ |
 | OS-native keychain credential storage | ✅ |
 | Interactive first-run credential prompt | ✅ |
-| GitHub Actions CI, security audit, Codecov, release builds | ✅ |
-| 327 tests (unit + integration) | ✅ |
+| Windows, macOS, and Linux support | ✅ |
+| GitHub Actions CI, security audit, Codecov (Linux + Windows), release builds | ✅ |
+| 449 tests (unit + integration) | ✅ |
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,149 +1,115 @@
-# Release Notes — v0.4.0
+# Release Notes — v0.5.0
 
-**Release date:** 2026-05-12
+**Release date:** 2026-05-18
 **MSRV:** Rust 1.88+
-**Previous release:** [v0.3.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.3.0)
+**Previous release:** [v0.4.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.4.0)
 
 ---
 
 ## Overview
 
-v0.4.0 is a UX and information-density release. The Account panel gains Day P&L, Open P&L, and
-Account #. The Watchlist replaces Ask/Bid with Volume and Change%. The Symbol Detail modal adds
-full OHLCV data and an intraday sparkline. The header correctly identifies pre-market and
-after-hours trading sessions. Three new keyboard shortcuts round out the experience: `s` for
-SELL SHORT from the Positions panel, `↑`/`↓` for cycling dropdown values in Order Entry, and `A`
-for a new About modal. A longstanding bug that left the intraday sparkline permanently on
-"Loading…" is fixed.
+v0.5.0 is a quality, portability, and UX release. The five headline changes are:
 
-The test suite grows from **198 → 327 tests**.
+1. **`--dry-run` mode** — test order workflows without sending a single real order.
+2. **Persistent user preferences** — theme and environment settings survive restarts.
+3. **Runtime colour-theme switching** (`T` key) — switch themes live and have the choice remembered.
+4. **Windows support** — full CI build, test, and code-coverage matrix on `windows-latest`.
+5. **Braille line charts** — sharper double-resolution equity and intraday charts.
+
+Four bug fixes land alongside: the terminal resize no-op, paper-trading watchlist messaging,
+market-closed price data, and a Windows clippy warning in the logging module.
+
+Test count grows from **327 → 449 tests**.
 
 ---
 
 ## What's New
 
-### About Modal (`A`)
+### `--dry-run` Mode
 
-A new global `A` key opens an About overlay that shows the app name, version, author contact
-details, project and documentation URLs, and license — all embedded at compile time via `env!`
-macros so no runtime I/O is needed. Any key press closes it.
+Pass `--dry-run` to intercept all order submissions before they reach Alpaca. The order is shown
+as `[DRY-RUN]` in the status bar and logged, but no network request is made. Read-only operations
+(account data, positions, watchlist, quotes) are unaffected.
 
-```
-╔═ About alpaca-trader-rs ══════════════════╗
-║                                           ║
-║   alpaca-trader-rs  v0.4.0                ║
-║                                           ║
-║   Alpaca Markets TUI trading terminal     ║
-║   and async REST client library.          ║
-║                                           ║
-║  ── Author ─────────────────────────────  ║
-║   Arunkumar Mourougappane                 ║
-║   amouroug.dev@gmail.com                  ║
-║   github.com/arunkumar-mourougappane      ║
-║   anengineersrant.com                     ║
-║                                           ║
-║  ── Project ────────────────────────────  ║
-║   github.com/arunkumar-mourougappane/     ║
-║     alpaca-trader-rs                      ║
-║   docs.rs/alpaca-trader-rs                ║
-║                                           ║
-║  ── License ────────────────────────────  ║
-║   MIT OR Apache-2.0                       ║
-║                                           ║
-║              Press any key to close       ║
-╚═══════════════════════════════════════════╝
+```bash
+alpaca-trader --paper --dry-run   # safe sandbox — simulated env + no real orders
+alpaca-trader --dry-run           # live data, intercepted orders
 ```
 
-### Symbol Detail — OHLCV + Intraday Sparkline + Watchlist Toggle
+The dry-run state is visible in the header so it's impossible to forget it is active.
 
-The Symbol Detail modal (`Enter` on a Watchlist or Positions row) now shows a full OHLCV snapshot
-(Open, High, Low, Volume) alongside the existing bid/ask, an intraday 1-minute price sparkline,
-and a `w` key to add or remove the symbol from the watchlist without leaving the modal.
+### Persistent User Preferences
 
-The longstanding bug that caused the sparkline to remain on "Loading…" indefinitely is fixed —
-intraday bars are now stored and rendered correctly.
+A `prefs.toml` file is created on first run in the OS config directory:
 
-### Account Panel — Day P&L, Open P&L, Account #
-
-The Account panel displays two new P&L fields (green if positive, red if negative) and the
-account number pulled from the Alpaca account response:
-
-```
-Portfolio Value   $125,432.18     Day P&L   +$843.22  (+0.68%)
-Buying Power       $48,210.00     Open P&L  +$1,204.50
-Cash               $48,210.00     Account # PA1234567
-Long Market Value  $77,222.18     Status    ACTIVE
-```
-
-### Watchlist — Volume and Change%
-
-The Ask and Bid price columns have been replaced with Volume (shares traded) and Change%
-(day-over-day percentage change), giving a more actionable at-a-glance view:
-
-```
-Symbol   Name                     Price      Change      Volume
-INTC     Intel Corporation        $24.18    -0.42%      45.2M
-AMD      Advanced Micro Devices  $142.85    +1.24%      28.7M
-```
-
-Change% and Price are colour-coded green (positive) / red (negative).
-
-### Header — PRE-MARKET / AFTER-HOURS State
-
-The market clock in the header now correctly identifies and displays all four session states:
-
-| State | Display |
+| Platform | Path |
 |---|---|
-| Pre-market (04:00–09:30 ET) | `PRE-MARKET` |
-| Regular session (09:30–16:00 ET) | `OPEN` |
-| After-hours (16:00–20:00 ET) | `AFTER-HOURS` |
-| Overnight / weekend | `CLOSED` |
+| Linux / macOS | `~/.config/alpaca-trader/prefs.toml` |
+| Windows | `%APPDATA%\alpaca-trader\prefs.toml` |
 
-### `s` Key — SELL SHORT from Positions Panel
+Current persisted settings:
 
-From the Positions panel, `s` opens the Order Entry modal pre-filled with the selected symbol and
-the SELL SHORT side (existing `o` continues to open SELL). This mirrors the symbol-detail modal
-which also offers `o` / `s`.
+| Key | Default | Description |
+|---|---|---|
+| `app.default_env` | `"live"` | Which environment to connect to when `--paper` is not passed |
+| `ui.theme` | `"default"` | Active colour theme name |
 
-### ↑ / ↓ Arrow Keys in Order Entry Dropdowns
+The file is created automatically with defaults on first run and never requires manual editing.
 
-The Up and Down arrow keys now cycle through values in the Side, OrderType, and TimeInForce
-dropdown fields inside the Order Entry modal — mirroring the existing Left/Right behaviour for
-users who prefer vertical navigation.
+### Runtime Colour-Theme Switching (`T` key)
+
+Press `T` at any time to cycle through the available colour themes. The selection is written to
+`prefs.toml` immediately so it persists across restarts. The key binding is documented in the Help
+overlay (`?`).
+
+### Windows Support
+
+The full CI pipeline now runs on `windows-latest` in addition to the existing `ubuntu-latest` and
+`macos-latest` runners:
+
+- **Build** — `cargo build --release` succeeds on Windows with no feature flags needed
+- **Tests** — all 449 tests pass on Windows (platform-conditional tests skip unix-only paths)
+- **Code coverage** — `cargo-llvm-cov` runs on both Linux and Windows; both reports are uploaded to
+  Codecov with separate `Linux` / `Windows` flags and merged into the coverage badge
+
+### Braille Line Charts
+
+The equity sparkline in the Account panel and the intraday price chart in the Symbol Detail modal
+have been upgraded from ratatui's `Sparkline` widget to a full `Chart` with a braille canvas.
+Braille cells pack 2×4 dots per cell, giving roughly double the effective resolution at the same
+terminal width.
 
 ---
 
 ## Bug Fixes
 
-| Fix | Description |
+| Fix | Details |
 |---|---|
-| Intraday sparkline stuck on "Loading…" | `Event::IntradayBarsReceived` now correctly stores bars per symbol; Symbol Detail renders them on open |
+| Terminal resize silently ignored | `Event::Resize` now sets `needs_redraw = true`; the main loop draws an extra frame before blocking for the next event, so layout adapts immediately instead of waiting up to 250 ms for the next tick |
+| Paper-trading watchlist shows blank panel | A persistent info message ("Watchlists unavailable in paper mode") is now shown when the paper endpoint returns a 422, matching the behaviour users expect from the `--paper` flag |
+| Price and Change% blank when market is closed | Watchlist rows now fall back to REST snapshot data for price and daily change when the market is closed and live quotes are unavailable |
+| `MessageVisitor` dead-code warning on Windows | `struct MessageVisitor` and all syslog helpers are gated to `#[cfg(unix)]`; Windows builds are now clippy-clean with `-D warnings` |
 
 ---
 
 ## Tests
 
-**327 tests total** (up from 198 in v0.3.0):
+**449 tests total** (up from 327 in v0.4.0):
 
-| Scope | Count | Highlights |
+| Scope | Count | Notable additions |
 |---|---|---|
-| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 55 | Serde round-trips, env-var resolution, WebSocket integration |
-| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/ui/`) | 249 | All new features + navigation + mouse modal handler |
-| HTTP integration (`tests/client_tests.rs`) | 23 | All `AlpacaClient` methods against a `wiremock` mock |
-
-New test coverage includes:
-- Orders, Positions, and Watchlist panel `j`/`k`/`g`/`G` navigation and edge cases
-- Mouse modal handler — submit button, Side thirds, OrderType halves, Confirm yes/no buttons
-- About and Symbol Detail render paths
-- Dashboard `render_status()` helper for all tab contexts
-- Search handler backspace, empty-backspace, and character-append selection reset
+| Library (`src/stream/`, `src/types.rs`, `src/config.rs`) | 99 | Logging module ~90% coverage; client coverage improvements |
+| Binary crate (`src/app.rs`, `src/update.rs`, `src/handlers/`, `src/ui/`) | 320 | Resize handler, theme switching, prefs persistence, UI renderer tests |
+| HTTP integration (`tests/client_tests.rs`) | 29 | Additional REST method coverage |
+| Doc-tests | 1 | `with_dry_run` example |
 
 ---
 
 ## No Breaking Changes
 
-v0.4.0 is fully backwards-compatible with v0.3.0. All credential resolution, CLI flags,
-environment variables, and library API are unchanged.
+v0.5.0 is fully backwards-compatible with v0.4.0. All credential resolution, CLI flags,
+environment variables, and library API are unchanged. The only new required file is `prefs.toml`,
+which is created automatically with safe defaults.
 
 ---
 
@@ -156,6 +122,9 @@ cd alpaca-trader-rs
 # First run — app prompts for credentials and offers to save to keychain
 ./run.sh --paper   # paper trading (simulated funds — recommended for first run)
 ./run.sh           # live trading  (real money — default)
+
+# Try out dry-run mode without any risk
+./run.sh --paper --dry-run
 ```
 
 Or configure via `.env`:

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1074,8 +1074,9 @@ mod tests {
     #[test]
     fn render_about_shows_version() {
         let output = render_about_to_string();
+        let expected = format!("v{}", env!("CARGO_PKG_VERSION"));
         assert!(
-            output.contains("v0.4.0"),
+            output.contains(&expected),
             "About modal should display the version"
         );
     }


### PR DESCRIPTION
## v0.5.0 Release Preparation

Bumps version to `0.5.0` and updates all release documentation.

### Changes
- **`Cargo.toml`**: `0.4.0` → `0.5.0`
- **`CHANGELOG.md`**: adds v0.5.0 section (features, fixes, test count 327 → 449)
- **`RELEASE_NOTES.md`**: replaces v0.4.0 notes with v0.5.0 release notes
- **`README.md`**: adds `T` key binding, `--dry-run` usage, updates features table and test count to 449

### v0.5.0 Headlines
- `--dry-run` flag for safe order testing
- Persistent TOML user preferences
- Runtime colour-theme switching (`T` key)
- Windows CI + coverage support
- Braille line charts (higher resolution)
- Fix: terminal resize silently ignored
- Fix: paper-trading watchlist blank panel
- Fix: market-closed price/Change% blank