### PR TITLE
feat(orders): filter by symbol with f key

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -594,6 +594,18 @@ pub struct App {
 
     /// Active sort column and direction for the Orders table.
     pub orders_sort: SortState<OrderSortCol>,
+
+    /// Symbol prefix filter applied to the Orders table.
+    ///
+    /// Empty string means no filter is active. When non-empty, only orders
+    /// whose symbol contains this string (case-insensitive) are shown.
+    pub orders_symbol_filter: String,
+
+    /// Whether the Orders table is currently in filter-input mode.
+    ///
+    /// While `true`, printable key-presses are appended to `orders_symbol_filter`
+    /// instead of being handled as navigation or action shortcuts.
+    pub orders_filter_active: bool,
 }
 
 impl App {
@@ -646,10 +658,13 @@ impl App {
             equity_chart_cursor: None,
             positions_sort: SortState::default(),
             orders_sort: SortState::default(),
+            orders_symbol_filter: String::new(),
+            orders_filter_active: false,
         }
     }
 
     pub fn filtered_orders(&self) -> Vec<&Order> {
+        let filter = self.orders_symbol_filter.to_uppercase();
         self.orders
             .iter()
             .filter(|o| match self.orders_subtab {
@@ -667,6 +682,7 @@ impl App {
                     )
                 }
             })
+            .filter(|o| filter.is_empty() || o.symbol.to_uppercase().contains(&filter))
             .collect()
     }
 
@@ -994,6 +1010,54 @@ mod tests {
         let mut app = make_test_app();
         app.orders_subtab = OrdersSubTab::Open;
         assert!(app.filtered_orders().is_empty());
+    }
+
+    #[test]
+    fn filtered_orders_symbol_filter_narrows_results() {
+        let mut app = make_test_app();
+        app.orders = vec![
+            make_order("1", "new"), // symbol = AAPL
+            make_order("2", "new"), // symbol = AAPL
+        ];
+        // Override second order symbol via a custom Order
+        app.orders[1].symbol = "TSLA".into();
+        app.orders_subtab = OrdersSubTab::Open;
+        app.orders_symbol_filter = "AAPL".to_string();
+        let result = app.filtered_orders();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].symbol, "AAPL");
+    }
+
+    #[test]
+    fn filtered_orders_symbol_filter_is_case_insensitive() {
+        let mut app = make_test_app();
+        app.orders = vec![make_order("1", "new")]; // symbol = AAPL
+        app.orders_subtab = OrdersSubTab::Open;
+        app.orders_symbol_filter = "aapl".to_string();
+        assert_eq!(app.filtered_orders().len(), 1);
+    }
+
+    #[test]
+    fn filtered_orders_symbol_filter_empty_shows_all() {
+        let mut app = make_test_app();
+        app.orders = vec![make_order("1", "new"), make_order("2", "new")];
+        app.orders[1].symbol = "TSLA".into();
+        app.orders_subtab = OrdersSubTab::Open;
+        app.orders_symbol_filter = String::new();
+        assert_eq!(app.filtered_orders().len(), 2);
+    }
+
+    #[test]
+    fn filtered_orders_symbol_filter_prefix_match() {
+        let mut app = make_test_app();
+        app.orders = vec![make_order("1", "new"), make_order("2", "new")];
+        app.orders[1].symbol = "AMZN".into();
+        app.orders_subtab = OrdersSubTab::Open;
+        app.orders_symbol_filter = "AA".to_string();
+        // "AAPL" contains "AA", "AMZN" does not
+        let result = app.filtered_orders();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].symbol, "AAPL");
     }
 
     // ── push_equity ───────────────────────────────────────────────────────────

--- a/src/input/orders.rs
+++ b/src/input/orders.rs
@@ -210,4 +210,95 @@ mod tests {
         assert_eq!(app.orders_symbol_filter, "O");
         assert!(app.modal.is_none());
     }
+
+    #[test]
+    fn unhandled_key_in_filter_mode_is_ignored() {
+        // Arrow keys and other non-text keys should be silently ignored in filter mode
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Char('f'));
+        app.orders_symbol_filter = "AB".to_string();
+        press(&mut app, KeyCode::Tab);
+        press(&mut app, KeyCode::Home);
+        // filter string unchanged, mode still active
+        assert_eq!(app.orders_symbol_filter, "AB");
+        assert!(app.orders_filter_active);
+    }
+
+    #[test]
+    fn c_key_with_selected_order_opens_confirm_modal() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("order-abc-123", "new"));
+        app.orders_state.select(Some(0));
+        press(&mut app, KeyCode::Char('c'));
+        match &app.modal {
+            Some(crate::app::Modal::Confirm { action, .. }) => {
+                assert!(
+                    matches!(action, crate::app::ConfirmAction::CancelOrder(_)),
+                    "expected CancelOrder action"
+                );
+            }
+            other => panic!("expected Confirm modal, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn c_key_with_no_selection_does_nothing() {
+        let mut app = make_test_app();
+        // orders_state starts with no selection and no orders
+        press(&mut app, KeyCode::Char('c'));
+        assert!(app.modal.is_none());
+    }
+
+    #[test]
+    fn j_key_moves_selection_down() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("o1", "new"));
+        app.orders.push(make_order("o2", "new"));
+        app.orders_state.select(Some(0));
+        press(&mut app, KeyCode::Char('j'));
+        assert_eq!(app.orders_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn k_key_moves_selection_up() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("o1", "new"));
+        app.orders.push(make_order("o2", "new"));
+        app.orders_state.select(Some(1));
+        press(&mut app, KeyCode::Char('k'));
+        assert_eq!(app.orders_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn capital_g_jumps_to_last_row() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("o1", "new"));
+        app.orders.push(make_order("o2", "new"));
+        app.orders.push(make_order("o3", "new"));
+        app.orders_state.select(Some(0));
+        press(&mut app, KeyCode::Char('G'));
+        assert_eq!(app.orders_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn shift_f_resets_selection_to_zero() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("o1", "new"));
+        app.orders.push(make_order("o2", "new"));
+        app.orders_state.select(Some(1));
+        app.orders_symbol_filter = "AA".to_string();
+        let event = KeyEvent::new(KeyCode::Char('F'), KeyModifiers::SHIFT);
+        super::handle_orders_key(&mut app, event);
+        assert!(app.orders_symbol_filter.is_empty());
+        assert_eq!(app.orders_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn f_key_clears_previous_filter_before_activating() {
+        let mut app = make_test_app();
+        app.orders_symbol_filter = "OLD".to_string();
+        press(&mut app, KeyCode::Char('f'));
+        assert!(app.orders_filter_active);
+        assert!(app.orders_symbol_filter.is_empty());
+    }
 }

--- a/src/input/orders.rs
+++ b/src/input/orders.rs
@@ -3,6 +3,29 @@ use crossterm::event::KeyCode;
 use crate::app::{App, ConfirmAction, Modal, OrderEntryState, OrdersSubTab};
 
 pub(crate) fn handle_orders_key(app: &mut App, key: crossterm::event::KeyEvent) {
+    // While the filter input is active, intercept all keys for text editing.
+    if app.orders_filter_active {
+        match key.code {
+            KeyCode::Esc => {
+                app.orders_filter_active = false;
+                app.orders_symbol_filter.clear();
+                app.orders_state.select(Some(0));
+            }
+            KeyCode::Enter => {
+                app.orders_filter_active = false;
+                app.orders_state.select(Some(0));
+            }
+            KeyCode::Backspace => {
+                app.orders_symbol_filter.pop();
+            }
+            KeyCode::Char(c) => {
+                app.orders_symbol_filter.push(c.to_ascii_uppercase());
+            }
+            _ => {}
+        }
+        return;
+    }
+
     let orders = app.filtered_orders();
     let len = orders.len();
 
@@ -32,6 +55,16 @@ pub(crate) fn handle_orders_key(app: &mut App, key: crossterm::event::KeyEvent) 
                     confirmed: false,
                 });
             }
+        }
+        KeyCode::Char('f') => {
+            app.orders_filter_active = true;
+            app.orders_symbol_filter.clear();
+        }
+        KeyCode::Char('F') => {
+            // Clear any active symbol filter.
+            app.orders_symbol_filter.clear();
+            app.orders_filter_active = false;
+            app.orders_state.select(Some(0));
         }
         KeyCode::Char('s') => {
             app.orders_sort.col = app.orders_sort.col.cycle();
@@ -97,5 +130,84 @@ mod tests {
         assert_eq!(app.orders_subtab, crate::app::OrdersSubTab::Cancelled);
         press(&mut app, KeyCode::Char('1'));
         assert_eq!(app.orders_subtab, crate::app::OrdersSubTab::Open);
+    }
+
+    #[test]
+    fn f_key_activates_filter_mode() {
+        let mut app = make_test_app();
+        assert!(!app.orders_filter_active);
+        press(&mut app, KeyCode::Char('f'));
+        assert!(app.orders_filter_active);
+        assert!(app.orders_symbol_filter.is_empty());
+    }
+
+    #[test]
+    fn chars_typed_in_filter_mode_build_filter_string() {
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Char('f'));
+        press(&mut app, KeyCode::Char('a'));
+        press(&mut app, KeyCode::Char('a'));
+        press(&mut app, KeyCode::Char('p'));
+        press(&mut app, KeyCode::Char('l'));
+        assert_eq!(app.orders_symbol_filter, "AAPL");
+    }
+
+    #[test]
+    fn backspace_removes_last_char_in_filter_mode() {
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Char('f'));
+        press(&mut app, KeyCode::Char('a'));
+        press(&mut app, KeyCode::Char('b'));
+        press(&mut app, KeyCode::Backspace);
+        assert_eq!(app.orders_symbol_filter, "A");
+    }
+
+    #[test]
+    fn enter_confirms_filter_and_exits_input_mode() {
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Char('f'));
+        press(&mut app, KeyCode::Char('a'));
+        press(&mut app, KeyCode::Enter);
+        assert!(!app.orders_filter_active);
+        assert_eq!(app.orders_symbol_filter, "A");
+    }
+
+    #[test]
+    fn esc_clears_filter_and_exits_input_mode() {
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Char('f'));
+        press(&mut app, KeyCode::Char('a'));
+        press(&mut app, KeyCode::Esc);
+        assert!(!app.orders_filter_active);
+        assert!(app.orders_symbol_filter.is_empty());
+    }
+
+    #[test]
+    fn shift_f_clears_active_filter() {
+        let mut app = make_test_app();
+        app.orders_symbol_filter = "AAPL".to_string();
+        let event = KeyEvent::new(KeyCode::Char('F'), KeyModifiers::SHIFT);
+        super::handle_orders_key(&mut app, event);
+        assert!(app.orders_symbol_filter.is_empty());
+        assert!(!app.orders_filter_active);
+    }
+
+    #[test]
+    fn filter_mode_does_not_consume_normal_keys_when_inactive() {
+        // 'o' should open order modal when NOT in filter mode
+        let mut app = make_test_app();
+        assert!(!app.orders_filter_active);
+        press(&mut app, KeyCode::Char('o'));
+        assert!(app.modal.is_some());
+    }
+
+    #[test]
+    fn filter_mode_blocks_normal_key_handling() {
+        // When filter is active, 'o' should be appended to the filter string, not open modal
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Char('f'));
+        press(&mut app, KeyCode::Char('o'));
+        assert_eq!(app.orders_symbol_filter, "O");
+        assert!(app.modal.is_none());
     }
 }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -122,7 +122,7 @@ pub fn render_status(frame: &mut Frame, area: Rect, app: &App) {
         Tab::Positions => {
             " j/k:Navigate  Enter:Detail  o:Order  c:Copy  s:Sort  S:SortDir  T:Theme  A:About  ?:Help  q:Quit"
         }
-        Tab::Orders => " j/k:Navigate  o:New  c:Cancel  s:Sort  S:SortDir  1-3:Filter  T:Theme  A:About  ?:Help  q:Quit",
+        Tab::Orders => " j/k:Navigate  o:New  c:Cancel  f:Filter  F:ClearFilter  s:Sort  S:SortDir  1-3:Filter  T:Theme  A:About  ?:Help  q:Quit",
     };
 
     let status = if app.current_status_text().is_empty() {

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -64,6 +64,8 @@ fn render_help(frame: &mut Frame, area: Rect, app: &App) {
         ("/", "Search / filter watchlist"),
         ("s", "Cycle sort column (Positions / Orders)"),
         ("S", "Toggle sort direction ▲/▼ (Positions / Orders)"),
+        ("f", "Filter orders by symbol prefix"),
+        ("F", "Clear orders symbol filter"),
         ("", ""),
         ("GLOBAL", ""),
         ("T", "Cycle theme (Default → Dark → High-contrast)"),

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -98,10 +98,19 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
     let orders = app.filtered_orders();
     let is_filled_tab = app.orders_subtab == OrdersSubTab::Filled;
 
+    // Build block title — show filter state in the title.
+    let block_title = if app.orders_filter_active {
+        format!(" Orders / Filter: {}_ ", app.orders_symbol_filter)
+    } else if !app.orders_symbol_filter.is_empty() {
+        format!(" Orders [{}] ", app.orders_symbol_filter)
+    } else {
+        " Orders ".to_string()
+    };
+
     if orders.is_empty() {
         let para = Paragraph::new("  No orders in this category.")
             .style(c.dim_style())
-            .block(c.bordered_block(" Orders "));
+            .block(c.bordered_block(&block_title));
         frame.render_widget(para, area);
         return;
     }
@@ -215,7 +224,7 @@ fn render_table(frame: &mut Frame, area: Rect, app: &mut App) {
         })
         .collect();
 
-    let block = c.bordered_block(" Orders ");
+    let block = c.bordered_block(&block_title);
 
     let mut constraints = vec![
         Constraint::Length(10),
@@ -893,6 +902,68 @@ mod tests {
         assert!(
             output.contains("Open (1)"),
             "held status should count in Open subtab, got: {output}"
+        );
+    }
+
+    // ── Symbol filter render tests ─────────────────────────────────────────────
+
+    #[test]
+    fn orders_filter_active_shows_filter_prompt_in_title() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("o1", "new"));
+        app.orders_filter_active = true;
+        app.orders_symbol_filter = "AAP".to_string();
+        let output = render_orders_to_string(&mut app);
+        assert!(
+            output.contains("Filter: AAP"),
+            "expected 'Filter: AAP' in title when active, got: {output}"
+        );
+    }
+
+    #[test]
+    fn orders_filter_inactive_with_value_shows_bracket_notation() {
+        let mut app = make_test_app();
+        app.orders.push(make_order("o1", "new"));
+        app.orders_filter_active = false;
+        app.orders_symbol_filter = "TSLA".to_string();
+        let output = render_orders_to_string(&mut app);
+        assert!(
+            output.contains("[TSLA]"),
+            "expected '[TSLA]' bracket notation in title when filter set, got: {output}"
+        );
+    }
+
+    #[test]
+    fn orders_filter_narrows_displayed_rows() {
+        let mut app = make_test_app();
+        app.orders.push(make_order_full("o1", "AAPL", "buy", "new"));
+        app.orders.push(make_order_full("o2", "TSLA", "buy", "new"));
+        app.orders_symbol_filter = "TSLA".to_string();
+        let output = render_orders_to_string(&mut app);
+        assert!(
+            output.contains("TSLA"),
+            "TSLA should be visible when filter is TSLA, got: {output}"
+        );
+        assert!(
+            !output.contains("AAPL"),
+            "AAPL should be filtered out, got: {output}"
+        );
+    }
+
+    #[test]
+    fn orders_no_filter_shows_all_rows() {
+        let mut app = make_test_app();
+        app.orders.push(make_order_full("o1", "AAPL", "buy", "new"));
+        app.orders.push(make_order_full("o2", "TSLA", "buy", "new"));
+        app.orders_symbol_filter = String::new();
+        let output = render_orders_to_string(&mut app);
+        assert!(
+            output.contains("AAPL"),
+            "AAPL should be visible, got: {output}"
+        );
+        assert!(
+            output.contains("TSLA"),
+            "TSLA should be visible, got: {output}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Implements inline symbol filter for the Orders tab as requested in issue #86.

### Changes
- **app.rs**: Added `orders_symbol_filter: String` and `orders_filter_active: bool` fields; `filtered_orders()` now applies case-insensitive contains filter after subtab filter
- **input/orders.rs**: Filter mode intercept — `f` activates, typing appends (uppercased), Backspace removes, Enter confirms, Esc clears, `F` clears filter from normal mode
- **ui/orders.rs**: Dynamic block title: `"Filter: X_"` (active), `"[X]"` (set), `"Orders"` (no filter)
- **ui/dashboard.rs**: Added `f:Filter  F:ClearFilter` to Orders status bar hints
- **ui/modals.rs**: Added `f`/`F` entries to keyboard shortcuts help modal

### Tests
- Input handler: filter activation, char append, backspace, Enter/Esc behavior, F clear, filter mode blocks normal key handling
- App logic: symbol filter narrows results, case-insensitive match, empty filter shows all, prefix match
- Renderer: active filter shows prompt in title, inactive filter shows bracket notation, filtered rows visible/hidden

Closes #86
