### PR TITLE
feat(modal): add global symbol search modal (Ctrl-F / /)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -322,6 +322,15 @@ pub enum Modal {
         input: String,
         watchlist_id: String,
     },
+    /// Floating search input for looking up any ticker symbol globally.
+    ///
+    /// User types a symbol and presses `Enter` to open [`Modal::SymbolDetail`]
+    /// for that symbol (fetching intraday bars) without adding it to the watchlist.
+    /// `Esc` dismisses without action.
+    GlobalSearch {
+        /// The symbol characters typed so far (uppercased).
+        query: String,
+    },
 }
 
 /// Date range for the equity-history chart.

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -286,6 +286,28 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 watchlist_id,
             }),
         },
+
+        Modal::GlobalSearch { mut query } => match key.code {
+            KeyCode::Char(c) => {
+                query.push(c.to_ascii_uppercase());
+                Some(Modal::GlobalSearch { query })
+            }
+            KeyCode::Backspace => {
+                query.pop();
+                Some(Modal::GlobalSearch { query })
+            }
+            KeyCode::Enter => {
+                if query.is_empty() {
+                    None
+                } else {
+                    let _ = app
+                        .command_tx
+                        .try_send(Command::FetchIntradayBars(query.clone()));
+                    Some(Modal::SymbolDetail(query))
+                }
+            }
+            _ => Some(Modal::GlobalSearch { query }),
+        },
     };
 
     app.modal = new_modal;

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -28,6 +28,7 @@ pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
             render_confirm_remove_watchlist(frame, area, symbol, app)
         }
         Modal::AddSymbol { input, .. } => render_add_symbol(frame, area, input, app),
+        Modal::GlobalSearch { query } => render_global_search(frame, area, query, app),
     }
 }
 
@@ -67,6 +68,7 @@ fn render_help(frame: &mut Frame, area: Rect, app: &App) {
         ("q / Ctrl-C", "Quit"),
         ("?", "This help screen"),
         ("A", "About this app"),
+        ("Ctrl-F / /", "Global symbol search"),
     ];
 
     let header = Row::new(vec![
@@ -812,6 +814,48 @@ fn render_add_symbol(frame: &mut Frame, area: Rect, input: &str, app: &App) {
 
     frame.render_widget(
         Paragraph::new("  Enter:Add  Esc:Cancel").style(c.dim_style()),
+        chunks[2],
+    );
+}
+
+fn render_global_search(frame: &mut Frame, area: Rect, query: &str, app: &App) {
+    let popup = popup_area(area, 35, 20);
+    frame.render_widget(Clear, popup);
+
+    let c = app.current_theme.colors();
+
+    let block = Block::default()
+        .title(" Global Symbol Search ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(c.accent_style());
+
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    frame.render_widget(
+        Paragraph::new("  Enter ticker symbol:").style(c.dim_style()),
+        chunks[0],
+    );
+
+    let input_line = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(query.to_string(), c.bold_style()),
+        Span::styled("▋", c.accent_style()),
+    ]);
+    frame.render_widget(Paragraph::new(input_line), chunks[1]);
+
+    frame.render_widget(
+        Paragraph::new("  Enter:Open  Esc:Cancel").style(c.dim_style()),
         chunks[2],
     );
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1349,4 +1349,73 @@ mod tests {
             "render() with Modal::ConfirmRemoveWatchlist should display the symbol"
         );
     }
+
+    fn render_global_search_to_string(app: &mut App, query: &str) -> String {
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let modal = Modal::GlobalSearch {
+                    query: query.to_string(),
+                };
+                render(frame, area, &modal, app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_global_search_shows_title() {
+        let mut app = make_test_app();
+        let output = render_global_search_to_string(&mut app, "");
+        assert!(
+            output.contains("Global Symbol Search"),
+            "modal should display 'Global Symbol Search' title"
+        );
+    }
+
+    #[test]
+    fn render_global_search_shows_query_text() {
+        let mut app = make_test_app();
+        let output = render_global_search_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("AAPL"),
+            "modal should display the current query"
+        );
+    }
+
+    #[test]
+    fn render_global_search_shows_instructions() {
+        let mut app = make_test_app();
+        let output = render_global_search_to_string(&mut app, "");
+        assert!(
+            output.contains("Enter ticker symbol"),
+            "modal should display entry prompt"
+        );
+        assert!(
+            output.contains("Enter"),
+            "modal footer should mention Enter key"
+        );
+        assert!(
+            output.contains("Esc"),
+            "modal footer should mention Esc key"
+        );
+    }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1418,4 +1418,686 @@ mod tests {
             "modal footer should mention Esc key"
         );
     }
+
+    // ── render_help ───────────────────────────────────────────────────────────
+
+    fn render_help_to_string() -> String {
+        let app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_help(frame, area, &app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_help_shows_title() {
+        let output = render_help_to_string();
+        assert!(
+            output.contains("Keyboard Shortcuts"),
+            "help modal should show 'Keyboard Shortcuts' title"
+        );
+    }
+
+    #[test]
+    fn render_help_shows_navigation_section() {
+        let output = render_help_to_string();
+        assert!(
+            output.contains("NAVIGATION"),
+            "help modal should show NAVIGATION section"
+        );
+    }
+
+    #[test]
+    fn render_help_shows_actions_section() {
+        let output = render_help_to_string();
+        assert!(
+            output.contains("ACTIONS"),
+            "help modal should show ACTIONS section"
+        );
+    }
+
+    #[test]
+    fn render_help_shows_global_section() {
+        let output = render_help_to_string();
+        assert!(
+            output.contains("GLOBAL"),
+            "help modal should show GLOBAL section"
+        );
+    }
+
+    #[test]
+    fn render_help_shows_close_hint() {
+        let output = render_help_to_string();
+        assert!(
+            output.contains("Press any key to close"),
+            "help modal should show close hint"
+        );
+    }
+
+    #[test]
+    fn render_help_shows_global_search_shortcut() {
+        let output = render_help_to_string();
+        assert!(
+            output.contains("Ctrl-F"),
+            "help modal should list the Ctrl-F global search shortcut"
+        );
+    }
+
+    #[test]
+    fn render_dispatch_help_modal() {
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render(frame, area, &Modal::Help, &mut app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("Keyboard Shortcuts"),
+            "render() with Modal::Help should show shortcuts title"
+        );
+    }
+
+    // ── render_confirm ────────────────────────────────────────────────────────
+
+    fn render_confirm_to_string(message: &str, confirmed: bool) -> String {
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_confirm(
+                    frame,
+                    area,
+                    message,
+                    &ConfirmAction::CancelOrder("id".into()),
+                    confirmed,
+                    &mut app,
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_confirm_shows_title() {
+        let output = render_confirm_to_string("Cancel order?", false);
+        assert!(
+            output.contains("Confirm"),
+            "confirm modal should show 'Confirm' title"
+        );
+    }
+
+    #[test]
+    fn render_confirm_shows_message() {
+        let output = render_confirm_to_string("Cancel order?", false);
+        assert!(
+            output.contains("Cancel order"),
+            "confirm modal should display the message"
+        );
+    }
+
+    #[test]
+    fn render_confirm_shows_yes_and_no_buttons() {
+        let output = render_confirm_to_string("Are you sure?", true);
+        assert!(
+            output.contains("Yes"),
+            "confirm modal should show Yes button"
+        );
+        assert!(output.contains("No"), "confirm modal should show No button");
+    }
+
+    #[test]
+    fn render_confirm_not_confirmed_shows_no_highlighted() {
+        // confirmed=false means NO is highlighted (reversed style)
+        let output = render_confirm_to_string("Are you sure?", false);
+        assert!(
+            output.contains("No"),
+            "No button should be present when confirmed=false"
+        );
+    }
+
+    #[test]
+    fn render_confirm_confirmed_shows_yes_highlighted() {
+        // confirmed=true means YES is highlighted (reversed style)
+        let output = render_confirm_to_string("Proceed?", true);
+        assert!(
+            output.contains("Yes"),
+            "Yes button should be present when confirmed=true"
+        );
+    }
+
+    #[test]
+    fn render_dispatch_confirm_modal() {
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render(
+                    frame,
+                    area,
+                    &Modal::Confirm {
+                        message: "Delete?".into(),
+                        action: ConfirmAction::CancelOrder("id".into()),
+                        confirmed: false,
+                    },
+                    &mut app,
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("Confirm"),
+            "render() with Modal::Confirm should show Confirm title"
+        );
+    }
+
+    // ── render_add_symbol ─────────────────────────────────────────────────────
+
+    fn render_add_symbol_to_string(input: &str) -> String {
+        let app = make_test_app();
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_add_symbol(frame, area, input, &app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_add_symbol_shows_title() {
+        let output = render_add_symbol_to_string("");
+        assert!(
+            output.contains("Add Symbol"),
+            "add-symbol modal should show 'Add Symbol' title"
+        );
+    }
+
+    #[test]
+    fn render_add_symbol_shows_input() {
+        let output = render_add_symbol_to_string("MSFT");
+        assert!(
+            output.contains("MSFT"),
+            "add-symbol modal should display the current input"
+        );
+    }
+
+    #[test]
+    fn render_add_symbol_shows_hints() {
+        let output = render_add_symbol_to_string("");
+        assert!(
+            output.contains("Enter"),
+            "add-symbol modal should show Enter hint"
+        );
+        assert!(
+            output.contains("Esc"),
+            "add-symbol modal should show Esc hint"
+        );
+    }
+
+    #[test]
+    fn render_dispatch_add_symbol_modal() {
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render(
+                    frame,
+                    area,
+                    &Modal::AddSymbol {
+                        input: "GOOG".into(),
+                        watchlist_id: "wl-1".into(),
+                    },
+                    &mut app,
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("GOOG"),
+            "render() with Modal::AddSymbol should display the input symbol"
+        );
+    }
+
+    // ── render_order_entry additional branches ────────────────────────────────
+
+    #[test]
+    fn render_order_entry_market_order_shows_na_price() {
+        use crate::app::OrderEntryState;
+        let mut app = make_test_app();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.market_order = true;
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("N/A"),
+            "market order should show N/A for price field"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_limit_order_shows_price_field() {
+        use crate::app::OrderEntryState;
+        let mut app = make_test_app();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.market_order = false;
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("Price"),
+            "limit order should show Price field"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_market_closed_day_shows_warning() {
+        use crate::app::OrderEntryState;
+        use crate::types::MarketClock;
+        let mut app = make_test_app();
+        app.clock = Some(MarketClock {
+            is_open: false,
+            next_open: "2026-01-01T09:30:00Z".into(),
+            next_close: "2026-01-01T16:00:00Z".into(),
+            timestamp: "2026-01-01T08:00:00Z".into(),
+        });
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.gtc_order = false; // DAY order + market closed → warning
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("Market closed"),
+            "should show market-closed warning when market is closed and order is DAY"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_market_closed_gtc_no_warning() {
+        use crate::app::OrderEntryState;
+        use crate::types::MarketClock;
+        let mut app = make_test_app();
+        app.clock = Some(MarketClock {
+            is_open: false,
+            next_open: "2026-01-01T09:30:00Z".into(),
+            next_close: "2026-01-01T16:00:00Z".into(),
+            timestamp: "2026-01-01T08:00:00Z".into(),
+        });
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.gtc_order = true; // GTC order → no warning even when market closed
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            !output.contains("Market closed"),
+            "GTC order should not show market-closed warning"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_shows_buying_power_from_account() {
+        use crate::app::OrderEntryState;
+        use crate::types::AccountInfo;
+        let mut app = make_test_app();
+        app.account = Some(AccountInfo {
+            buying_power: "50000.00".into(),
+            ..Default::default()
+        });
+        let state = OrderEntryState::new("AAPL".into());
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("50000"),
+            "order entry should display buying power from account"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_shows_dash_when_no_account() {
+        use crate::app::OrderEntryState;
+        let mut app = make_test_app();
+        app.account = None;
+        let state = OrderEntryState::new("TSLA".into());
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("Buying Power"),
+            "order entry should show Buying Power label even without account"
+        );
+    }
+
+    #[test]
+    fn render_order_entry_shows_estimated_total_when_filled() {
+        use crate::app::OrderEntryState;
+        let mut app = make_test_app();
+        let mut state = OrderEntryState::new("AAPL".into());
+        state.qty_input = "10".into();
+        state.price_input = "150.00".into();
+        state.market_order = false;
+        let output = render_order_entry_to_string(&mut app, state);
+        assert!(
+            output.contains("1500.00"),
+            "order entry should display estimated total (qty × price)"
+        );
+    }
+
+    #[test]
+    fn render_dispatch_order_entry_modal() {
+        use crate::app::OrderEntryState;
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let state = OrderEntryState::new("NVDA".into());
+                render(frame, area, &Modal::OrderEntry(state), &mut app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("New Order"),
+            "render() with Modal::OrderEntry should show 'New Order' title"
+        );
+    }
+
+    // ── render_symbol_detail with snapshot data ───────────────────────────────
+
+    #[test]
+    fn render_symbol_detail_shows_ohlcv_values_from_snapshot() {
+        use crate::types::{Snapshot, SnapshotBar};
+        let mut app = make_test_app();
+        app.snapshots.insert(
+            "AAPL".into(),
+            Snapshot {
+                daily_bar: Some(SnapshotBar {
+                    o: 180.0,
+                    h: 195.0,
+                    l: 178.0,
+                    c: 190.0,
+                    v: 1_500_000.0,
+                }),
+                prev_daily_bar: Some(SnapshotBar {
+                    o: 179.0,
+                    h: 182.0,
+                    l: 177.0,
+                    c: 185.0,
+                    v: 1_200_000.0,
+                }),
+                ..Default::default()
+            },
+        );
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("180"),
+            "should display open price from snapshot"
+        );
+        assert!(
+            output.contains("195"),
+            "should display high price from snapshot"
+        );
+        assert!(
+            output.contains("178"),
+            "should display low price from snapshot"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_positive_change_from_snapshot() {
+        use crate::types::{Snapshot, SnapshotBar};
+        let mut app = make_test_app();
+        app.snapshots.insert(
+            "AAPL".into(),
+            Snapshot {
+                daily_bar: Some(SnapshotBar {
+                    o: 180.0,
+                    h: 195.0,
+                    l: 178.0,
+                    c: 190.0,
+                    v: 1_000_000.0,
+                }),
+                prev_daily_bar: Some(SnapshotBar {
+                    c: 185.0,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        // 190/185 → +2.70%
+        assert!(
+            output.contains("+"),
+            "positive change should be shown with + sign"
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_negative_change_from_snapshot() {
+        use crate::types::{Snapshot, SnapshotBar};
+        let mut app = make_test_app();
+        app.snapshots.insert(
+            "MSFT".into(),
+            Snapshot {
+                daily_bar: Some(SnapshotBar {
+                    o: 390.0,
+                    h: 395.0,
+                    l: 382.0,
+                    c: 385.0,
+                    v: 900_000.0,
+                }),
+                prev_daily_bar: Some(SnapshotBar {
+                    c: 400.0,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        let output = render_symbol_detail_to_string(&mut app, "MSFT");
+        // 385/400 → -3.75%
+        assert!(
+            output.contains("-"),
+            "negative change should be shown with - sign"
+        );
+    }
+
+    #[test]
+    fn render_dispatch_symbol_detail_modal() {
+        let mut app = make_test_app();
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render(frame, area, &Modal::SymbolDetail("AAPL".into()), &mut app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("AAPL"),
+            "render() with Modal::SymbolDetail should display the symbol"
+        );
+    }
+
+    // ── Helper unit tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn estimate_total_returns_dash_when_qty_zero() {
+        use crate::app::OrderEntryState;
+        let mut state = OrderEntryState::new("X".into());
+        state.qty_input = "0".into();
+        state.price_input = "100.0".into();
+        assert_eq!(estimate_total(&state), "—");
+    }
+
+    #[test]
+    fn estimate_total_returns_dash_when_price_zero() {
+        use crate::app::OrderEntryState;
+        let mut state = OrderEntryState::new("X".into());
+        state.qty_input = "5".into();
+        state.price_input = "0".into();
+        assert_eq!(estimate_total(&state), "—");
+    }
+
+    #[test]
+    fn estimate_total_computes_correctly() {
+        use crate::app::OrderEntryState;
+        let mut state = OrderEntryState::new("X".into());
+        state.qty_input = "3".into();
+        state.price_input = "25.50".into();
+        assert_eq!(estimate_total(&state), "$76.50");
+    }
+
+    #[test]
+    fn estimate_total_returns_dash_when_unparseable() {
+        use crate::app::OrderEntryState;
+        let mut state = OrderEntryState::new("X".into());
+        state.qty_input = "abc".into();
+        state.price_input = "100".into();
+        assert_eq!(estimate_total(&state), "—");
+    }
+
+    #[test]
+    fn flag_returns_checkmark_for_true() {
+        assert_eq!(flag(true), "✓");
+    }
+
+    #[test]
+    fn flag_returns_cross_for_false() {
+        assert_eq!(flag(false), "✗");
+    }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -196,6 +196,17 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         KeyCode::Char('c') if app.active_tab != Tab::Orders => {
             copy_focused_symbol(app);
         }
+        // Global symbol search: Ctrl-F from any tab, or '/' from non-Watchlist tabs.
+        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.modal = Some(Modal::GlobalSearch {
+                query: String::new(),
+            });
+        }
+        KeyCode::Char('/') if app.active_tab != Tab::Watchlist => {
+            app.modal = Some(Modal::GlobalSearch {
+                query: String::new(),
+            });
+        }
         _ => handle_panel_key(app, key),
     }
 }
@@ -1337,6 +1348,166 @@ mod tests {
         update(&mut app, key(KeyCode::Enter));
 
         assert!(cmd_rx.try_recv().is_err(), "no command for empty input");
+    }
+
+    // ── GlobalSearch modal ────────────────────────────────────────────────────
+
+    #[test]
+    fn ctrl_f_opens_global_search_modal() {
+        let mut app = make_test_app();
+        update(&mut app, ctrl(KeyCode::Char('f')));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { query }) if query.is_empty()),
+            "Ctrl-F should open GlobalSearch with empty query"
+        );
+    }
+
+    #[test]
+    fn slash_opens_global_search_on_account_tab() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Account;
+        update(&mut app, key(KeyCode::Char('/')));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { .. })),
+            "'/' on Account tab should open GlobalSearch"
+        );
+    }
+
+    #[test]
+    fn slash_opens_global_search_on_positions_tab() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Positions;
+        update(&mut app, key(KeyCode::Char('/')));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { .. })),
+            "'/' on Positions tab should open GlobalSearch"
+        );
+    }
+
+    #[test]
+    fn slash_opens_global_search_on_orders_tab() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Orders;
+        update(&mut app, key(KeyCode::Char('/')));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { .. })),
+            "'/' on Orders tab should open GlobalSearch"
+        );
+    }
+
+    #[test]
+    fn slash_does_not_open_global_search_on_watchlist_tab() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        update(&mut app, key(KeyCode::Char('/')));
+        assert!(
+            !matches!(&app.modal, Some(Modal::GlobalSearch { .. })),
+            "'/' on Watchlist tab must NOT open GlobalSearch (it activates watchlist search)"
+        );
+    }
+
+    #[test]
+    fn global_search_char_key_appends_uppercase() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::GlobalSearch {
+            query: String::new(),
+        });
+        update(&mut app, key(KeyCode::Char('a')));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { query }) if query == "A"),
+            "char should be uppercased and appended"
+        );
+    }
+
+    #[test]
+    fn global_search_backspace_removes_last_char() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::GlobalSearch { query: "AA".into() });
+        update(&mut app, key(KeyCode::Backspace));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { query }) if query == "A"),
+            "Backspace should remove last character"
+        );
+    }
+
+    #[test]
+    fn global_search_esc_dismisses_modal() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::GlobalSearch {
+            query: "GOO".into(),
+        });
+        update(&mut app, key(KeyCode::Esc));
+        assert!(app.modal.is_none(), "Esc should close GlobalSearch");
+    }
+
+    #[test]
+    fn global_search_enter_with_query_opens_symbol_detail() {
+        let (mut app, _rx) = app_with_rx();
+        app.modal = Some(Modal::GlobalSearch {
+            query: "GOOG".into(),
+        });
+        update(&mut app, key(KeyCode::Enter));
+        assert!(
+            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "GOOG"),
+            "Enter should transition GlobalSearch → SymbolDetail"
+        );
+    }
+
+    #[test]
+    fn global_search_enter_dispatches_fetch_intraday_bars() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.modal = Some(Modal::GlobalSearch {
+            query: "TSLA".into(),
+        });
+        update(&mut app, key(KeyCode::Enter));
+        let cmd = cmd_rx
+            .try_recv()
+            .expect("FetchIntradayBars command should be dispatched");
+        assert!(
+            matches!(cmd, Command::FetchIntradayBars(s) if s == "TSLA"),
+            "expected FetchIntradayBars for TSLA"
+        );
+    }
+
+    #[test]
+    fn global_search_enter_with_empty_query_closes_modal() {
+        let (mut app, mut cmd_rx) = app_with_rx();
+        app.modal = Some(Modal::GlobalSearch {
+            query: String::new(),
+        });
+        update(&mut app, key(KeyCode::Enter));
+        assert!(
+            app.modal.is_none(),
+            "Enter on empty query should close modal"
+        );
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "no command should be sent for empty query"
+        );
+    }
+
+    #[test]
+    fn global_search_backspace_on_empty_query_is_noop() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::GlobalSearch {
+            query: String::new(),
+        });
+        update(&mut app, key(KeyCode::Backspace));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { query }) if query.is_empty()),
+            "Backspace on empty query should keep modal open with empty query"
+        );
+    }
+
+    #[test]
+    fn ctrl_f_opens_search_even_when_on_watchlist_tab() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        update(&mut app, ctrl(KeyCode::Char('f')));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { .. })),
+            "Ctrl-F should open GlobalSearch regardless of active tab"
+        );
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -1500,6 +1500,18 @@ mod tests {
     }
 
     #[test]
+    fn global_search_unhandled_key_keeps_modal_open() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::GlobalSearch { query: "MS".into() });
+        // Arrow keys are unhandled; modal should remain open with unchanged query.
+        update(&mut app, key(KeyCode::Up));
+        assert!(
+            matches!(&app.modal, Some(Modal::GlobalSearch { query }) if query == "MS"),
+            "unhandled key should keep GlobalSearch open with unchanged query"
+        );
+    }
+
+    #[test]
     fn ctrl_f_opens_search_even_when_on_watchlist_tab() {
         let mut app = make_test_app();
         app.active_tab = Tab::Watchlist;


### PR DESCRIPTION
## Summary

Implements a floating global symbol search modal accessible from any screen.

## Changes

- `src/app.rs`: Add `Modal::GlobalSearch { query }` variant
- `src/update.rs`: Handle Ctrl-F (any tab) and / (non-Watchlist) to open modal; 13 new unit tests
- `src/input/modal.rs`: Char input (uppercased), Backspace, Enter to SymbolDetail + FetchIntradayBars, Esc dismiss
- `src/ui/modals.rs`: render_global_search floating widget; help table entry

## Tests

13 new unit tests: key triggers, input handling, Enter transition, empty-query edge cases, Watchlist-tab exclusion.

Closes #80