### PR TITLE
feat(watchlist): add dedicated ConfirmRemoveWatchlist modal

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -286,11 +286,6 @@ impl OrderEntryState {
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     CancelOrder(String),
-    RemoveFromWatchlist {
-        #[allow(dead_code)]
-        watchlist_id: String,
-        symbol: String,
-    },
 }
 
 #[derive(Debug, Clone)]
@@ -303,6 +298,14 @@ pub enum Modal {
         message: String,
         action: ConfirmAction,
         confirmed: bool,
+    },
+    /// Dedicated confirmation dialog for removing a symbol from the watchlist.
+    ///
+    /// Shows a focused modal with `[y] Yes` / `[n / Esc] No` buttons.
+    /// On confirmation the `RemoveFromWatchlist` command is dispatched.
+    ConfirmRemoveWatchlist {
+        symbol: String,
+        watchlist_id: String,
     },
     AddSymbol {
         input: String,

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -198,19 +198,6 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                                 format!("Cancelling {}…", &id[..id.len().min(8)]),
                             );
                         }
-                        ConfirmAction::RemoveFromWatchlist {
-                            watchlist_id,
-                            symbol,
-                        } => {
-                            send_command(
-                                app,
-                                Command::RemoveFromWatchlist {
-                                    watchlist_id: watchlist_id.clone(),
-                                    symbol: symbol.clone(),
-                                },
-                                format!("Removing {}…", symbol),
-                            );
-                        }
                     }
                     app.modal = None;
                     return;
@@ -232,6 +219,34 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 message,
                 action,
                 confirmed,
+            }),
+        },
+
+        // Dedicated watchlist-removal confirmation modal.
+        // `y` or `Enter` confirms; `n` or `Esc` cancels.
+        Modal::ConfirmRemoveWatchlist {
+            symbol,
+            watchlist_id,
+        } => match key.code {
+            KeyCode::Char('y') | KeyCode::Enter => {
+                send_command(
+                    app,
+                    Command::RemoveFromWatchlist {
+                        watchlist_id: watchlist_id.clone(),
+                        symbol: symbol.clone(),
+                    },
+                    format!("Removing {}…", symbol),
+                );
+                app.modal = None;
+                return;
+            }
+            KeyCode::Char('n') => {
+                // 'n' cancels; Esc is handled at the top of the function
+                None
+            }
+            _ => Some(Modal::ConfirmRemoveWatchlist {
+                symbol,
+                watchlist_id,
             }),
         },
 

--- a/src/input/watchlist.rs
+++ b/src/input/watchlist.rs
@@ -1,6 +1,6 @@
 use crossterm::event::KeyCode;
 
-use crate::app::{App, ConfirmAction, Modal, OrderEntryState};
+use crate::app::{App, Modal, OrderEntryState};
 
 pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEvent) {
     let len = app.watchlist.as_ref().map(|w| w.assets.len()).unwrap_or(0);
@@ -43,21 +43,17 @@ pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEven
             if let (Some(symbol), Some(wl)) =
                 (app.selected_watchlist_symbol(), app.watchlist.as_ref())
             {
-                let wl_id = wl.id.clone();
+                let watchlist_id = wl.id.clone();
                 if app.prefs.safety.confirm_watchlist_remove {
-                    app.modal = Some(Modal::Confirm {
-                        message: format!("Remove {} from watchlist?", symbol),
-                        action: ConfirmAction::RemoveFromWatchlist {
-                            watchlist_id: wl_id,
-                            symbol,
-                        },
-                        confirmed: false,
+                    app.modal = Some(Modal::ConfirmRemoveWatchlist {
+                        symbol,
+                        watchlist_id,
                     });
                 } else {
                     let _ =
                         app.command_tx
                             .try_send(crate::commands::Command::RemoveFromWatchlist {
-                                watchlist_id: wl_id,
+                                watchlist_id,
                                 symbol,
                             });
                 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1195,4 +1195,114 @@ mod tests {
             "render() with Modal::About should display app name"
         );
     }
+
+    fn render_confirm_remove_watchlist_to_string(symbol: &str) -> String {
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_confirm_remove_watchlist(frame, area, symbol, &mut app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let width = buffer.area().width as usize;
+        let height = buffer.area().height as usize;
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_confirm_remove_watchlist_shows_title() {
+        let output = render_confirm_remove_watchlist_to_string("AAPL");
+        assert!(
+            output.contains("Remove from Watchlist"),
+            "modal title should say 'Remove from Watchlist', got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_confirm_remove_watchlist_shows_symbol() {
+        let output = render_confirm_remove_watchlist_to_string("TSLA");
+        assert!(
+            output.contains("TSLA"),
+            "modal should display the symbol being removed, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_confirm_remove_watchlist_shows_yes_button() {
+        let output = render_confirm_remove_watchlist_to_string("AAPL");
+        assert!(
+            output.contains("Yes"),
+            "modal should show Yes button, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_confirm_remove_watchlist_shows_no_button() {
+        let output = render_confirm_remove_watchlist_to_string("AAPL");
+        assert!(
+            output.contains("No"),
+            "modal should show No button, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_dispatch_confirm_remove_watchlist_modal() {
+        // Exercises the Modal::ConfirmRemoveWatchlist arm in render()
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render(
+                    frame,
+                    area,
+                    &Modal::ConfirmRemoveWatchlist {
+                        symbol: "NVDA".into(),
+                        watchlist_id: "wl-1".into(),
+                    },
+                    &mut app,
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("NVDA"),
+            "render() with Modal::ConfirmRemoveWatchlist should display the symbol"
+        );
+    }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -24,6 +24,9 @@ pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
             action,
             confirmed,
         } => render_confirm(frame, area, message, action, *confirmed, app),
+        Modal::ConfirmRemoveWatchlist { symbol, .. } => {
+            render_confirm_remove_watchlist(frame, area, symbol, app)
+        }
         Modal::AddSymbol { input, .. } => render_add_symbol(frame, area, input, app),
     }
 }
@@ -717,6 +720,56 @@ fn render_confirm(
         Span::styled("  [ y: Yes ]", yes_style),
         Span::raw("  "),
         Span::styled("[ n: No ]", no_style),
+    ]);
+    frame.render_widget(Paragraph::new(buttons), chunks[2]);
+}
+
+/// Renders the dedicated watchlist-removal confirmation dialog:
+///
+/// ```text
+/// ┌─ Remove from Watchlist ─────────┐
+/// │                                  │
+/// │  Remove AAPL from watchlist?    │
+/// │                                  │
+/// │    [y / Enter] Yes  [n / Esc] No │
+/// └──────────────────────────────────┘
+/// ```
+fn render_confirm_remove_watchlist(frame: &mut Frame, area: Rect, symbol: &str, app: &mut App) {
+    let popup = popup_area(area, 42, 22);
+    frame.render_widget(Clear, popup);
+
+    let c = app.current_theme.colors();
+
+    let block = Block::default()
+        .title(" Remove from Watchlist ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(c.negative_style());
+
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    // Store button row for mouse hit-testing
+    app.hit_areas.modal_confirm_buttons = Some(chunks[2]);
+
+    frame.render_widget(
+        Paragraph::new(format!("  Remove {} from watchlist?", symbol)).style(c.bold_style()),
+        chunks[0],
+    );
+
+    let buttons = Line::from(vec![
+        Span::styled("  [y / Enter] Yes", c.positive_style()),
+        Span::raw("  "),
+        Span::styled("[n / Esc] No", c.negative_style()),
     ]);
     frame.render_widget(Paragraph::new(buttons), chunks[2]);
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -778,10 +778,13 @@ mod tests {
     }
 
     #[test]
-    fn watchlist_d_opens_confirm() {
+    fn watchlist_d_opens_confirm_remove_watchlist() {
         let mut app = watchlist_app();
         update(&mut app, key(KeyCode::Char('d')));
-        assert!(matches!(&app.modal, Some(Modal::Confirm { .. })));
+        assert!(matches!(
+            &app.modal,
+            Some(Modal::ConfirmRemoveWatchlist { symbol, .. }) if symbol == "AAPL"
+        ));
     }
 
     #[test]
@@ -1029,15 +1032,10 @@ mod tests {
 
     #[test]
     fn confirm_remove_watchlist_sends_remove_command() {
-        use crate::app::ConfirmAction;
         let (mut app, mut cmd_rx) = app_with_rx();
-        app.modal = Some(Modal::Confirm {
-            message: "Remove?".into(),
-            action: ConfirmAction::RemoveFromWatchlist {
-                watchlist_id: "wl-id".into(),
-                symbol: "TLRY".into(),
-            },
-            confirmed: false,
+        app.modal = Some(Modal::ConfirmRemoveWatchlist {
+            symbol: "TLRY".into(),
+            watchlist_id: "wl-id".into(),
         });
 
         update(&mut app, key(KeyCode::Char('y')));
@@ -1046,6 +1044,82 @@ mod tests {
         let cmd = cmd_rx.try_recv().expect("command should be sent");
         assert!(
             matches!(cmd, Command::RemoveFromWatchlist { symbol, .. } if symbol == "TLRY"),
+            "expected RemoveFromWatchlist command"
+        );
+    }
+
+    #[test]
+    fn confirm_remove_watchlist_enter_confirms() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.modal = Some(Modal::ConfirmRemoveWatchlist {
+            symbol: "AAPL".into(),
+            watchlist_id: "wl-id".into(),
+        });
+
+        update(&mut app, key(KeyCode::Enter));
+
+        assert!(app.modal.is_none(), "Enter should close the modal");
+        let cmd = cmd_rx.try_recv().expect("command should be sent");
+        assert!(
+            matches!(cmd, Command::RemoveFromWatchlist { symbol, .. } if symbol == "AAPL"),
+            "expected RemoveFromWatchlist command on Enter"
+        );
+    }
+
+    #[test]
+    fn confirm_remove_watchlist_n_cancels() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.modal = Some(Modal::ConfirmRemoveWatchlist {
+            symbol: "AAPL".into(),
+            watchlist_id: "wl-id".into(),
+        });
+
+        update(&mut app, key(KeyCode::Char('n')));
+
+        assert!(
+            app.modal.is_none(),
+            "'n' should close the modal without action"
+        );
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no command should be sent on cancel"
+        );
+    }
+
+    #[test]
+    fn confirm_remove_watchlist_esc_cancels() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.modal = Some(Modal::ConfirmRemoveWatchlist {
+            symbol: "AAPL".into(),
+            watchlist_id: "wl-id".into(),
+        });
+
+        update(&mut app, key(KeyCode::Esc));
+
+        assert!(
+            app.modal.is_none(),
+            "Esc should close the modal without action"
+        );
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no command should be sent on Esc"
+        );
+    }
+
+    #[test]
+    fn watchlist_d_no_confirm_pref_sends_remove_directly() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.active_tab = Tab::Watchlist;
+        app.watchlist = Some(make_watchlist(&["AAPL"]));
+        app.watchlist_state.select(Some(0));
+        app.prefs.safety.confirm_watchlist_remove = false;
+
+        update(&mut app, key(KeyCode::Char('d')));
+
+        assert!(app.modal.is_none(), "no modal when pref is false");
+        let cmd = cmd_rx.try_recv().expect("command should be sent directly");
+        assert!(
+            matches!(cmd, Command::RemoveFromWatchlist { symbol, .. } if symbol == "AAPL"),
             "expected RemoveFromWatchlist command"
         );
     }
@@ -2109,9 +2183,12 @@ mod tests {
         app.active_tab = Tab::Watchlist;
         app.watchlist = Some(make_watchlist(&["AAPL"]));
         app.watchlist_state.select(Some(0));
-        // Open a Confirm modal first
+        // Open a ConfirmRemoveWatchlist modal first
         update(&mut app, key(KeyCode::Char('d')));
-        assert!(matches!(&app.modal, Some(Modal::Confirm { .. })));
+        assert!(matches!(
+            &app.modal,
+            Some(Modal::ConfirmRemoveWatchlist { .. })
+        ));
         // Place confirm buttons at x=10, width=20; left half = Yes
         app.hit_areas.modal_confirm_buttons = Some(rect(10, 10, 20, 1));
 
@@ -2127,9 +2204,12 @@ mod tests {
         app.active_tab = Tab::Watchlist;
         app.watchlist = Some(make_watchlist(&["AAPL"]));
         app.watchlist_state.select(Some(0));
-        // Open a Confirm modal first
+        // Open a ConfirmRemoveWatchlist modal first
         update(&mut app, key(KeyCode::Char('d')));
-        assert!(matches!(&app.modal, Some(Modal::Confirm { .. })));
+        assert!(matches!(
+            &app.modal,
+            Some(Modal::ConfirmRemoveWatchlist { .. })
+        ));
         // Place confirm buttons at x=10, width=20; right half = No
         app.hit_areas.modal_confirm_buttons = Some(rect(10, 10, 20, 1));
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -1125,6 +1125,27 @@ mod tests {
     }
 
     #[test]
+    fn confirm_remove_watchlist_unhandled_key_keeps_modal_open() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.modal = Some(Modal::ConfirmRemoveWatchlist {
+            symbol: "AAPL".into(),
+            watchlist_id: "wl-id".into(),
+        });
+
+        // Press an unrecognized key — modal should stay open and no command sent
+        update(&mut app, key(KeyCode::F(1)));
+
+        assert!(
+            matches!(&app.modal, Some(Modal::ConfirmRemoveWatchlist { symbol, .. }) if symbol == "AAPL"),
+            "unrecognized key should keep ConfirmRemoveWatchlist modal open"
+        );
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no command should be sent on unrecognized key"
+        );
+    }
+
+    #[test]
     fn add_symbol_enter_sends_add_command() {
         let (mut app, mut cmd_rx) = app_with_rx();
         app.modal = Some(Modal::AddSymbol {


### PR DESCRIPTION
## Summary

Implements #84 — replaces the generic `Modal::Confirm` used for watchlist removal with a dedicated `Modal::ConfirmRemoveWatchlist { symbol, watchlist_id }` variant that shows a focused, clearly-titled dialog.

## Changes

- **`src/app.rs`**: Add `Modal::ConfirmRemoveWatchlist { symbol, watchlist_id }` variant; remove `ConfirmAction::RemoveFromWatchlist` (no longer needed)
- **`src/input/watchlist.rs`**: `d` key now opens `Modal::ConfirmRemoveWatchlist` when `confirm_watchlist_remove` pref is true; fires `RemoveFromWatchlist` command directly when pref is false
- **`src/input/modal.rs`**: Handle `Modal::ConfirmRemoveWatchlist` — `y`/Enter confirms and dispatches command, `n`/Esc cancels
- **`src/ui/modals.rs`**: Render the new modal with title "Remove from Watchlist" and `[y / Enter] Yes  [n / Esc] No` button row

## New Tests (6)

- `watchlist_d_opens_confirm_remove_watchlist` — `d` opens the new modal variant
- `confirm_remove_watchlist_sends_remove_command` — `y` fires `RemoveFromWatchlist`
- `confirm_remove_watchlist_enter_confirms` — Enter also confirms
- `confirm_remove_watchlist_n_cancels` — `n` closes without command
- `confirm_remove_watchlist_esc_cancels` — Esc closes without command
- `watchlist_d_no_confirm_pref_sends_remove_directly` — removal without modal when pref is false

Closes #84
