### PR TITLE
feat(input): copy focused symbol to clipboard with 'c' key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +28,7 @@ name = "alpaca-trader-rs"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "chrono",
  "clap",
  "crossterm",
@@ -112,6 +119,26 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -227,6 +254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +495,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -592,6 +649,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +751,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -707,6 +795,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -855,6 +953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1019,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1212,6 +1331,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
 ]
 
 [[package]]
@@ -1525,6 +1658,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1677,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1628,6 +1781,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1837,6 +2063,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +2123,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -2530,6 +2781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +3088,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3448,6 +3719,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,6 +4192,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4022,3 +4316,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ratatui    = "0.30"
 crossterm  = { version = "0.29", features = ["event-stream"] }
 clap       = { version = "4", features = ["derive"] }
 rpassword  = "7"
+arboard    = "3"
 
 # Logging
 tracing            = "0.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -489,6 +489,26 @@ impl App {
         orders.get(i).map(|o| o.id.clone())
     }
 
+    /// Returns the ticker symbol of the selected row in the Orders table.
+    pub fn selected_order_symbol(&self) -> Option<String> {
+        let orders = self.filtered_orders();
+        let i = self.orders_state.selected()?;
+        orders.get(i).map(|o| o.symbol.clone())
+    }
+
+    /// Returns the ticker symbol of the focused row in whichever table tab is active.
+    ///
+    /// Returns `None` when no row is selected or the active tab has no symbols
+    /// (e.g. the Account tab).
+    pub fn focused_symbol(&self) -> Option<String> {
+        match self.active_tab {
+            Tab::Watchlist => self.selected_watchlist_symbol(),
+            Tab::Positions => self.selected_position_symbol(),
+            Tab::Orders => self.selected_order_symbol(),
+            Tab::Account => None,
+        }
+    }
+
     pub fn push_equity(&mut self) {
         if let Some(account) = &self.account {
             if let Ok(v) = account.equity.parse::<f64>() {
@@ -768,5 +788,78 @@ mod tests {
         app.search_query = "ts".into();
         app.watchlist_state.select(Some(0)); // index 0 of the *filtered* list = TSLA
         assert_eq!(app.selected_watchlist_symbol(), Some("TSLA".into()));
+    }
+
+    // ── selected_order_symbol ─────────────────────────────────────────────────
+
+    #[test]
+    fn selected_order_symbol_returns_symbol_of_selected_order() {
+        let mut app = make_test_app();
+        app.orders = vec![make_order("id-1", "new"), make_order("id-2", "filled")];
+        app.orders_state.select(Some(0));
+        // Open sub-tab — id-1 is in "new" status, so it's shown
+        assert_eq!(app.selected_order_symbol(), Some("AAPL".into()));
+    }
+
+    #[test]
+    fn selected_order_symbol_none_when_no_selection() {
+        let mut app = make_test_app();
+        app.orders = vec![make_order("id-1", "new")];
+        assert_eq!(app.selected_order_symbol(), None);
+    }
+
+    // ── focused_symbol ────────────────────────────────────────────────────────
+
+    #[test]
+    fn focused_symbol_watchlist_tab_returns_selected_symbol() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        app.watchlist = Some(make_watchlist(&["AAPL", "TSLA"]));
+        app.watchlist_state.select(Some(0));
+        assert_eq!(app.focused_symbol(), Some("AAPL".into()));
+    }
+
+    #[test]
+    fn focused_symbol_positions_tab_returns_selected_symbol() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Positions;
+        app.positions = vec![crate::types::Position {
+            symbol: "MSFT".into(),
+            qty: "5".into(),
+            avg_entry_price: "300".into(),
+            current_price: "310".into(),
+            market_value: "1550".into(),
+            unrealized_pl: "50".into(),
+            unrealized_plpc: "0.032".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        }];
+        app.positions_state.select(Some(0));
+        assert_eq!(app.focused_symbol(), Some("MSFT".into()));
+    }
+
+    #[test]
+    fn focused_symbol_orders_tab_returns_selected_symbol() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Orders;
+        app.orders = vec![make_order("id-1", "new")];
+        app.orders_state.select(Some(0));
+        assert_eq!(app.focused_symbol(), Some("AAPL".into()));
+    }
+
+    #[test]
+    fn focused_symbol_account_tab_returns_none() {
+        let app = make_test_app();
+        // active_tab defaults to Account
+        assert_eq!(app.focused_symbol(), None);
+    }
+
+    #[test]
+    fn focused_symbol_returns_none_when_nothing_selected() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        app.watchlist = Some(make_watchlist(&["AAPL"]));
+        // no selection
+        assert_eq!(app.focused_symbol(), None);
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,14 @@
+//! Thin wrapper around [`arboard`] for writing text to the system clipboard.
+//!
+//! All errors are returned as `String` so callers can forward them directly
+//! to the status bar without pulling in the `arboard` type into every module.
+
+/// Copies `text` to the system clipboard.
+///
+/// Returns `Ok(())` on success, or an error message that can be shown in the
+/// status bar on failure (e.g. when running in a headless environment).
+pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    arboard::Clipboard::new()
+        .and_then(|mut cb| cb.set_text(text))
+        .map_err(|e| format!("Clipboard error: {e}"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(missing_docs)]
 
 pub mod client;
+pub mod clipboard;
 pub mod commands;
 pub mod config;
 pub mod events;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ mod types {
 }
 
 mod app;
+mod clipboard;
 mod credentials;
 mod handlers;
 mod input;

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -117,10 +117,10 @@ pub fn render_status(frame: &mut Frame, area: Rect, app: &App) {
     let panel_hints = match app.active_tab {
         Tab::Account => " r:Refresh  T:Theme  A:About  ?:Help  q:Quit",
         Tab::Watchlist => {
-            " j/k:Navigate  Enter:Detail  o:Order  a:Add  d:Remove  /:Search  T:Theme  A:About  ?:Help  q:Quit"
+            " j/k:Navigate  Enter:Detail  o:Order  a:Add  d:Remove  c:Copy  /:Search  T:Theme  A:About  ?:Help  q:Quit"
         }
         Tab::Positions => {
-            " j/k:Navigate  Enter:Detail  o:Close  s:Short  T:Theme  A:About  ?:Help  q:Quit"
+            " j/k:Navigate  Enter:Detail  o:Close  s:Short  c:Copy  T:Theme  A:About  ?:Help  q:Quit"
         }
         Tab::Orders => " j/k:Navigate  o:New  c:Cancel  1-3:Filter  T:Theme  A:About  ?:Help  q:Quit",
     };

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::app::{App, Modal, StatusMessage, Tab};
+use crate::clipboard;
 use crate::events::{Event, StreamKind};
 use crate::input::{
     handle_modal_key, handle_mouse, handle_orders_key, handle_positions_key, handle_search_key,
@@ -149,7 +150,24 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             app.cycle_theme();
             app.push_transient_status(format!("Theme: {}", app.current_theme.display_name()));
         }
+        // Copy focused symbol to clipboard (Watchlist, Positions, Orders)
+        KeyCode::Char('c') if app.active_tab != Tab::Orders => {
+            copy_focused_symbol(app);
+        }
         _ => handle_panel_key(app, key),
+    }
+}
+
+/// Copies the currently focused symbol to the system clipboard and sets a
+/// transient status message.  If no row is selected, or the clipboard is
+/// unavailable, an informational status is shown instead.
+fn copy_focused_symbol(app: &mut App) {
+    match app.focused_symbol() {
+        None => app.push_transient_status("No symbol selected"),
+        Some(symbol) => match clipboard::copy_to_clipboard(&symbol) {
+            Ok(()) => app.push_transient_status(format!("Copied {symbol} to clipboard")),
+            Err(e) => app.push_transient_status(e),
+        },
     }
 }
 
@@ -2362,5 +2380,72 @@ mod tests {
             frames[0],
             "spinner should wrap after 10 ticks"
         );
+    }
+
+    // ── copy symbol ('c' key) ─────────────────────────────────────────────────
+
+    #[test]
+    fn c_key_on_watchlist_with_selection_sets_status_message() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        app.watchlist = Some(make_watchlist(&["AAPL", "TSLA"]));
+        app.watchlist_state.select(Some(0));
+        update(&mut app, key(KeyCode::Char('c')));
+        let status = app.current_status_text();
+        // Either "Copied AAPL to clipboard" or a clipboard error — either way non-empty
+        assert!(
+            !status.is_empty(),
+            "pressing 'c' with a selection must always set a status message"
+        );
+        assert!(
+            status.contains("AAPL") || status.contains("Clipboard") || status.contains("clipboard"),
+            "status should mention symbol or clipboard; got: {status:?}"
+        );
+    }
+
+    #[test]
+    fn c_key_on_watchlist_without_selection_sets_no_symbol_selected_message() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        app.watchlist = Some(make_watchlist(&["AAPL"]));
+        // no selection
+        update(&mut app, key(KeyCode::Char('c')));
+        assert_eq!(app.current_status_text(), "No symbol selected");
+    }
+
+    #[test]
+    fn c_key_on_positions_with_selection_sets_status_message() {
+        let (mut app, _rx) = positions_app();
+        update(&mut app, key(KeyCode::Char('c')));
+        let status = app.current_status_text();
+        assert!(
+            !status.is_empty(),
+            "pressing 'c' on positions with selection must set a status message"
+        );
+    }
+
+    #[test]
+    fn c_key_on_orders_does_not_copy_but_opens_cancel_modal() {
+        let mut app = orders_app();
+        // Orders tab: 'c' should still trigger cancel confirm, not copy
+        update(&mut app, key(KeyCode::Char('c')));
+        assert!(
+            matches!(app.modal, Some(Modal::Confirm { .. })),
+            "pressing 'c' in Orders should open cancel confirm modal, not copy"
+        );
+        // Status should not be set to a copy message
+        let status = app.current_status_text();
+        assert!(
+            !status.contains("Copied"),
+            "Orders 'c' must not trigger copy; got: {status:?}"
+        );
+    }
+
+    #[test]
+    fn c_key_on_account_tab_sets_no_symbol_selected() {
+        let mut app = make_test_app();
+        assert_eq!(app.active_tab, Tab::Account);
+        update(&mut app, key(KeyCode::Char('c')));
+        assert_eq!(app.current_status_text(), "No symbol selected");
     }
 }


### PR DESCRIPTION
Closes #83

## Changes

**`Cargo.toml`** — added `arboard = "3"`

**`src/clipboard.rs`** (new) — thin arboard wrapper; errors returned as `String` for status bar display

**`src/app.rs`**
- `selected_order_symbol()` — symbol of the selected order row
- `focused_symbol()` — symbol of focused row for whichever tab is active (Account → None)

**`src/update.rs`**
- `KeyCode::Char('c')` handled globally **only when not in the Orders tab** (Orders keeps its existing cancel behaviour)
- `copy_focused_symbol()` helper: writes via arboard, shows `Copied {symbol} to clipboard` or clipboard error message

**`src/ui/dashboard.rs`** — added `c:Copy` hint to Watchlist and Positions status bars

## Behaviour
| Tab | 'c' key |
|-----|---------|
| Watchlist | Copies selected symbol → "Copied AAPL to clipboard" |
| Positions | Copies selected symbol → "Copied MSFT to clipboard" |
| Orders | Existing cancel order behaviour (unchanged) |
| Account | No-op → "No symbol selected" |

## Tests (+12)
- 2 `selected_order_symbol` tests in `app.rs`
- 4 `focused_symbol` tests in `app.rs`
- 5 copy key tests in `update.rs`

Total: 484 tests, all passing.