### PR TITLE
feat(equity-chart): add date-range toggle (1D/1W/1M/YTD)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -324,6 +324,65 @@ pub enum Modal {
     },
 }
 
+/// Date range for the equity-history chart.
+///
+/// Controls both the API query parameters (`period` / `timeframe`) sent to
+/// Alpaca and the x-axis labels shown in the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EquityRange {
+    /// Intraday (current trading day), 1-minute bars.
+    #[default]
+    OneDay,
+    /// Past week, hourly bars.
+    OneWeek,
+    /// Past month, daily bars.
+    OneMonth,
+    /// Year-to-date, daily bars.
+    Ytd,
+}
+
+impl EquityRange {
+    /// Cycle to the next range in order: 1D → 1W → 1M → YTD → 1D.
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::OneDay => Self::OneWeek,
+            Self::OneWeek => Self::OneMonth,
+            Self::OneMonth => Self::Ytd,
+            Self::Ytd => Self::OneDay,
+        }
+    }
+
+    /// Short label shown in the chart title (e.g., `"1D"`, `"1W"`).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::OneDay => "1D",
+            Self::OneWeek => "1W",
+            Self::OneMonth => "1M",
+            Self::Ytd => "YTD",
+        }
+    }
+
+    /// `(period, timeframe)` query parameters for the Alpaca portfolio history API.
+    pub fn api_params(self) -> (&'static str, &'static str) {
+        match self {
+            Self::OneDay => ("1D", "1Min"),
+            Self::OneWeek => ("1W", "1H"),
+            Self::OneMonth => ("1M", "1D"),
+            Self::Ytd => ("YTD", "1D"),
+        }
+    }
+
+    /// `[start_label, end_label]` for the chart x-axis.
+    pub fn x_labels(self) -> [&'static str; 2] {
+        match self {
+            Self::OneDay => ["09:30", "16:00"],
+            Self::OneWeek => ["Mon", "Fri"],
+            Self::OneMonth => ["Day 1", "Day 30"],
+            Self::Ytd => ["Jan", "Today"],
+        }
+    }
+}
+
 /// Screen areas of interactive elements, populated by the renderer each frame.
 /// Used by the mouse event handler to map click coordinates to actions.
 #[derive(Default, Clone, Debug)]
@@ -367,6 +426,11 @@ pub struct App {
     pub snapshots: HashMap<String, Snapshot>,
     pub clock: Option<MarketClock>,
     pub equity_history: Vec<u64>,
+    /// Active date range displayed in the equity chart.
+    ///
+    /// Determines both the x-axis labels and the API parameters used when
+    /// re-fetching history after the user cycles the range with `p`.
+    pub equity_range: EquityRange,
     /// Intraday 1-minute close prices in cents, keyed by ticker symbol.
     pub intraday_bars: HashMap<String, Vec<u64>>,
 
@@ -457,6 +521,7 @@ impl App {
             snapshots: HashMap::new(),
             clock: None,
             equity_history: Vec::new(),
+            equity_range: EquityRange::OneDay,
             intraday_bars: HashMap::new(),
             active_tab: Tab::Account,
             watchlist_state: TableState::default(),
@@ -556,6 +621,9 @@ impl App {
     }
 
     pub fn push_equity(&mut self) {
+        if self.equity_range != EquityRange::OneDay {
+            return;
+        }
         if let Some(account) = &self.account {
             if let Ok(v) = account.equity.parse::<f64>() {
                 self.equity_history.push((v * 100.0) as u64);
@@ -580,6 +648,10 @@ impl App {
     /// avoid flooding `equity_history` when quotes arrive in rapid succession.
     /// Skips silently when there are no open positions (nothing to compute).
     pub fn push_equity_from_quotes(&mut self) {
+        // Only meaningful for intraday; other ranges are static snapshots.
+        if self.equity_range != EquityRange::OneDay {
+            return;
+        }
         // Throttle: skip if we pushed a streaming sample too recently.
         if let Some(last) = self.last_equity_stream_push {
             if last.elapsed() < EQUITY_STREAM_INTERVAL {
@@ -1104,5 +1176,112 @@ mod tests {
         app.watchlist = Some(make_watchlist(&["AAPL"]));
         // no selection
         assert_eq!(app.focused_symbol(), None);
+    }
+
+    // ── EquityRange ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn equity_range_default_is_one_day() {
+        let app = make_test_app();
+        assert_eq!(app.equity_range, EquityRange::OneDay);
+    }
+
+    #[test]
+    fn equity_range_cycle_one_day_to_week() {
+        assert_eq!(EquityRange::OneDay.cycle(), EquityRange::OneWeek);
+    }
+
+    #[test]
+    fn equity_range_cycle_week_to_month() {
+        assert_eq!(EquityRange::OneWeek.cycle(), EquityRange::OneMonth);
+    }
+
+    #[test]
+    fn equity_range_cycle_month_to_ytd() {
+        assert_eq!(EquityRange::OneMonth.cycle(), EquityRange::Ytd);
+    }
+
+    #[test]
+    fn equity_range_cycle_ytd_wraps_to_one_day() {
+        assert_eq!(EquityRange::Ytd.cycle(), EquityRange::OneDay);
+    }
+
+    #[test]
+    fn equity_range_label_values() {
+        assert_eq!(EquityRange::OneDay.label(), "1D");
+        assert_eq!(EquityRange::OneWeek.label(), "1W");
+        assert_eq!(EquityRange::OneMonth.label(), "1M");
+        assert_eq!(EquityRange::Ytd.label(), "YTD");
+    }
+
+    #[test]
+    fn equity_range_api_params_one_day() {
+        assert_eq!(EquityRange::OneDay.api_params(), ("1D", "1Min"));
+    }
+
+    #[test]
+    fn equity_range_api_params_one_week() {
+        assert_eq!(EquityRange::OneWeek.api_params(), ("1W", "1H"));
+    }
+
+    #[test]
+    fn equity_range_api_params_one_month() {
+        assert_eq!(EquityRange::OneMonth.api_params(), ("1M", "1D"));
+    }
+
+    #[test]
+    fn equity_range_api_params_ytd() {
+        assert_eq!(EquityRange::Ytd.api_params(), ("YTD", "1D"));
+    }
+
+    #[test]
+    fn equity_range_x_labels_one_day() {
+        assert_eq!(EquityRange::OneDay.x_labels(), ["09:30", "16:00"]);
+    }
+
+    #[test]
+    fn equity_range_x_labels_one_week() {
+        assert_eq!(EquityRange::OneWeek.x_labels(), ["Mon", "Fri"]);
+    }
+
+    #[test]
+    fn equity_range_x_labels_one_month() {
+        assert_eq!(EquityRange::OneMonth.x_labels(), ["Day 1", "Day 30"]);
+    }
+
+    #[test]
+    fn equity_range_x_labels_ytd() {
+        assert_eq!(EquityRange::Ytd.x_labels(), ["Jan", "Today"]);
+    }
+
+    #[test]
+    fn push_equity_is_noop_when_range_is_not_one_day() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            equity: "1000.00".into(),
+            ..Default::default()
+        });
+        app.equity_range = EquityRange::OneWeek;
+        app.push_equity();
+        assert!(
+            app.equity_history.is_empty(),
+            "push_equity must not append when range != OneDay"
+        );
+    }
+
+    #[test]
+    fn push_equity_from_quotes_is_noop_when_range_is_not_one_day() {
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            cash: "0.00".into(),
+            ..Default::default()
+        });
+        app.positions = vec![make_position_with_price("AAPL", "10", "150.00")];
+        app.equity_range = EquityRange::OneMonth;
+        app.push_equity_from_quotes();
+        assert!(
+            app.equity_history.is_empty(),
+            "push_equity_from_quotes must not append when range != OneDay"
+        );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -224,14 +224,22 @@ impl AlpacaClient {
             .context("DELETE /watchlists/{id}/{symbol} parse failed")
     }
 
-    /// Fetch intraday portfolio equity history (`GET /account/portfolio/history`).
+    /// Fetch portfolio equity history (`GET /account/portfolio/history`).
     ///
-    /// Requests 1-minute bars for the current trading day. Equity values are
-    /// `None` for buckets when the market was closed.
-    pub async fn get_portfolio_history(&self) -> Result<PortfolioHistory> {
+    /// `period` and `timeframe` map directly to the Alpaca API query parameters.
+    /// Typical combinations:
+    /// - `("1D",  "1Min")` — intraday 1-minute bars (default)
+    /// - `("1W",  "1H")`  — past week, hourly bars
+    /// - `("1M",  "1D")`  — past month, daily bars
+    /// - `("YTD", "1D")`  — year-to-date, daily bars
+    pub async fn get_portfolio_history(
+        &self,
+        period: &str,
+        timeframe: &str,
+    ) -> Result<PortfolioHistory> {
         self.http
             .get(self.url("/account/portfolio/history"))
-            .query(&[("timeframe", "1Min"), ("period", "1D")])
+            .query(&[("timeframe", timeframe), ("period", period)])
             .headers(self.auth_headers()?)
             .send()
             .await
@@ -597,7 +605,7 @@ mod tests {
             .await;
 
         let client = AlpacaClient::new(paper_config(server.uri()));
-        let history = client.get_portfolio_history().await.unwrap();
+        let history = client.get_portfolio_history("1D", "1Min").await.unwrap();
         assert_eq!(history.equity.len(), 3);
         assert_eq!(history.equity[0], Some(100000.0));
         assert_eq!(history.equity[2], None);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -38,4 +38,11 @@ pub enum Command {
     },
     /// Fetch intraday (1-minute) bars for the given ticker to populate the sparkline.
     FetchIntradayBars(String),
+    /// Fetch portfolio equity history for the given Alpaca API parameters.
+    FetchPortfolioHistory {
+        /// Alpaca `period` query param (e.g., `"1D"`, `"1W"`, `"1M"`, `"YTD"`).
+        period: String,
+        /// Alpaca `timeframe` query param (e.g., `"1Min"`, `"1H"`, `"1D"`).
+        timeframe: String,
+    },
 }

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -171,6 +171,21 @@ async fn handle(cmd: Command, tx: &Sender<Event>, client: &AlpacaClient, refresh
                 }
             }
         }
+
+        Command::FetchPortfolioHistory { period, timeframe } => {
+            info!(period = %period, timeframe = %timeframe, "fetching portfolio history");
+            match client.get_portfolio_history(&period, &timeframe).await {
+                Ok(h) => {
+                    let data: Vec<f64> = h.equity.into_iter().flatten().collect();
+                    if !data.is_empty() {
+                        let _ = tx.send(Event::PortfolioHistoryLoaded(data)).await;
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "portfolio history fetch failed");
+                }
+            }
+        }
     }
 }
 

--- a/src/handlers/rest.rs
+++ b/src/handlers/rest.rs
@@ -160,7 +160,7 @@ async fn poll_snapshots(client: &AlpacaClient, tx: &Sender<Event>, symbols: &[St
 }
 
 async fn poll_portfolio_history(client: &AlpacaClient, tx: &Sender<Event>) {
-    match client.get_portfolio_history().await {
+    match client.get_portfolio_history("1D", "1Min").await {
         Ok(h) => {
             let data: Vec<f64> = h.equity.into_iter().flatten().collect();
             if !data.is_empty() {

--- a/src/ui/account.rs
+++ b/src/ui/account.rs
@@ -95,7 +95,11 @@ fn render_summary(frame: &mut Frame, area: Rect, app: &App) {
 
 fn render_equity_chart(frame: &mut Frame, area: Rect, app: &App) {
     let c = app.current_theme.colors();
-    let block = c.bordered_block(" Today's Equity Curve  ←/→ to inspect ");
+    let title = format!(
+        " Equity Curve [{}]  ←/→ to inspect  p to cycle range ",
+        app.equity_range.label()
+    );
+    let block = c.bordered_block(title.as_str());
 
     if app.equity_history.is_empty() {
         let para = Paragraph::new("  Collecting data…")
@@ -116,12 +120,14 @@ fn render_equity_chart(frame: &mut Frame, area: Rect, app: &App) {
         .style(Style::default().fg(line_color))
         .data(&data_points);
 
+    let [x_start, x_end] = app.equity_range.x_labels();
+
     let chart = Chart::new(vec![dataset])
         .block(block)
         .x_axis(
             Axis::default()
                 .bounds([0.0, (n - 1.0).max(0.0)])
-                .labels(["09:30", "16:00"]),
+                .labels([x_start, x_end]),
         )
         .y_axis(Axis::default().bounds([y_min, y_max]));
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -227,6 +227,20 @@ fn handle_panel_key(app: &mut App, key: crossterm::event::KeyEvent) {
 /// `←` / `h` and `→` / `l` move the equity-chart crosshair left and right
 /// one data point at a time.  `Esc` dismisses the crosshair.
 fn handle_account_key(app: &mut App, key: crossterm::event::KeyEvent) {
+    // Range toggle works regardless of whether history is loaded.
+    if key.code == KeyCode::Char('p') {
+        app.equity_range = app.equity_range.cycle();
+        app.equity_history.clear();
+        app.equity_chart_cursor = None;
+        let (period, timeframe) = app.equity_range.api_params();
+        let _ = app.command_tx.try_send(Command::FetchPortfolioHistory {
+            period: period.to_string(),
+            timeframe: timeframe.to_string(),
+        });
+        app.push_transient_status(format!("Equity range: {}", app.equity_range.label()));
+        return;
+    }
+
     let n = app.equity_history.len();
     if n == 0 {
         return;
@@ -3132,6 +3146,143 @@ mod tests {
         assert!(
             cmd_rx.try_recv().is_err(),
             "no refresh command when bars have never been fetched"
+        );
+    }
+
+    // ── p key / equity range toggle ───────────────────────────────────────────
+
+    fn make_app_with_cmd() -> (App, tokio::sync::mpsc::Receiver<Command>) {
+        let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel(8);
+        let (symbol_tx, _) = tokio::sync::watch::channel(vec![]);
+        let app = App::new(
+            crate::config::AlpacaConfig {
+                base_url: "http://localhost".into(),
+                key: "k".into(),
+                secret: "s".into(),
+                env: crate::config::AlpacaEnv::Paper,
+                dry_run: false,
+            },
+            crate::prefs::AppPrefs::default(),
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            cmd_tx,
+            symbol_tx,
+        );
+        (app, cmd_rx)
+    }
+
+    #[test]
+    fn p_key_cycles_equity_range_from_one_day_to_one_week() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_history = vec![1, 2, 3];
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(app.equity_range, crate::app::EquityRange::OneWeek);
+    }
+
+    #[test]
+    fn p_key_clears_equity_history_on_range_change() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_history = vec![1, 2, 3];
+        update(&mut app, key(KeyCode::Char('p')));
+        assert!(
+            app.equity_history.is_empty(),
+            "history should be cleared when range changes"
+        );
+    }
+
+    #[test]
+    fn p_key_clears_crosshair_cursor_on_range_change() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_history = vec![1, 2, 3];
+        app.equity_chart_cursor = Some(2);
+        update(&mut app, key(KeyCode::Char('p')));
+        assert!(
+            app.equity_chart_cursor.is_none(),
+            "cursor should be cleared when range changes"
+        );
+    }
+
+    #[test]
+    fn p_key_dispatches_fetch_portfolio_history_command() {
+        let (mut app, mut cmd_rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_history = vec![1, 2, 3];
+        update(&mut app, key(KeyCode::Char('p')));
+        let cmd = cmd_rx
+            .try_recv()
+            .expect("FetchPortfolioHistory command should be dispatched");
+        assert!(
+            matches!(
+                cmd,
+                Command::FetchPortfolioHistory { period, timeframe }
+                    if period == "1W" && timeframe == "1H"
+            ),
+            "command should carry the new range's API params"
+        );
+    }
+
+    #[test]
+    fn p_key_dispatches_correct_params_for_ytd() {
+        let (mut app, mut cmd_rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_range = crate::app::EquityRange::OneMonth;
+        app.equity_history = vec![1];
+        update(&mut app, key(KeyCode::Char('p')));
+        let cmd = cmd_rx.try_recv().expect("command dispatched");
+        assert!(
+            matches!(
+                cmd,
+                Command::FetchPortfolioHistory { period, timeframe }
+                    if period == "YTD" && timeframe == "1D"
+            ),
+            "expected YTD/1D params"
+        );
+    }
+
+    #[test]
+    fn p_key_sets_status_message_with_new_range_label() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_history = vec![1];
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(app.current_status_text(), "Equity range: 1W");
+    }
+
+    #[test]
+    fn p_key_cycles_all_four_ranges() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        app.equity_history = vec![1];
+        assert_eq!(app.equity_range, crate::app::EquityRange::OneDay);
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(app.equity_range, crate::app::EquityRange::OneWeek);
+        app.equity_history = vec![1];
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(app.equity_range, crate::app::EquityRange::OneMonth);
+        app.equity_history = vec![1];
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(app.equity_range, crate::app::EquityRange::Ytd);
+        app.equity_history = vec![1];
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(
+            app.equity_range,
+            crate::app::EquityRange::OneDay,
+            "should wrap back to 1D"
+        );
+    }
+
+    #[test]
+    fn p_key_on_empty_history_is_handled_gracefully() {
+        let (mut app, mut cmd_rx) = make_app_with_cmd();
+        app.active_tab = Tab::Account;
+        // equity_history is empty; p key should still cycle and dispatch command
+        update(&mut app, key(KeyCode::Char('p')));
+        assert_eq!(app.equity_range, crate::app::EquityRange::OneWeek);
+        assert!(
+            cmd_rx.try_recv().is_ok(),
+            "command should still be dispatched"
         );
     }
 }


### PR DESCRIPTION
Implements #77 — equity curve date-range toggle.

## Changes

- **`EquityRange` enum** in `app.rs`: variants `OneDay`, `OneWeek`, `OneMonth`, `Ytd` with `cycle()`, `label()`, `api_params()`, and `x_labels()` methods
- **`App.equity_range`** field, defaulting to `OneDay`; `push_equity` and `push_equity_from_quotes` are now no-ops when the range is not intraday (non-intraday ranges are static snapshots)
- **`Command::FetchPortfolioHistory { period, timeframe }`** variant for on-demand fetches
- **`get_portfolio_history`** now accepts `period` / `timeframe` params (previously hard-coded)
- **`p` key** on the Account tab cycles the range, clears history + cursor, dispatches `FetchPortfolioHistory`, and shows a transient status
- **Chart title** updated to show active range label (e.g. `[1D]`) and `p to cycle range` hint
- **X-axis labels** driven by `app.equity_range.x_labels()` (e.g. 09:30–16:00 for 1D, Mon–Fri for 1W)

## Tests

- All `EquityRange` methods (cycle, label, api_params, x_labels)
- `push_equity` / `push_equity_from_quotes` guard for non-intraday ranges
- `p` key: range cycling through all four values, history/cursor clearing, `FetchPortfolioHistory` command dispatch with correct params, status message, empty-history edge case

Closes #77