### PR TITLE
feat(ui): add refresh spinner and last-updated timestamp to header

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Local};
 use ratatui::layout::Rect;
 
 /// Maximum number of status messages held in the queue at once.
@@ -368,6 +369,18 @@ pub struct App {
     /// redraw before the next tick. Cleared by the main loop after drawing.
     pub needs_redraw: bool,
 
+    /// Number of in-flight REST requests.
+    ///
+    /// Incremented by `Event::FetchStarted`, decremented by `Event::FetchComplete`.
+    /// Non-zero while any fetch is in-flight; used to show the loading spinner.
+    pub pending_requests: u8,
+    /// Wall-clock time of the most recent complete data refresh, updated when
+    /// `pending_requests` drops to zero.
+    pub last_updated: Option<DateTime<Local>>,
+    /// Frame index advanced on every `Event::Tick` while `pending_requests > 0`.
+    /// Used to cycle through spinner frames without storing wall-clock timers.
+    pub spinner_tick: u8,
+
     /// `true` while the market-data WebSocket is connected and authenticated.
     pub market_stream_ok: bool,
     /// `true` while the account WebSocket is connected and authenticated.
@@ -414,6 +427,9 @@ impl App {
             status_queue: VecDeque::new(),
             should_quit: false,
             needs_redraw: false,
+            pending_requests: 0,
+            last_updated: None,
+            spinner_tick: 0,
             market_stream_ok: false,
             account_stream_ok: false,
             hit_areas: HitAreas::default(),
@@ -514,6 +530,35 @@ impl App {
     /// Sets a fill-notification status message using the fill TTL from user preferences.
     pub fn push_fill_notification(&mut self, text: impl Into<String>) {
         self.push_status(StatusMessage::with_ttl(text, self.prefs.fill_ttl()));
+    }
+
+    /// Increments the in-flight request counter (called when a fetch begins).
+    pub fn request_started(&mut self) {
+        self.pending_requests = self.pending_requests.saturating_add(1);
+    }
+
+    /// Decrements the in-flight request counter (called when a fetch completes).
+    ///
+    /// When the counter reaches zero, [`last_updated`](App::last_updated) is
+    /// set to the current local time.
+    pub fn request_finished(&mut self) {
+        self.pending_requests = self.pending_requests.saturating_sub(1);
+        if self.pending_requests == 0 {
+            self.last_updated = Some(Local::now());
+        }
+    }
+
+    /// Returns the current spinner frame character for the active-fetch indicator.
+    ///
+    /// Cycles through the ten braille-dot frames on each tick.
+    pub fn spinner_frame(&self) -> char {
+        const FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+        FRAMES[(self.spinner_tick as usize) % FRAMES.len()]
+    }
+
+    /// Advances the spinner by one frame (called on each `Event::Tick` while busy).
+    pub fn tick_spinner(&mut self) {
+        self.spinner_tick = self.spinner_tick.wrapping_add(1);
     }
 
     /// Advances to the next theme in the cycle (Default → Dark → High-contrast → Default).

--- a/src/events.rs
+++ b/src/events.rs
@@ -61,6 +61,15 @@ pub enum Event {
     /// Emitted once when the REST handler detects `client.is_paper()` so the
     /// UI can display a clear, persistent explanation instead of "Loading…".
     WatchlistUnavailable,
+    /// A REST fetch has been dispatched (one per in-flight request).
+    ///
+    /// Increments `App::pending_requests` so the UI can show a spinner.
+    FetchStarted,
+    /// A REST fetch has completed (success or error).
+    ///
+    /// Decrements `App::pending_requests`; when it reaches zero,
+    /// `App::last_updated` is recorded with the current local time.
+    FetchComplete,
     /// Periodic tick to trigger UI refresh / REST polls.
     Tick,
     /// One-shot status message to display in the status bar.

--- a/src/handlers/rest.rs
+++ b/src/handlers/rest.rs
@@ -32,16 +32,40 @@ pub async fn run(
 }
 
 pub async fn poll_once(tx: Sender<Event>, client: Arc<AlpacaClient>) {
-    tokio::join!(poll_all(&client, &tx), poll_portfolio_history(&client, &tx));
+    tokio::join!(poll_all(&client, &tx), async {
+        let _ = tx.send(Event::FetchStarted).await;
+        poll_portfolio_history(&client, &tx).await;
+        let _ = tx.send(Event::FetchComplete).await;
+    },);
 }
 
 async fn poll_all(client: &AlpacaClient, tx: &Sender<Event>) {
     tokio::join!(
-        poll_account(client, tx),
-        poll_positions(client, tx),
-        poll_orders(client, tx),
-        poll_clock(client, tx),
-        poll_watchlist(client, tx),
+        async {
+            let _ = tx.send(Event::FetchStarted).await;
+            poll_account(client, tx).await;
+            let _ = tx.send(Event::FetchComplete).await;
+        },
+        async {
+            let _ = tx.send(Event::FetchStarted).await;
+            poll_positions(client, tx).await;
+            let _ = tx.send(Event::FetchComplete).await;
+        },
+        async {
+            let _ = tx.send(Event::FetchStarted).await;
+            poll_orders(client, tx).await;
+            let _ = tx.send(Event::FetchComplete).await;
+        },
+        async {
+            let _ = tx.send(Event::FetchStarted).await;
+            poll_clock(client, tx).await;
+            let _ = tx.send(Event::FetchComplete).await;
+        },
+        async {
+            let _ = tx.send(Event::FetchStarted).await;
+            poll_watchlist(client, tx).await;
+            let _ = tx.send(Event::FetchComplete).await;
+        },
     );
 }
 

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -36,6 +36,15 @@ pub fn render_header(frame: &mut Frame, area: Rect, app: &App) {
 
     let now = Local::now().format("%H:%M:%S ET  %Y-%m-%d").to_string();
 
+    // Right-side indicator: spinner while fetching, or "Updated HH:MM:SS" when idle.
+    let fetch_indicator = if app.pending_requests > 0 {
+        format!("  {} Fetching…", app.spinner_frame())
+    } else if let Some(updated_at) = app.last_updated {
+        format!("  Updated {}", updated_at.format("%H:%M:%S"))
+    } else {
+        String::new()
+    };
+
     let mut spans = vec![
         Span::styled(
             format!(" [{}] ", env_label),
@@ -54,6 +63,7 @@ pub fn render_header(frame: &mut Frame, area: Rect, app: &App) {
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(format!("   {}", now), c.dim_style()),
+        Span::styled(fetch_indicator, c.dim_style()),
     ];
 
     if app.config.dry_run {
@@ -287,6 +297,45 @@ mod tests {
         assert!(
             !output.contains("Second"),
             "should not show queued second message"
+        );
+    }
+
+    #[test]
+    fn header_shows_fetching_spinner_when_pending() {
+        let mut app = make_test_app();
+        app.pending_requests = 1;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("Fetching"),
+            "header should show 'Fetching…' while requests are in-flight; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_updated_time_when_idle_with_last_updated() {
+        let mut app = make_test_app();
+        app.pending_requests = 0;
+        app.last_updated = Some(chrono::Local::now());
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("Updated"),
+            "header should show 'Updated HH:MM:SS' when idle with last_updated set; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_no_fetch_indicator_when_idle_and_no_last_updated() {
+        let app = make_test_app();
+        assert_eq!(app.pending_requests, 0);
+        assert!(app.last_updated.is_none());
+        let output = render_header_to_string(&app);
+        assert!(
+            !output.contains("Fetching"),
+            "header must not show spinner when idle"
+        );
+        assert!(
+            !output.contains("Updated"),
+            "header must not show 'Updated' when last_updated is None"
         );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -90,7 +90,13 @@ pub fn update(app: &mut App, event: Event) {
         Event::IntradayBarsReceived { symbol, bars } => {
             app.intraday_bars.insert(symbol, bars);
         }
+        Event::FetchStarted => app.request_started(),
+        Event::FetchComplete => app.request_finished(),
         Event::Tick => {
+            // Advance spinner frame while any fetch is in-flight.
+            if app.pending_requests > 0 {
+                app.tick_spinner();
+            }
             // Pop the front entry if it has expired; keep popping while the
             // next front is also expired so stale messages never block fresh ones.
             loop {
@@ -2258,5 +2264,103 @@ mod tests {
             update(&mut app, key(KeyCode::Char('T')));
         }
         assert_eq!(app.current_theme, Theme::Default);
+    }
+
+    // ── Fetch counter / spinner ───────────────────────────────────────────────
+
+    #[test]
+    fn fetch_started_increments_pending_requests() {
+        let mut app = make_test_app();
+        assert_eq!(app.pending_requests, 0);
+        update(&mut app, Event::FetchStarted);
+        assert_eq!(app.pending_requests, 1);
+        update(&mut app, Event::FetchStarted);
+        assert_eq!(app.pending_requests, 2);
+    }
+
+    #[test]
+    fn fetch_complete_decrements_pending_requests() {
+        let mut app = make_test_app();
+        update(&mut app, Event::FetchStarted);
+        update(&mut app, Event::FetchStarted);
+        update(&mut app, Event::FetchComplete);
+        assert_eq!(app.pending_requests, 1);
+    }
+
+    #[test]
+    fn fetch_complete_sets_last_updated_when_counter_reaches_zero() {
+        let mut app = make_test_app();
+        assert!(app.last_updated.is_none());
+        update(&mut app, Event::FetchStarted);
+        update(&mut app, Event::FetchComplete);
+        assert!(
+            app.last_updated.is_some(),
+            "last_updated should be set once all fetches complete"
+        );
+    }
+
+    #[test]
+    fn fetch_complete_does_not_set_last_updated_while_still_pending() {
+        let mut app = make_test_app();
+        update(&mut app, Event::FetchStarted);
+        update(&mut app, Event::FetchStarted);
+        update(&mut app, Event::FetchComplete); // still 1 in-flight
+        assert!(
+            app.last_updated.is_none(),
+            "last_updated must not be set while fetches are still in-flight"
+        );
+    }
+
+    #[test]
+    fn fetch_complete_does_not_underflow_pending_requests() {
+        let mut app = make_test_app();
+        // Simulate spurious extra FetchComplete without FetchStarted
+        update(&mut app, Event::FetchComplete);
+        assert_eq!(
+            app.pending_requests, 0,
+            "saturating_sub should prevent underflow"
+        );
+    }
+
+    #[test]
+    fn tick_advances_spinner_when_requests_pending() {
+        let mut app = make_test_app();
+        app.pending_requests = 1;
+        let before = app.spinner_tick;
+        update(&mut app, Event::Tick);
+        assert_eq!(app.spinner_tick, before.wrapping_add(1));
+    }
+
+    #[test]
+    fn tick_does_not_advance_spinner_when_idle() {
+        let mut app = make_test_app();
+        assert_eq!(app.pending_requests, 0);
+        let before = app.spinner_tick;
+        update(&mut app, Event::Tick);
+        assert_eq!(
+            app.spinner_tick, before,
+            "spinner should not advance when idle"
+        );
+    }
+
+    #[test]
+    fn spinner_frame_cycles_through_ten_frames() {
+        let mut app = make_test_app();
+        let frames: Vec<char> = (0..10)
+            .map(|_| {
+                let f = app.spinner_frame();
+                app.spinner_tick = app.spinner_tick.wrapping_add(1);
+                f
+            })
+            .collect();
+        // All frames distinct within a cycle
+        let unique: std::collections::HashSet<char> = frames.iter().copied().collect();
+        assert_eq!(unique.len(), 10, "spinner should have 10 distinct frames");
+        // Frame 10 wraps back to frame 0
+        assert_eq!(
+            app.spinner_frame(),
+            frames[0],
+            "spinner should wrap after 10 ticks"
+        );
     }
 }


### PR DESCRIPTION
Closes #81

## Changes

**`src/events.rs`**
- Added `FetchStarted` and `FetchComplete` event variants

**`src/app.rs`**
- Added `pending_requests: u8`, `last_updated: Option<DateTime<Local>>`, `spinner_tick: u8`
- Added `request_started()`, `request_finished()`, `spinner_frame()`, `tick_spinner()` helpers

**`src/handlers/rest.rs`**
- Each individual poll in `poll_all` now emits `FetchStarted` before and `FetchComplete` after
- `poll_once` wraps `poll_portfolio_history` the same way

**`src/update.rs`**
- `Event::FetchStarted` → `app.request_started()`
- `Event::FetchComplete` → `app.request_finished()`
- `Event::Tick` advances spinner while `pending_requests > 0`

**`src/ui/dashboard.rs`**
- Header appends dim right-side indicator:
  - `⠋ Fetching…` (braille spinner) while in-flight
  - `Updated HH:MM:SS` once complete
  - Empty before first fetch

## Tests (+11)
- 8 fetch counter/spinner tests in `update.rs`
- 3 header rendering tests in `ui/dashboard.rs`

Total: 472 tests, all passing.