### PR TITLE
feat(charts): stream live data into braille charts between REST polls

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,11 @@ use ratatui::layout::Rect;
 /// Maximum number of status messages held in the queue at once.
 const STATUS_QUEUE_CAP: usize = 5;
 
+/// Minimum gap between equity-history samples pushed from streaming quotes.
+///
+/// Prevents flooding `equity_history` when many quotes arrive in rapid succession.
+const EQUITY_STREAM_INTERVAL: Duration = Duration::from_secs(1);
+
 ///
 /// Transient messages (e.g. "Order submitted", "Refreshing…") carry a TTL and are
 /// cleared automatically on the next `Tick` after they expire. Persistent messages (errors,
@@ -397,6 +402,19 @@ pub struct App {
     /// Set on the first `g`; cleared when a second `g` arrives within 500 ms
     /// (firing jump-to-top) or when any other key clears the pending state.
     pub pending_g_at: Option<Instant>,
+
+    /// Timestamp of the last equity-history point pushed from streaming quotes.
+    ///
+    /// Used to throttle how often `push_equity_from_quotes` appends a new
+    /// sample so the chart isn't flooded on every incoming quote.
+    pub last_equity_stream_push: Option<Instant>,
+
+    /// Tracks when each symbol's intraday bars were last fetched.
+    ///
+    /// Keyed by ticker symbol; updated whenever `Event::IntradayBarsReceived`
+    /// arrives. The `Tick` handler uses this to schedule periodic re-fetches
+    /// while a symbol-detail modal is open.
+    pub intraday_fetched_at: HashMap<String, Instant>,
 }
 
 impl App {
@@ -443,6 +461,8 @@ impl App {
             account_stream_ok: false,
             hit_areas: HitAreas::default(),
             pending_g_at: None,
+            last_equity_stream_push: None,
+            intraday_fetched_at: HashMap::new(),
         }
     }
 
@@ -527,6 +547,63 @@ impl App {
                     self.equity_history.remove(0);
                 }
             }
+        }
+    }
+
+    /// Appends an estimated equity data point computed from live streaming quotes.
+    ///
+    /// Called on every [`Event::MarketQuote`] so the equity chart updates
+    /// between REST polls without any extra API calls.
+    ///
+    /// The estimate is: `account.cash + Σ(qty × mid_price)` for each open
+    /// position, where `mid_price` is the ask or bid from the latest streaming
+    /// quote for that symbol, falling back to the position's `current_price`
+    /// when no live quote is available yet.
+    ///
+    /// Calls are throttled to at most once per [`EQUITY_STREAM_INTERVAL`] to
+    /// avoid flooding `equity_history` when quotes arrive in rapid succession.
+    /// Skips silently when there are no open positions (nothing to compute).
+    pub fn push_equity_from_quotes(&mut self) {
+        // Throttle: skip if we pushed a streaming sample too recently.
+        if let Some(last) = self.last_equity_stream_push {
+            if last.elapsed() < EQUITY_STREAM_INTERVAL {
+                return;
+            }
+        }
+
+        // No positions → no meaningful estimate to push.
+        if self.positions.is_empty() {
+            return;
+        }
+
+        let position_value: f64 = self
+            .positions
+            .iter()
+            .filter_map(|p| {
+                let qty = p.qty.parse::<f64>().ok()?;
+                // Prefer live quote (ask then bid), fall back to last REST price.
+                let price = self
+                    .quotes
+                    .get(&p.symbol)
+                    .and_then(|q| q.ap.or(q.bp))
+                    .or_else(|| p.current_price.parse::<f64>().ok())?;
+                Some(qty * price)
+            })
+            .sum();
+
+        let cash: f64 = self
+            .account
+            .as_ref()
+            .and_then(|a| a.cash.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        let equity = cash + position_value;
+        if equity > 0.0 {
+            self.equity_history.push((equity * 100.0) as u64);
+            if self.equity_history.len() > 120 {
+                self.equity_history.remove(0);
+            }
+            self.last_equity_stream_push = Some(Instant::now());
         }
     }
 
@@ -773,7 +850,147 @@ mod tests {
         assert!(app.equity_history.is_empty());
     }
 
-    // ── selected_watchlist_symbol ─────────────────────────────────────────────
+    // ── push_equity_from_quotes ───────────────────────────────────────────────
+
+    fn make_position_with_price(
+        symbol: &str,
+        qty: &str,
+        current_price: &str,
+    ) -> crate::types::Position {
+        crate::types::Position {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            avg_entry_price: current_price.into(),
+            current_price: current_price.into(),
+            market_value: "0".into(),
+            unrealized_pl: "0".into(),
+            unrealized_plpc: "0".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        }
+    }
+
+    #[test]
+    fn push_equity_from_quotes_no_positions_is_noop() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "10000.00".into(),
+            ..Default::default()
+        });
+        app.push_equity_from_quotes();
+        assert!(app.equity_history.is_empty());
+    }
+
+    #[test]
+    fn push_equity_from_quotes_uses_live_quote_ask_price() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("AAPL", "10", "150.00")];
+        app.quotes.insert(
+            "AAPL".into(),
+            crate::types::Quote {
+                symbol: "AAPL".into(),
+                ap: Some(200.00),
+                bp: None,
+                ..Default::default()
+            },
+        );
+        app.push_equity_from_quotes();
+        // 10 shares × $200.00 = $2000.00 → 200000 cents
+        assert_eq!(app.equity_history, vec![200_000]);
+    }
+
+    #[test]
+    fn push_equity_from_quotes_falls_back_to_bid_when_no_ask() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("TSLA", "5", "300.00")];
+        app.quotes.insert(
+            "TSLA".into(),
+            crate::types::Quote {
+                symbol: "TSLA".into(),
+                ap: None,
+                bp: Some(250.00),
+                ..Default::default()
+            },
+        );
+        app.push_equity_from_quotes();
+        // 5 × $250.00 = $1250.00 → 125000 cents
+        assert_eq!(app.equity_history, vec![125_000]);
+    }
+
+    #[test]
+    fn push_equity_from_quotes_falls_back_to_current_price_when_no_quote() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("NVDA", "2", "400.00")];
+        // No quote for NVDA
+        app.push_equity_from_quotes();
+        // 2 × $400.00 = $800.00 → 80000 cents
+        assert_eq!(app.equity_history, vec![80_000]);
+    }
+
+    #[test]
+    fn push_equity_from_quotes_includes_cash() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "500.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("AAPL", "1", "100.00")];
+        app.push_equity_from_quotes();
+        // $500 cash + 1 × $100.00 = $600.00 → 60000 cents
+        assert_eq!(app.equity_history, vec![60_000]);
+    }
+
+    #[test]
+    fn push_equity_from_quotes_throttles_rapid_calls() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("AAPL", "1", "100.00")];
+
+        app.push_equity_from_quotes();
+        assert_eq!(app.equity_history.len(), 1);
+
+        // Immediately call again — should be suppressed by throttle
+        app.push_equity_from_quotes();
+        assert_eq!(
+            app.equity_history.len(),
+            1,
+            "second immediate call should be throttled"
+        );
+    }
+
+    #[test]
+    fn push_equity_from_quotes_caps_at_120_entries() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("AAPL", "1", "100.00")];
+
+        // Bypass throttle for this test by pre-filling equity_history
+        app.equity_history = vec![1u64; 120];
+        // Reset throttle stamp so one more push is allowed
+        app.last_equity_stream_push = None;
+        app.push_equity_from_quotes();
+        assert_eq!(app.equity_history.len(), 120, "should stay at 120 cap");
+    }
+
+    // ── focused_symbol ────────────────────────────────────────────────────────
 
     #[test]
     fn selected_watchlist_symbol_returns_at_index() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -552,7 +552,7 @@ impl App {
 
     /// Appends an estimated equity data point computed from live streaming quotes.
     ///
-    /// Called on every [`Event::MarketQuote`] so the equity chart updates
+    /// Called on every `MarketQuote` event so the equity chart updates
     /// between REST polls without any extra API calls.
     ///
     /// The estimate is: `account.cash + Σ(qty × mid_price)` for each open

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,14 +1,18 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::app::{App, Modal, StatusMessage, Tab};
 use crate::clipboard;
+use crate::commands::Command;
 use crate::events::{Event, StreamKind};
 use crate::input::{
     handle_modal_key, handle_mouse, handle_orders_key, handle_positions_key, handle_search_key,
     handle_watchlist_key,
 };
+
+/// How long to wait before re-fetching intraday bars for an open symbol-detail modal.
+const INTRADAY_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 pub fn update(app: &mut App, event: Event) {
     match event {
@@ -52,6 +56,9 @@ pub fn update(app: &mut App, event: Event) {
         }
         Event::MarketQuote(q) => {
             app.quotes.insert(q.symbol.clone(), q);
+            // Push a streaming equity sample between REST polls so the chart
+            // reflects live price movement without extra API calls.
+            app.push_equity_from_quotes();
         }
         Event::TradeUpdate {
             order: o,
@@ -86,6 +93,10 @@ pub fn update(app: &mut App, event: Event) {
             app.snapshots = snapshots;
         }
         Event::IntradayBarsReceived { symbol, bars } => {
+            // Record fetch time before storing bars so the Tick handler can
+            // schedule the next periodic refresh from this instant.
+            app.intraday_fetched_at
+                .insert(symbol.clone(), Instant::now());
             app.intraday_bars.insert(symbol, bars);
         }
         Event::FetchStarted => app.request_started(),
@@ -103,6 +114,19 @@ pub fn update(app: &mut App, event: Event) {
                         app.status_queue.pop_front();
                     }
                     _ => break,
+                }
+            }
+            // Periodically re-fetch intraday bars while a symbol-detail modal is open.
+            if let Some(Modal::SymbolDetail(symbol)) = &app.modal.clone() {
+                let due = app
+                    .intraday_fetched_at
+                    .get(symbol)
+                    .map(|t| t.elapsed() >= INTRADAY_REFRESH_INTERVAL)
+                    .unwrap_or(false);
+                if due {
+                    let _ = app
+                        .command_tx
+                        .try_send(Command::FetchIntradayBars(symbol.clone()));
                 }
             }
         }
@@ -2853,6 +2877,215 @@ mod tests {
         assert!(
             !status.contains("✓") && !status.contains("✗") && !status.contains("~"),
             "pending_new should not push a notification, got: {status:?}"
+        );
+    }
+
+    // ── MarketQuote streaming equity ──────────────────────────────────────────
+
+    fn make_position(symbol: &str, qty: &str, price: &str) -> crate::types::Position {
+        crate::types::Position {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            avg_entry_price: price.into(),
+            current_price: price.into(),
+            market_value: "0".into(),
+            unrealized_pl: "0".into(),
+            unrealized_plpc: "0".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        }
+    }
+
+    #[test]
+    fn market_quote_pushes_equity_when_positions_present() {
+        let mut app = make_test_app();
+        app.account = Some(crate::types::AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position("AAPL", "10", "150.00")];
+        update(
+            &mut app,
+            Event::MarketQuote(Quote {
+                symbol: "AAPL".into(),
+                ap: Some(200.00),
+                bp: None,
+                ..Default::default()
+            }),
+        );
+        // Quote stored
+        assert!(app.quotes.contains_key("AAPL"));
+        // Equity pushed: 10 × $200 = $2000 → 200000 cents
+        assert_eq!(
+            app.equity_history,
+            vec![200_000],
+            "equity_history should have streaming sample"
+        );
+    }
+
+    #[test]
+    fn market_quote_no_equity_push_without_positions() {
+        let mut app = make_test_app();
+        // No positions — push_equity_from_quotes should skip silently
+        update(
+            &mut app,
+            Event::MarketQuote(Quote {
+                symbol: "AAPL".into(),
+                ap: Some(200.00),
+                bp: None,
+                ..Default::default()
+            }),
+        );
+        assert!(
+            app.equity_history.is_empty(),
+            "no equity sample without positions"
+        );
+    }
+
+    // ── IntradayBarsReceived fetch timestamp ──────────────────────────────────
+
+    #[test]
+    fn intraday_bars_received_records_fetched_at_timestamp() {
+        let mut app = make_test_app();
+        let before = std::time::Instant::now();
+        update(
+            &mut app,
+            Event::IntradayBarsReceived {
+                symbol: "MSFT".into(),
+                bars: vec![10_000, 10_050],
+            },
+        );
+        let after = std::time::Instant::now();
+        let ts = app
+            .intraday_fetched_at
+            .get("MSFT")
+            .expect("fetched_at should be recorded");
+        assert!(
+            *ts >= before && *ts <= after,
+            "fetched_at should be close to now"
+        );
+        // Bars also stored
+        assert_eq!(
+            app.intraday_bars.get("MSFT"),
+            Some(&vec![10_000u64, 10_050])
+        );
+    }
+
+    // ── Tick intraday refresh ─────────────────────────────────────────────────
+
+    #[test]
+    fn tick_dispatches_intraday_refresh_when_due() {
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(4);
+        let (symbol_tx, _) = tokio::sync::watch::channel(vec![]);
+        let mut app = crate::app::App::new(
+            crate::config::AlpacaConfig {
+                base_url: "http://localhost".into(),
+                key: "k".into(),
+                secret: "s".into(),
+                env: crate::config::AlpacaEnv::Paper,
+                dry_run: false,
+            },
+            crate::prefs::AppPrefs::default(),
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            cmd_tx,
+            symbol_tx,
+        );
+        // Open a SymbolDetail modal for AAPL
+        app.modal = Some(crate::app::Modal::SymbolDetail("AAPL".into()));
+        // Simulate a fetch that happened > 60 seconds ago
+        app.intraday_fetched_at.insert(
+            "AAPL".into(),
+            std::time::Instant::now() - std::time::Duration::from_secs(61),
+        );
+        update(&mut app, Event::Tick);
+        // A FetchIntradayBars command should have been dispatched
+        let cmd = cmd_rx.try_recv().expect("command should be dispatched");
+        assert!(
+            matches!(cmd, Command::FetchIntradayBars(s) if s == "AAPL"),
+            "expected FetchIntradayBars for AAPL"
+        );
+    }
+
+    #[test]
+    fn tick_skips_intraday_refresh_when_not_due() {
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(4);
+        let (symbol_tx, _) = tokio::sync::watch::channel(vec![]);
+        let mut app = crate::app::App::new(
+            crate::config::AlpacaConfig {
+                base_url: "http://localhost".into(),
+                key: "k".into(),
+                secret: "s".into(),
+                env: crate::config::AlpacaEnv::Paper,
+                dry_run: false,
+            },
+            crate::prefs::AppPrefs::default(),
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            cmd_tx,
+            symbol_tx,
+        );
+        app.modal = Some(crate::app::Modal::SymbolDetail("AAPL".into()));
+        // Fetched just now — not due yet
+        app.intraday_fetched_at
+            .insert("AAPL".into(), std::time::Instant::now());
+        update(&mut app, Event::Tick);
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no refresh command when interval not elapsed"
+        );
+    }
+
+    #[test]
+    fn tick_skips_intraday_refresh_when_no_modal() {
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(4);
+        let (symbol_tx, _) = tokio::sync::watch::channel(vec![]);
+        let mut app = crate::app::App::new(
+            crate::config::AlpacaConfig {
+                base_url: "http://localhost".into(),
+                key: "k".into(),
+                secret: "s".into(),
+                env: crate::config::AlpacaEnv::Paper,
+                dry_run: false,
+            },
+            crate::prefs::AppPrefs::default(),
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            cmd_tx,
+            symbol_tx,
+        );
+        // No modal open
+        app.intraday_fetched_at.insert(
+            "AAPL".into(),
+            std::time::Instant::now() - std::time::Duration::from_secs(61),
+        );
+        update(&mut app, Event::Tick);
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no refresh command without an open modal"
+        );
+    }
+
+    #[test]
+    fn tick_skips_intraday_refresh_when_never_fetched() {
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(4);
+        let (symbol_tx, _) = tokio::sync::watch::channel(vec![]);
+        let mut app = crate::app::App::new(
+            crate::config::AlpacaConfig {
+                base_url: "http://localhost".into(),
+                key: "k".into(),
+                secret: "s".into(),
+                env: crate::config::AlpacaEnv::Paper,
+                dry_run: false,
+            },
+            crate::prefs::AppPrefs::default(),
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            cmd_tx,
+            symbol_tx,
+        );
+        // Modal open but bars were never fetched (no entry in intraday_fetched_at)
+        app.modal = Some(crate::app::Modal::SymbolDetail("AAPL".into()));
+        update(&mut app, Event::Tick);
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no refresh command when bars have never been fetched"
         );
     }
 }


### PR DESCRIPTION
## Summary

Feeds live market WebSocket data into both braille charts between REST polls, so the curves update in real time without any extra API calls.

## Portfolio Equity Chart

A new `push_equity_from_quotes()` method on `App` computes estimated portfolio equity on every `Event::MarketQuote`:

```
estimated_equity = account.cash + Σ(qty × mid_price)
```

Where `mid_price` for each position:
1. Streaming ask price (`Quote.ap`)  
2. Streaming bid price (`Quote.bp`) if no ask  
3. Last REST `current_price` from the position itself  

Calls are **throttled to at most once per second** (`EQUITY_STREAM_INTERVAL`) to prevent flooding `equity_history` when many quotes arrive in rapid succession.

## Intraday Sparkline

A new `intraday_fetched_at: HashMap<String, Instant>` field on `App` tracks when each symbol's bars were last fetched. The `Event::Tick` handler now re-dispatches `Command::FetchIntradayBars` for the currently open symbol-detail modal every **60 seconds** (`INTRADAY_REFRESH_INTERVAL`).

This means the sparkline stays up-to-date as long as the modal is open, with no user action required.

## Changes

### `src/app.rs`
- `EQUITY_STREAM_INTERVAL: Duration = 1s` constant  
- `last_equity_stream_push: Option<Instant>` field — throttle stamp  
- `intraday_fetched_at: HashMap<String, Instant>` field — refresh schedule  
- `push_equity_from_quotes()` method  

### `src/update.rs`
- `INTRADAY_REFRESH_INTERVAL: Duration = 60s` constant  
- `Event::MarketQuote` → calls `push_equity_from_quotes()`  
- `Event::IntradayBarsReceived` → records `intraday_fetched_at` timestamp  
- `Event::Tick` → dispatches `FetchIntradayBars` when refresh is due  

## Tests

14 new tests (532 total, all passing):

**`push_equity_from_quotes` unit tests (7)**
- No positions → no-op
- Uses live ask price
- Falls back to bid when no ask
- Falls back to `current_price` when no quote
- Includes `account.cash`
- Throttles rapid calls
- Respects 120-entry cap

**Integration tests (7)**
- `market_quote_pushes_equity_when_positions_present`
- `market_quote_no_equity_push_without_positions`
- `intraday_bars_received_records_fetched_at_timestamp`
- `tick_dispatches_intraday_refresh_when_due`
- `tick_skips_intraday_refresh_when_not_due`
- `tick_skips_intraday_refresh_when_no_modal`
- `tick_skips_intraday_refresh_when_never_fetched`

Closes #122
