### PR TITLE
refactor(ui/input): eliminate code repetitions across ui and input modules

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -286,6 +286,12 @@ impl OrderEntryState {
             focused_field: OrderField::Qty,
         }
     }
+
+    /// Builder method to set the order side, allowing one-liner construction.
+    pub fn with_side(mut self, side: OrderSide) -> Self {
+        self.side = side;
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -14,10 +14,82 @@ pub(crate) use search::handle_search_key;
 pub(crate) use validation::validate;
 pub(crate) use watchlist::handle_watchlist_key;
 
+use std::time::{Duration, Instant};
+
+use crossterm::event::KeyCode;
+use ratatui::widgets::{ListState, TableState};
 use tokio::sync::mpsc::error::TrySendError;
 
 use crate::app::{App, StatusMessage};
 use crate::commands::Command;
+
+/// Timeout window for the `gg` (jump-to-top) vim key sequence.
+pub(crate) const GG_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Abstraction over ratatui selection states so [`handle_nav_key`] can work
+/// with both [`ListState`] and [`TableState`].
+pub(crate) trait SelectionState {
+    fn selected(&self) -> Option<usize>;
+    fn select(&mut self, index: Option<usize>);
+}
+
+impl SelectionState for ListState {
+    fn selected(&self) -> Option<usize> {
+        ListState::selected(self)
+    }
+    fn select(&mut self, index: Option<usize>) {
+        ListState::select(self, index);
+    }
+}
+
+impl SelectionState for TableState {
+    fn selected(&self) -> Option<usize> {
+        TableState::selected(self)
+    }
+    fn select(&mut self, index: Option<usize>) {
+        TableState::select(self, index);
+    }
+}
+
+/// Handle vim-style navigation keys (`j`/`k`/`Up`/`Down`/`g`/`G`) for any list or table.
+///
+/// Mutates `state` (any [`SelectionState`] such as [`ListState`] or [`TableState`]) and
+/// `pending_g` (the timestamp of the last `g` press used for `gg` detection).  Any
+/// non-navigation key resets `pending_g` so the `gg` sequence is cancelled.
+pub(crate) fn handle_nav_key(
+    key: KeyCode,
+    len: usize,
+    state: &mut impl SelectionState,
+    pending_g: &mut Option<Instant>,
+) {
+    // Any key except a fresh 'g' press cancels the gg sequence.
+    let was_pending = *pending_g;
+    *pending_g = None;
+    match key {
+        KeyCode::Char('j') | KeyCode::Down if len > 0 => {
+            let i = state.selected().unwrap_or(0);
+            state.select(Some((i + 1).min(len - 1)));
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            let i = state.selected().unwrap_or(0);
+            state.select(Some(i.saturating_sub(1)));
+        }
+        KeyCode::Char('g') => {
+            if was_pending
+                .map(|t| t.elapsed() < GG_TIMEOUT)
+                .unwrap_or(false)
+            {
+                state.select(Some(0));
+            } else {
+                *pending_g = Some(Instant::now());
+            }
+        }
+        KeyCode::Char('G') if len > 0 => {
+            state.select(Some(len - 1));
+        }
+        _ => {}
+    }
+}
 
 /// Send a command on the command channel and set the appropriate status message.
 ///

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -142,9 +142,9 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 return;
             }
             KeyCode::Char('s') => {
-                let mut state = OrderEntryState::new(symbol.clone());
-                state.side = OrderSide::Sell;
-                app.modal = Some(Modal::OrderEntry(state));
+                app.modal = Some(Modal::OrderEntry(
+                    OrderEntryState::new(symbol.clone()).with_side(OrderSide::Sell),
+                ));
                 return;
             }
             KeyCode::Char('w') => {

--- a/src/input/orders.rs
+++ b/src/input/orders.rs
@@ -1,44 +1,14 @@
-use std::time::Duration;
-
 use crossterm::event::KeyCode;
 
 use crate::app::{App, ConfirmAction, Modal, OrderEntryState, OrdersSubTab};
-
-const GG_TIMEOUT: Duration = Duration::from_millis(500);
 
 pub(crate) fn handle_orders_key(app: &mut App, key: crossterm::event::KeyEvent) {
     let orders = app.filtered_orders();
     let len = orders.len();
 
-    // Any key other than 'g' clears the pending-gg state.
-    if key.code != KeyCode::Char('g') {
-        app.pending_g_at = None;
-    }
+    super::handle_nav_key(key.code, len, &mut app.orders_state, &mut app.pending_g_at);
 
     match key.code {
-        KeyCode::Char('j') | KeyCode::Down if len > 0 => {
-            let i = app.orders_state.selected().unwrap_or(0);
-            app.orders_state.select(Some((i + 1).min(len - 1)));
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            let i = app.orders_state.selected().unwrap_or(0);
-            app.orders_state.select(Some(i.saturating_sub(1)));
-        }
-        KeyCode::Char('g') => {
-            if app
-                .pending_g_at
-                .map(|t| t.elapsed() < GG_TIMEOUT)
-                .unwrap_or(false)
-            {
-                app.orders_state.select(Some(0));
-                app.pending_g_at = None;
-            } else {
-                app.pending_g_at = Some(std::time::Instant::now());
-            }
-        }
-        KeyCode::Char('G') if len > 0 => {
-            app.orders_state.select(Some(len - 1));
-        }
         KeyCode::Char('1') => {
             app.orders_subtab = OrdersSubTab::Open;
             app.orders_state.select(Some(0));

--- a/src/input/positions.rs
+++ b/src/input/positions.rs
@@ -1,43 +1,18 @@
-use std::time::Duration;
-
 use crossterm::event::KeyCode;
 
 use crate::app::{App, Modal, OrderEntryState, OrderSide};
 
-const GG_TIMEOUT: Duration = Duration::from_millis(500);
-
 pub(crate) fn handle_positions_key(app: &mut App, key: crossterm::event::KeyEvent) {
     let len = app.positions.len();
 
-    // Any key other than 'g' clears the pending-gg state.
-    if key.code != KeyCode::Char('g') {
-        app.pending_g_at = None;
-    }
+    super::handle_nav_key(
+        key.code,
+        len,
+        &mut app.positions_state,
+        &mut app.pending_g_at,
+    );
 
     match key.code {
-        KeyCode::Char('j') | KeyCode::Down if len > 0 => {
-            let i = app.positions_state.selected().unwrap_or(0);
-            app.positions_state.select(Some((i + 1).min(len - 1)));
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            let i = app.positions_state.selected().unwrap_or(0);
-            app.positions_state.select(Some(i.saturating_sub(1)));
-        }
-        KeyCode::Char('g') => {
-            if app
-                .pending_g_at
-                .map(|t| t.elapsed() < GG_TIMEOUT)
-                .unwrap_or(false)
-            {
-                app.positions_state.select(Some(0));
-                app.pending_g_at = None;
-            } else {
-                app.pending_g_at = Some(std::time::Instant::now());
-            }
-        }
-        KeyCode::Char('G') if len > 0 => {
-            app.positions_state.select(Some(len - 1));
-        }
         KeyCode::Enter => {
             if let Some(symbol) = app.selected_position_symbol() {
                 let _ = app
@@ -48,15 +23,15 @@ pub(crate) fn handle_positions_key(app: &mut App, key: crossterm::event::KeyEven
         }
         KeyCode::Char('o') => {
             let symbol = app.selected_position_symbol().unwrap_or_default();
-            let mut state = OrderEntryState::new(symbol);
-            state.side = OrderSide::Sell;
-            app.modal = Some(Modal::OrderEntry(state));
+            app.modal = Some(Modal::OrderEntry(
+                OrderEntryState::new(symbol).with_side(OrderSide::Sell),
+            ));
         }
         KeyCode::Char('s') => {
             let symbol = app.selected_position_symbol().unwrap_or_default();
-            let mut state = OrderEntryState::new(symbol);
-            state.side = OrderSide::SellShort;
-            app.modal = Some(Modal::OrderEntry(state));
+            app.modal = Some(Modal::OrderEntry(
+                OrderEntryState::new(symbol).with_side(OrderSide::SellShort),
+            ));
         }
         _ => {}
     }

--- a/src/input/watchlist.rs
+++ b/src/input/watchlist.rs
@@ -1,44 +1,18 @@
-use std::time::Duration;
-
 use crossterm::event::KeyCode;
 
 use crate::app::{App, Modal, OrderEntryState};
 
-const GG_TIMEOUT: Duration = Duration::from_millis(500);
-
 pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEvent) {
     let len = app.watchlist.as_ref().map(|w| w.assets.len()).unwrap_or(0);
 
-    // Any key other than 'g' clears the pending-gg state.
-    if key.code != KeyCode::Char('g') {
-        app.pending_g_at = None;
-    }
+    super::handle_nav_key(
+        key.code,
+        len,
+        &mut app.watchlist_state,
+        &mut app.pending_g_at,
+    );
 
     match key.code {
-        KeyCode::Char('j') | KeyCode::Down if len > 0 => {
-            let i = app.watchlist_state.selected().unwrap_or(0);
-            app.watchlist_state.select(Some((i + 1).min(len - 1)));
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            let i = app.watchlist_state.selected().unwrap_or(0);
-            app.watchlist_state.select(Some(i.saturating_sub(1)));
-        }
-        KeyCode::Char('g') => {
-            if app
-                .pending_g_at
-                .map(|t| t.elapsed() < GG_TIMEOUT)
-                .unwrap_or(false)
-            {
-                // Second 'g' within timeout → jump to top
-                app.watchlist_state.select(Some(0));
-                app.pending_g_at = None;
-            } else {
-                app.pending_g_at = Some(std::time::Instant::now());
-            }
-        }
-        KeyCode::Char('G') if len > 0 => {
-            app.watchlist_state.select(Some(len - 1));
-        }
         KeyCode::Enter => {
             if let Some(symbol) = app.selected_watchlist_symbol() {
                 let _ = app

--- a/src/ui/account.rs
+++ b/src/ui/account.rs
@@ -3,13 +3,14 @@ use ratatui::{
     style::Style,
     symbols,
     text::{Line, Span},
-    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, Paragraph},
+    widgets::{Axis, Chart, Dataset, GraphType, Paragraph},
     Frame,
 };
 
 use crate::app::App;
 use crate::types::Position;
 use crate::ui::charts;
+use crate::ui::formatting::format_dollar;
 use crate::ui::theme::ThemeColors;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
@@ -24,18 +25,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
 fn render_summary(frame: &mut Frame, area: Rect, app: &App) {
     let c = app.current_theme.colors();
-    let block = Block::default()
-        .title(" Account ")
-        .borders(Borders::ALL)
-        .border_style(c.border_fg_style());
-
+    let block = c.bordered_block(" Account ");
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
     if let Some(acc) = &app.account {
-        let buying_power = format!("${}", format_dollars(&acc.buying_power));
-        let cash = format!("${}", format_dollars(&acc.cash));
-        let long_val = format!("${}", format_dollars(&acc.long_market_value));
+        let buying_power = format!("${}", format_dollar(&acc.buying_power));
+        let cash = format!("${}", format_dollar(&acc.cash));
+        let long_val = format!("${}", format_dollar(&acc.long_market_value));
 
         // Day P&L
         let day_pl_str = match compute_day_pl(&acc.equity, &acc.last_equity) {
@@ -97,10 +94,7 @@ fn render_summary(frame: &mut Frame, area: Rect, app: &App) {
 
 fn render_equity_chart(frame: &mut Frame, area: Rect, app: &App) {
     let c = app.current_theme.colors();
-    let block = Block::default()
-        .title(" Today's Equity Curve ")
-        .borders(Borders::ALL)
-        .border_style(c.border_fg_style());
+    let block = c.bordered_block(" Today's Equity Curve ");
 
     if app.equity_history.is_empty() {
         let para = Paragraph::new("  Collecting data…")
@@ -184,14 +178,6 @@ fn spacer() -> Span<'static> {
     Span::raw("   ")
 }
 
-fn format_dollars(s: &str) -> String {
-    if let Ok(v) = s.parse::<f64>() {
-        format!("{:.2}", v)
-    } else {
-        s.to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -240,19 +226,22 @@ mod tests {
         assert_eq!(format_day_pl(-500.0, -1.0), "-$500.00 (-1.00%)");
     }
 
-    // ── format_dollars ────────────────────────────────────────────────────────
+    // ── format_dollar (from crate::ui::formatting) ────────────────────────────
 
     #[test]
     fn format_dollars_valid_float() {
-        assert_eq!(format_dollars("1000.5"), "1000.50");
-        assert_eq!(format_dollars("0"), "0.00");
-        assert_eq!(format_dollars("125432.18"), "125432.18");
+        assert_eq!(crate::ui::formatting::format_dollar("1000.5"), "1000.50");
+        assert_eq!(crate::ui::formatting::format_dollar("0"), "0.00");
+        assert_eq!(
+            crate::ui::formatting::format_dollar("125432.18"),
+            "125432.18"
+        );
     }
 
     #[test]
     fn format_dollars_non_numeric_passthrough() {
-        assert_eq!(format_dollars("N/A"), "N/A");
-        assert_eq!(format_dollars(""), "");
+        assert_eq!(crate::ui::formatting::format_dollar("N/A"), "N/A");
+        assert_eq!(crate::ui::formatting::format_dollar(""), "");
     }
 
     // ── span helpers ──────────────────────────────────────────────────────────

--- a/src/ui/formatting.rs
+++ b/src/ui/formatting.rs
@@ -1,0 +1,117 @@
+use ratatui::widgets::Cell;
+
+use crate::ui::theme::ThemeColors;
+
+/// Parse `s` as `f64` and format with 2 decimal places.
+/// Returns `s` unchanged if it is not parseable.
+///
+/// ```
+/// use alpaca_trader_rs::ui::formatting::format_dollar;
+/// assert_eq!(format_dollar("123.456"), "123.46");
+/// assert_eq!(format_dollar("N/A"), "N/A");
+/// ```
+pub fn format_dollar(s: &str) -> String {
+    if let Ok(v) = s.parse::<f64>() {
+        format!("{:.2}", v)
+    } else {
+        s.to_string()
+    }
+}
+
+/// Parse `s` as a `f64` price string and format as `"$x.xx"`.
+/// Falls back to `"$0.00"` for non-numeric input.
+///
+/// ```
+/// use alpaca_trader_rs::ui::formatting::format_price;
+/// assert_eq!(format_price("500.00"), "$500.00");
+/// assert_eq!(format_price("bad"), "$0.00");
+/// ```
+pub fn format_price(s: &str) -> String {
+    format!("${:.2}", s.parse::<f64>().unwrap_or(0.0))
+}
+
+/// Parse `s` as a fractional ratio (e.g. `"0.10"`) and format as `"+10.00%"`.
+/// Returns `s` unchanged if it is not parseable.
+///
+/// ```
+/// use alpaca_trader_rs::ui::formatting::format_pct_ratio;
+/// assert_eq!(format_pct_ratio("0.05"), "+5.00%");
+/// assert_eq!(format_pct_ratio("-0.025"), "-2.50%");
+/// assert_eq!(format_pct_ratio("n/a"), "n/a");
+/// ```
+pub fn format_pct_ratio(s: &str) -> String {
+    if let Ok(v) = s.parse::<f64>() {
+        format!("{:+.2}%", v * 100.0)
+    } else {
+        s.to_string()
+    }
+}
+
+/// Create a styled header [`Cell`] using `c.header_style()`.
+pub fn header_cell<'a>(label: &'a str, c: &ThemeColors) -> Cell<'a> {
+    Cell::from(label).style(c.header_style())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── format_dollar ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn format_dollar_valid() {
+        assert_eq!(format_dollar("123.456"), "123.46");
+        assert_eq!(format_dollar("0"), "0.00");
+        assert_eq!(format_dollar("1000.5"), "1000.50");
+    }
+
+    #[test]
+    fn format_dollar_invalid_passthrough() {
+        assert_eq!(format_dollar("not-a-number"), "not-a-number");
+        assert_eq!(format_dollar("N/A"), "N/A");
+        assert_eq!(format_dollar(""), "");
+    }
+
+    // ── format_price ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn format_price_valid() {
+        assert_eq!(format_price("500.00"), "$500.00");
+        assert_eq!(format_price("0"), "$0.00");
+    }
+
+    #[test]
+    fn format_price_invalid_falls_back_to_zero() {
+        assert_eq!(format_price("bad"), "$0.00");
+        assert_eq!(format_price(""), "$0.00");
+    }
+
+    // ── format_pct_ratio ──────────────────────────────────────────────────────
+
+    #[test]
+    fn format_pct_ratio_positive() {
+        assert_eq!(format_pct_ratio("0.05"), "+5.00%");
+        assert_eq!(format_pct_ratio("0.10"), "+10.00%");
+    }
+
+    #[test]
+    fn format_pct_ratio_negative() {
+        assert_eq!(format_pct_ratio("-0.025"), "-2.50%");
+    }
+
+    #[test]
+    fn format_pct_ratio_invalid_passthrough() {
+        assert_eq!(format_pct_ratio("n/a"), "n/a");
+    }
+
+    // ── header_cell ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn header_cell_applies_header_style() {
+        let c = crate::ui::theme::Theme::Default.colors();
+        let cell = header_cell("Symbol", &c);
+        // Verify the cell content is set (style is verified by the fact it compiles
+        // and uses c.header_style() — style equality tested in theme tests)
+        let _ = cell; // construction must not panic
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,11 +1,15 @@
 pub mod account;
 pub mod charts;
 pub mod dashboard;
+pub mod formatting;
 pub mod modals;
 pub mod orders;
 pub mod positions;
 pub mod theme;
 pub mod watchlist;
+
+#[cfg(test)]
+pub mod test_helpers;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -1,11 +1,12 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
-    widgets::{Block, Borders, Cell, Paragraph, Row, Table, Tabs},
+    widgets::{Cell, Paragraph, Row, Table, Tabs},
     Frame,
 };
 
 use crate::app::{App, OrdersSubTab};
+use crate::ui::formatting::{format_price, header_cell};
 
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     let chunks = Layout::default()
@@ -90,29 +91,24 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
     if orders.is_empty() {
         let para = Paragraph::new("  No orders in this category.")
             .style(c.dim_style())
-            .block(
-                Block::default()
-                    .title(" Orders ")
-                    .borders(Borders::ALL)
-                    .border_style(c.border_fg_style()),
-            );
+            .block(c.bordered_block(" Orders "));
         frame.render_widget(para, area);
         return;
     }
 
     let mut header_cells = vec![
-        Cell::from("ID").style(c.header_style()),
-        Cell::from("Symbol").style(c.header_style()),
-        Cell::from("Side").style(c.header_style()),
-        Cell::from("Qty").style(c.header_style()),
-        Cell::from("Type").style(c.header_style()),
-        Cell::from("Limit").style(c.header_style()),
-        Cell::from("Status").style(c.header_style()),
-        Cell::from("Submitted").style(c.header_style()),
+        header_cell("ID", &c),
+        header_cell("Symbol", &c),
+        header_cell("Side", &c),
+        header_cell("Qty", &c),
+        header_cell("Type", &c),
+        header_cell("Limit", &c),
+        header_cell("Status", &c),
+        header_cell("Submitted", &c),
     ];
     if is_filled_tab {
-        header_cells.push(Cell::from("Filled Qty").style(c.header_style()));
-        header_cells.push(Cell::from("Fill Price").style(c.header_style()));
+        header_cells.push(header_cell("Filled Qty", &c));
+        header_cells.push(header_cell("Fill Price", &c));
     }
     let header = Row::new(header_cells);
 
@@ -141,7 +137,7 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
             let limit_str = o
                 .limit_price
                 .as_deref()
-                .map(|p: &str| format!("${:.2}", p.parse::<f64>().unwrap_or(0.0)))
+                .map(format_price)
                 .unwrap_or_else(|| "—".into());
 
             let submitted = o
@@ -171,7 +167,7 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
                 let fill_price_str = o
                     .filled_avg_price
                     .as_deref()
-                    .map(|p| format!("${:.2}", p.parse::<f64>().unwrap_or(0.0)))
+                    .map(format_price)
                     .unwrap_or_else(|| "—".into());
                 cells.push(Cell::from(filled_qty_str));
                 cells.push(Cell::from(fill_price_str).style(c.positive_style()));
@@ -181,10 +177,7 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
         })
         .collect();
 
-    let block = Block::default()
-        .title(" Orders ")
-        .borders(Borders::ALL)
-        .border_style(c.border_fg_style());
+    let block = c.bordered_block(" Orders ");
 
     let mut constraints = vec![
         Constraint::Length(10),
@@ -212,27 +205,13 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use ratatui::{backend::TestBackend, Terminal};
-
     use crate::app::test_helpers::{make_order, make_test_app};
+    use crate::ui::test_helpers::render_to_string;
 
     fn render_orders_to_string(app: &mut crate::app::App) -> String {
-        let backend = TestBackend::new(100, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                super::render(frame, frame.area(), app);
-            })
-            .unwrap();
-        let buf = terminal.backend().buffer().clone();
-        let mut out = String::new();
-        for row in 0..buf.area.height {
-            for col in 0..buf.area.width {
-                out.push_str(buf[(col, row)].symbol());
-            }
-            out.push('\n');
-        }
-        out
+        render_to_string(100, 20, |frame| {
+            super::render(frame, frame.area(), app);
+        })
     }
 
     #[test]

--- a/src/ui/positions.rs
+++ b/src/ui/positions.rs
@@ -1,11 +1,12 @@
 use ratatui::{
     layout::Constraint,
     style::Style,
-    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    widgets::{Cell, Paragraph, Row, Table},
     Frame,
 };
 
 use crate::app::App;
+use crate::ui::formatting::{format_pct_ratio, format_price, header_cell};
 
 pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     let c = app.current_theme.colors();
@@ -13,24 +14,19 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     if app.positions.is_empty() {
         let para = Paragraph::new("  No open positions.")
             .style(c.dim_style())
-            .block(
-                Block::default()
-                    .title(" Positions ")
-                    .borders(Borders::ALL)
-                    .border_style(c.border_fg_style()),
-            );
+            .block(c.bordered_block(" Positions "));
         frame.render_widget(para, area);
         return;
     }
 
     let header = Row::new(vec![
-        Cell::from("Symbol").style(c.header_style()),
-        Cell::from("Qty").style(c.header_style()),
-        Cell::from("Avg Cost").style(c.header_style()),
-        Cell::from("Cur Price").style(c.header_style()),
-        Cell::from("Mkt Value").style(c.header_style()),
-        Cell::from("Unrealized P&L").style(c.header_style()),
-        Cell::from("%").style(c.header_style()),
+        header_cell("Symbol", &c),
+        header_cell("Qty", &c),
+        header_cell("Avg Cost", &c),
+        header_cell("Cur Price", &c),
+        header_cell("Mkt Value", &c),
+        header_cell("Unrealized P&L", &c),
+        header_cell("%", &c),
     ]);
 
     let mut rows: Vec<Row> = app
@@ -42,19 +38,19 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
                 .get(&p.symbol)
                 .and_then(|q| q.ap.or(q.bp))
                 .map(|v| format!("${:.2}", v))
-                .unwrap_or_else(|| format!("${}", fmt_dollar(&p.current_price)));
+                .unwrap_or_else(|| format_price(&p.current_price));
 
             let pnl = p.unrealized_pl.trim().to_string();
-            let pnl_pct = fmt_pct(&p.unrealized_plpc);
+            let pnl_pct = format_pct_ratio(&p.unrealized_plpc);
             let pnl_style = c.pnl_style(&pnl);
 
             Row::new(vec![
                 Cell::from(p.symbol.clone()).style(c.bold_style()),
                 Cell::from(p.qty.clone()),
-                Cell::from(format!("${}", fmt_dollar(&p.avg_entry_price))),
+                Cell::from(format_price(&p.avg_entry_price)),
                 Cell::from(cur_price),
-                Cell::from(format!("${}", fmt_dollar(&p.market_value))),
-                Cell::from(format!("${}", fmt_dollar(&pnl))).style(pnl_style),
+                Cell::from(format_price(&p.market_value)),
+                Cell::from(format_price(&pnl)).style(pnl_style),
                 Cell::from(pnl_pct).style(pnl_style),
             ])
         })
@@ -101,10 +97,8 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         .style(Style::default()),
     );
 
-    let block = Block::default()
-        .title(format!(" Positions ({}) ", app.positions.len()))
-        .borders(Borders::ALL)
-        .border_style(c.border_fg_style());
+    let title = format!(" Positions ({}) ", app.positions.len());
+    let block = c.bordered_block(&title);
 
     let table = Table::new(
         rows,
@@ -126,28 +120,11 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     frame.render_stateful_widget(table, area, &mut app.positions_state);
 }
 
-fn fmt_dollar(s: &str) -> String {
-    if let Ok(v) = s.parse::<f64>() {
-        format!("{:.2}", v)
-    } else {
-        s.to_string()
-    }
-}
-
-fn fmt_pct(s: &str) -> String {
-    if let Ok(v) = s.parse::<f64>() {
-        format!("{:+.2}%", v * 100.0)
-    } else {
-        s.to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use ratatui::{backend::TestBackend, Terminal};
-
     use crate::app::test_helpers::make_test_app;
     use crate::types::Position;
+    use crate::ui::test_helpers::render_to_string;
 
     fn make_position(symbol: &str, pnl: &str) -> Position {
         Position {
@@ -164,22 +141,9 @@ mod tests {
     }
 
     fn render_positions_to_string(app: &mut crate::app::App) -> String {
-        let backend = TestBackend::new(120, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                super::render(frame, frame.area(), app);
-            })
-            .unwrap();
-        let buf = terminal.backend().buffer().clone();
-        let mut out = String::new();
-        for row in 0..buf.area.height {
-            for col in 0..buf.area.width {
-                out.push_str(buf[(col, row)].symbol());
-            }
-            out.push('\n');
-        }
-        out
+        render_to_string(120, 20, |frame| {
+            super::render(frame, frame.area(), app);
+        })
     }
 
     #[test]
@@ -337,26 +301,29 @@ mod tests {
 
     #[test]
     fn positions_fmt_dollar_invalid_passthrough() {
-        assert_eq!(super::fmt_dollar("not-a-number"), "not-a-number");
+        assert_eq!(
+            crate::ui::formatting::format_dollar("not-a-number"),
+            "not-a-number"
+        );
     }
 
     #[test]
     fn positions_fmt_dollar_valid() {
-        assert_eq!(super::fmt_dollar("123.456"), "123.46");
+        assert_eq!(crate::ui::formatting::format_dollar("123.456"), "123.46");
     }
 
     #[test]
     fn positions_fmt_pct_valid() {
-        assert_eq!(super::fmt_pct("0.05"), "+5.00%");
+        assert_eq!(crate::ui::formatting::format_pct_ratio("0.05"), "+5.00%");
     }
 
     #[test]
     fn positions_fmt_pct_negative() {
-        assert_eq!(super::fmt_pct("-0.025"), "-2.50%");
+        assert_eq!(crate::ui::formatting::format_pct_ratio("-0.025"), "-2.50%");
     }
 
     #[test]
     fn positions_fmt_pct_invalid() {
-        assert_eq!(super::fmt_pct("n/a"), "n/a");
+        assert_eq!(crate::ui::formatting::format_pct_ratio("n/a"), "n/a");
     }
 }

--- a/src/ui/test_helpers.rs
+++ b/src/ui/test_helpers.rs
@@ -1,0 +1,24 @@
+use ratatui::{backend::TestBackend, Frame, Terminal};
+
+/// Render a single frame to a flat string for snapshot-style assertions.
+///
+/// Creates a [`TestBackend`] of the given dimensions, draws one frame using
+/// `render_fn`, then concatenates every cell symbol row-by-row with a newline
+/// after each row.
+pub fn render_to_string<F>(width: u16, height: u16, render_fn: F) -> String
+where
+    F: FnOnce(&mut Frame),
+{
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(render_fn).unwrap();
+    let buf = terminal.backend().buffer().clone();
+    let mut out = String::new();
+    for row in 0..buf.area.height {
+        for col in 0..buf.area.width {
+            out.push_str(buf[(col, row)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,4 +1,7 @@
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders},
+};
 
 // ── ThemeColors ───────────────────────────────────────────────────────────────
 
@@ -71,6 +74,18 @@ impl ThemeColors {
         } else {
             self.positive_style()
         }
+    }
+
+    /// Create a bordered [`Block`] with `Borders::ALL` and `border_fg_style()`.
+    ///
+    /// Eliminates the repeated
+    /// `Block::default().title(...).borders(Borders::ALL).border_style(c.border_fg_style())`
+    /// pattern across all UI panels.
+    pub fn bordered_block<'a>(&self, title: &'a str) -> Block<'a> {
+        Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(self.border_fg_style())
     }
 }
 

--- a/src/ui/watchlist.rs
+++ b/src/ui/watchlist.rs
@@ -7,6 +7,7 @@ use ratatui::{
 };
 
 use crate::app::App;
+use crate::ui::formatting::header_cell;
 
 /// Format a trading volume number into a compact human-readable string.
 ///
@@ -84,11 +85,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         .collect();
 
     let header = Row::new(vec![
-        Cell::from("Symbol").style(c.header_style()),
-        Cell::from("Name").style(c.header_style()),
-        Cell::from("Price").style(c.header_style()),
-        Cell::from("Change%").style(c.header_style()),
-        Cell::from("Volume").style(c.header_style()),
+        header_cell("Symbol", &c),
+        header_cell("Name", &c),
+        header_cell("Price", &c),
+        header_cell("Change%", &c),
+        header_cell("Volume", &c),
     ]);
 
     let rows: Vec<Row> = filtered
@@ -166,10 +167,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         .collect();
 
     let title = format!(" Watchlist: {} ({}) ", wl.name, filtered.len());
-    let block = Block::default()
-        .title(title)
-        .borders(Borders::ALL)
-        .border_style(c.border_fg_style());
+    let block = c.bordered_block(&title);
 
     let table = Table::new(
         rows,
@@ -205,8 +203,6 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use ratatui::{backend::TestBackend, Terminal};
-
     use super::format_volume;
     use crate::app::test_helpers::{make_test_app, make_watchlist};
     use crate::types::{Snapshot, SnapshotBar, SnapshotQuote, SnapshotTrade};
@@ -234,22 +230,9 @@ mod tests {
     // ── price fallback render tests ───────────────────────────────────────────
 
     fn render_watchlist_to_string(app: &mut crate::app::App) -> String {
-        let backend = TestBackend::new(80, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                super::render(frame, frame.area(), app);
-            })
-            .unwrap();
-        let buf = terminal.backend().buffer().clone();
-        let mut out = String::new();
-        for row in 0..buf.area.height {
-            for col in 0..buf.area.width {
-                out.push_str(buf[(col, row)].symbol());
-            }
-            out.push('\n');
-        }
-        out
+        crate::ui::test_helpers::render_to_string(80, 20, |frame| {
+            super::render(frame, frame.area(), app);
+        })
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #126

Eliminates all identified code repetitions across `src/ui/` and `src/input/` modules.

## Changes

### New files
- `src/ui/formatting.rs` — shared `format_dollar`, `format_price`, `format_pct_ratio`, `header_cell` helpers with unit tests
- `src/ui/test_helpers.rs` — `render_to_string(width, height, render_fn)` helper used in all UI render tests

### Refactored
- **`src/ui/theme.rs`**: Added `ThemeColors::bordered_block` — replaces all inline `Block::default().title().borders(ALL).border_style()` chains
- **`src/input/mod.rs`**: Added `SelectionState` trait (impl for `ListState` and `TableState`), `GG_TIMEOUT` constant, and `handle_nav_key` — removes ~20 lines of duplicated vim-nav logic from each input handler
- **`src/input/orders.rs`, `positions.rs`, `watchlist.rs`**: Delegate to `handle_nav_key`
- **`src/input/modal.rs`**: Uses `OrderEntryState::with_side` builder
- **`src/app.rs`**: Added `OrderEntryState::with_side` builder method
- **`src/ui/orders.rs`, `positions.rs`, `watchlist.rs`, `account.rs`**: Use shared formatting helpers and `bordered_block`; test helpers use `render_to_string`