### PR TITLE
feat(app): replace single status_msg with FIFO status_queue

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ratatui::layout::Rect;
 
-/// A status bar message that may auto-expire.
+/// Maximum number of status messages held in the queue at once.
+const STATUS_QUEUE_CAP: usize = 5;
+
 ///
 /// Transient messages (e.g. "Order submitted", "Refreshing…") carry a TTL and are
 /// cleared automatically on the next `Tick` after they expire. Persistent messages (errors,
@@ -30,17 +32,6 @@ impl StatusMessage {
             text: text.into(),
             expires_at: None,
         }
-    }
-
-    /// Returns `true` if the message text is empty (nothing to display).
-    pub fn is_empty(&self) -> bool {
-        self.text.is_empty()
-    }
-
-    /// Clears the message text and removes any expiry.
-    pub fn clear(&mut self) {
-        self.text.clear();
-        self.expires_at = None;
     }
 }
 
@@ -371,7 +362,7 @@ pub struct App {
     pub search_query: String,
     pub searching: bool,
 
-    pub status_msg: StatusMessage,
+    pub status_queue: VecDeque<StatusMessage>,
     pub should_quit: bool,
     /// Set to `true` by the `Event::Resize` handler to request an immediate
     /// redraw before the next tick. Cleared by the main loop after drawing.
@@ -420,7 +411,7 @@ impl App {
             modal: None,
             search_query: String::new(),
             searching: false,
-            status_msg: StatusMessage::persistent("Loading…"),
+            status_queue: VecDeque::new(),
             should_quit: false,
             needs_redraw: false,
             market_stream_ok: false,
@@ -493,14 +484,36 @@ impl App {
         }
     }
 
+    /// Enqueues a status message.
+    ///
+    /// If the queue is already at [`STATUS_QUEUE_CAP`], the oldest entry is
+    /// dropped from the front to make room. Persistent (no-TTL) messages that
+    /// are already at the front are not displaced — transient messages are
+    /// appended behind them so the persistent message stays visible.
+    pub fn push_status(&mut self, msg: StatusMessage) {
+        if self.status_queue.len() >= STATUS_QUEUE_CAP {
+            self.status_queue.pop_front();
+        }
+        self.status_queue.push_back(msg);
+    }
+
+    /// Returns the text of the current (front) status message, or `""` if the
+    /// queue is empty or the front message has no text.
+    pub fn current_status_text(&self) -> &str {
+        self.status_queue
+            .front()
+            .map(|m| m.text.as_str())
+            .unwrap_or("")
+    }
+
     /// Sets a transient status message using the TTL from user preferences.
     pub fn push_transient_status(&mut self, text: impl Into<String>) {
-        self.status_msg = StatusMessage::with_ttl(text, self.prefs.status_ttl());
+        self.push_status(StatusMessage::with_ttl(text, self.prefs.status_ttl()));
     }
 
     /// Sets a fill-notification status message using the fill TTL from user preferences.
     pub fn push_fill_notification(&mut self, text: impl Into<String>) {
-        self.status_msg = StatusMessage::with_ttl(text, self.prefs.fill_ttl());
+        self.push_status(StatusMessage::with_ttl(text, self.prefs.fill_ttl()));
     }
 
     /// Advances to the next theme in the cycle (Default → Dark → High-contrast → Default).

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -32,7 +32,9 @@ pub(crate) fn send_command(app: &mut App, cmd: Command, success_msg: impl Into<S
         }
         Err(TrySendError::Closed(_)) => {
             tracing::error!("command channel closed; command handler has stopped");
-            app.status_msg = StatusMessage::persistent("Command handler stopped — restart app");
+            app.push_status(StatusMessage::persistent(
+                "Command handler stopped — restart app",
+            ));
         }
     }
 }

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -96,7 +96,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         let market_open = app.clock.as_ref().map(|c| c.is_open).unwrap_or(true);
                         if let Some(err) = crate::input::validate(&state, buying_power, market_open)
                         {
-                            app.status_msg = StatusMessage::persistent(err);
+                            app.push_status(StatusMessage::persistent(err));
                             app.modal = Some(Modal::OrderEntry(state));
                             return;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,8 @@ async fn main() -> anyhow::Result<()> {
         command_tx,
         symbol_tx,
     );
+    // Show "Loading…" while initial data is being fetched.
+    app.push_status(app::StatusMessage::persistent("Loading…"));
 
     // Event channel
     let (tx, mut rx) = mpsc::channel::<Event>(256);

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -115,10 +115,10 @@ pub fn render_status(frame: &mut Frame, area: Rect, app: &App) {
         Tab::Orders => " j/k:Navigate  o:New  c:Cancel  1-3:Filter  T:Theme  A:About  ?:Help  q:Quit",
     };
 
-    let status = if app.status_msg.is_empty() {
+    let status = if app.current_status_text().is_empty() {
         panel_hints.to_string()
     } else {
-        format!("  {}  │{}", app.status_msg.text, panel_hints)
+        format!("  {}  │{}", app.current_status_text(), panel_hints)
     };
 
     let para = Paragraph::new(status).style(c.dim_style());
@@ -243,6 +243,50 @@ mod tests {
         assert!(
             !output.contains("[DRY-RUN]"),
             "header must not show [DRY-RUN] badge when dry_run is false"
+        );
+    }
+
+    #[test]
+    fn status_bar_empty_queue_shows_only_hints() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Account;
+        // queue starts empty → only hints should appear
+        let output = render_status_to_string(&app);
+        assert!(output.contains("q:Quit"), "should show hints");
+        assert!(
+            !output.contains("│"),
+            "should not show separator when no status message"
+        );
+    }
+
+    #[test]
+    fn status_bar_with_queue_message_shows_message_and_separator() {
+        use crate::app::StatusMessage;
+        let mut app = make_test_app();
+        app.active_tab = Tab::Account;
+        app.push_status(StatusMessage::persistent("Refreshing…"));
+        let output = render_status_to_string(&app);
+        assert!(output.contains("Refreshing…"), "should show status message");
+        assert!(
+            output.contains("│"),
+            "should show separator between message and hints"
+        );
+    }
+
+    #[test]
+    fn status_bar_shows_front_of_queue() {
+        use crate::app::StatusMessage;
+        let mut app = make_test_app();
+        app.push_status(StatusMessage::persistent("First"));
+        app.push_status(StatusMessage::persistent("Second"));
+        let output = render_status_to_string(&app);
+        assert!(
+            output.contains("First"),
+            "should show first (front) message"
+        );
+        assert!(
+            !output.contains("Second"),
+            "should not show queued second message"
         );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -70,7 +70,7 @@ pub fn update(app: &mut App, event: Event) {
                 app.orders.insert(0, o);
             }
         }
-        Event::StatusMsg(msg) => app.status_msg = StatusMessage::persistent(msg),
+        Event::StatusMsg(msg) => app.push_status(StatusMessage::persistent(msg)),
         Event::StreamConnected(kind) => match kind {
             StreamKind::Market => app.market_stream_ok = true,
             StreamKind::Account => app.account_stream_ok = true,
@@ -91,9 +91,14 @@ pub fn update(app: &mut App, event: Event) {
             app.intraday_bars.insert(symbol, bars);
         }
         Event::Tick => {
-            if let Some(exp) = app.status_msg.expires_at {
-                if exp <= Instant::now() {
-                    app.status_msg.clear();
+            // Pop the front entry if it has expired; keep popping while the
+            // next front is also expired so stale messages never block fresh ones.
+            loop {
+                match app.status_queue.front() {
+                    Some(m) if m.expires_at.is_some_and(|e| e <= Instant::now()) => {
+                        app.status_queue.pop_front();
+                    }
+                    _ => break,
                 }
             }
         }
@@ -341,7 +346,7 @@ mod tests {
     fn status_msg_updated() {
         let mut app = make_test_app();
         update(&mut app, Event::StatusMsg("hello".into()));
-        assert_eq!(app.status_msg, "hello");
+        assert_eq!(app.current_status_text(), "hello");
     }
 
     #[test]
@@ -444,10 +449,10 @@ mod tests {
     #[test]
     fn tick_is_noop() {
         let mut app = make_test_app();
-        let before_status = app.status_msg.clone();
+        let before_status = app.current_status_text().to_owned();
         update(&mut app, Event::Tick);
         assert!(!app.should_quit);
-        assert_eq!(app.status_msg, before_status);
+        assert_eq!(app.current_status_text(), before_status);
     }
 
     #[test]
@@ -455,13 +460,14 @@ mod tests {
         use std::time::{Duration, Instant};
         let mut app = make_test_app();
         // Set an already-expired transient message.
-        app.status_msg = crate::app::StatusMessage {
+        app.status_queue.clear();
+        app.status_queue.push_back(crate::app::StatusMessage {
             text: "Order submitted".into(),
             expires_at: Some(Instant::now() - Duration::from_secs(1)),
-        };
+        });
         update(&mut app, Event::Tick);
         assert!(
-            app.status_msg.is_empty(),
+            app.current_status_text().is_empty(),
             "expired transient message should be cleared"
         );
     }
@@ -471,13 +477,15 @@ mod tests {
         use std::time::{Duration, Instant};
         let mut app = make_test_app();
         // Set a transient message that expires in the far future.
-        app.status_msg = crate::app::StatusMessage {
+        app.status_queue.clear();
+        app.status_queue.push_back(crate::app::StatusMessage {
             text: "Refreshing…".into(),
             expires_at: Some(Instant::now() + Duration::from_secs(60)),
-        };
+        });
         update(&mut app, Event::Tick);
         assert_eq!(
-            app.status_msg, "Refreshing…",
+            app.current_status_text(),
+            "Refreshing…",
             "non-expired message must not be cleared"
         );
     }
@@ -485,10 +493,13 @@ mod tests {
     #[test]
     fn tick_does_not_clear_persistent_status_msg() {
         let mut app = make_test_app();
-        app.status_msg = crate::app::StatusMessage::persistent("Loading…");
+        app.status_queue.clear();
+        app.status_queue
+            .push_back(crate::app::StatusMessage::persistent("Loading…"));
         update(&mut app, Event::Tick);
         assert_eq!(
-            app.status_msg, "Loading…",
+            app.current_status_text(),
+            "Loading…",
             "persistent message must survive tick"
         );
     }
@@ -515,7 +526,67 @@ mod tests {
         );
     }
 
-    // ── Global key events ─────────────────────────────────────────────────────
+    #[test]
+    fn status_queue_multiple_messages_display_first_then_second() {
+        use crate::app::StatusMessage;
+        use std::time::{Duration, Instant};
+        let mut app = make_test_app();
+        // Push an expired transient message first, then a persistent one.
+        app.status_queue.push_back(StatusMessage {
+            text: "First".into(),
+            expires_at: Some(Instant::now() - Duration::from_secs(1)),
+        });
+        app.status_queue
+            .push_back(StatusMessage::persistent("Second"));
+        // Front is "First" (expired), so current text shows it first.
+        assert_eq!(app.current_status_text(), "First");
+        // After a tick, "First" expires and "Second" becomes current.
+        update(&mut app, Event::Tick);
+        assert_eq!(app.current_status_text(), "Second");
+    }
+
+    #[test]
+    fn status_queue_cap_drops_oldest_when_full() {
+        use crate::app::StatusMessage;
+        let mut app = make_test_app();
+        for i in 0..5 {
+            app.push_status(StatusMessage::persistent(format!("msg{i}")));
+        }
+        assert_eq!(app.status_queue.len(), 5);
+        // Pushing a 6th should drop the oldest (msg0) and keep msg1..msg5.
+        app.push_status(StatusMessage::persistent("msg5"));
+        assert_eq!(app.status_queue.len(), 5);
+        // The oldest "msg0" should be gone; the front is now "msg1".
+        assert_eq!(app.current_status_text(), "msg1");
+    }
+
+    #[test]
+    fn status_queue_tick_drains_all_expired_messages() {
+        use crate::app::StatusMessage;
+        use std::time::{Duration, Instant};
+        let mut app = make_test_app();
+        // Push three expired transient messages.
+        for i in 0..3 {
+            app.status_queue.push_back(StatusMessage {
+                text: format!("old{i}"),
+                expires_at: Some(Instant::now() - Duration::from_secs(1)),
+            });
+        }
+        app.push_status(StatusMessage::persistent("fresh"));
+        update(&mut app, Event::Tick);
+        // All expired messages should be cleared, leaving only "fresh".
+        assert_eq!(app.current_status_text(), "fresh");
+        assert_eq!(app.status_queue.len(), 1);
+    }
+
+    #[test]
+    fn push_status_first_message_becomes_current() {
+        use crate::app::StatusMessage;
+        let mut app = make_test_app();
+        assert_eq!(app.current_status_text(), "");
+        app.push_status(StatusMessage::persistent("hello"));
+        assert_eq!(app.current_status_text(), "hello");
+    }
 
     #[test]
     fn key_q_quits() {
@@ -602,7 +673,7 @@ mod tests {
     fn key_r_sets_refreshing_status() {
         let mut app = make_test_app();
         update(&mut app, key(KeyCode::Char('r')));
-        assert_eq!(app.status_msg, "Refreshing…");
+        assert_eq!(app.current_status_text(), "Refreshing…");
     }
 
     // ── Watchlist panel keys ──────────────────────────────────────────────────
@@ -878,7 +949,7 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert!(app.modal.is_none(), "modal should close after submit");
-        assert_eq!(app.status_msg, "Submitting order…");
+        assert_eq!(app.current_status_text(), "Submitting order…");
         let cmd = cmd_rx.try_recv().expect("command should be sent");
         assert!(
             matches!(cmd, Command::SubmitOrder { symbol, .. } if symbol == "AAPL"),
@@ -1063,7 +1134,8 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert_eq!(
-            app.status_msg, "System busy — please retry",
+            app.current_status_text(),
+            "System busy — please retry",
             "full channel should show busy message"
         );
     }
@@ -1190,7 +1262,8 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert_eq!(
-            app.status_msg, "Command handler stopped — restart app",
+            app.current_status_text(),
+            "Command handler stopped — restart app",
             "closed channel should show stopped message"
         );
     }
@@ -1221,7 +1294,7 @@ mod tests {
             "modal must stay open on validation failure"
         );
         assert!(
-            !app.status_msg.is_empty(),
+            !app.current_status_text().is_empty(),
             "status_msg must contain error text"
         );
     }
@@ -1236,7 +1309,7 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert!(app.modal.is_some());
-        assert!(!app.status_msg.is_empty());
+        assert!(!app.current_status_text().is_empty());
     }
 
     #[test]
@@ -1249,7 +1322,7 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert!(app.modal.is_some());
-        assert!(!app.status_msg.is_empty());
+        assert!(!app.current_status_text().is_empty());
     }
 
     #[test]
@@ -1266,7 +1339,7 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert!(app.modal.is_some());
-        assert!(!app.status_msg.is_empty());
+        assert!(!app.current_status_text().is_empty());
     }
 
     #[test]
@@ -2169,7 +2242,7 @@ mod tests {
     fn t_key_sets_status_message() {
         let mut app = make_test_app();
         update(&mut app, key(KeyCode::Char('T')));
-        let status = app.status_msg.text.as_str();
+        let status = app.current_status_text();
         assert!(
             status.contains("Theme:"),
             "Status should contain 'Theme:' after T key, got: {:?}",


### PR DESCRIPTION
Closes #79

## Changes

**`src/app.rs`**
- Replaced `status_msg: StatusMessage` with `status_queue: VecDeque<StatusMessage>` (cap 5)
- Added `push_status(msg)` — enqueues to back, drops oldest if over cap
- Added `current_status_text() -> &str` — returns front text or ""
- Updated `push_transient_status` and `push_fill_notification` to use `push_status`
- Removed unused `is_empty` / `clear` methods from `StatusMessage`

**`src/update.rs`**
- `Event::StatusMsg` enqueues via `push_status`
- `Event::Tick` drains all expired entries from the front in a loop

**`src/ui/dashboard.rs`**
- Renders from `current_status_text()`; shows `│` separator only when a message is present

**`src/main.rs`**
- Pushes initial "Loading…" after `App::new()`

**New tests (8 total):**
- 5 queue-behaviour tests in `update.rs`
- 3 dashboard rendering tests in `ui/dashboard.rs`

Total: 461 tests, all passing.