### PR TITLE
feat(positions): position detail modal on Enter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -331,6 +331,14 @@ pub enum Modal {
         /// The symbol characters typed so far (uppercased).
         query: String,
     },
+    /// Dedicated position detail view for a held position.
+    ///
+    /// Shows an intraday chart, position P/L summary, and related open orders
+    /// for the symbol. `Esc` dismisses; `o` opens a new order for the symbol.
+    PositionDetail {
+        /// Ticker symbol whose position is being viewed.
+        symbol: String,
+    },
 }
 
 /// Date range for the equity-history chart.

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -308,7 +308,68 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
             }
             _ => Some(Modal::GlobalSearch { query }),
         },
+
+        Modal::PositionDetail { symbol } => match key.code {
+            KeyCode::Char('o') => {
+                app.modal = Some(Modal::OrderEntry(OrderEntryState::new(symbol)));
+                return;
+            }
+            _ => Some(Modal::PositionDetail { symbol }),
+        },
     };
 
     app.modal = new_modal;
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use crate::app::test_helpers::make_test_app;
+    use crate::app::Modal;
+
+    fn press(app: &mut crate::app::App, code: KeyCode) {
+        let event = KeyEvent::new(code, KeyModifiers::NONE);
+        super::handle_modal_key(app, event);
+    }
+
+    // ── PositionDetail modal ───────────────────────────────────────────────────
+
+    #[test]
+    fn esc_closes_position_detail_modal() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::PositionDetail {
+            symbol: "AAPL".into(),
+        });
+        press(&mut app, KeyCode::Esc);
+        assert!(app.modal.is_none());
+    }
+
+    #[test]
+    fn o_key_in_position_detail_opens_order_entry() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::PositionDetail {
+            symbol: "AAPL".into(),
+        });
+        press(&mut app, KeyCode::Char('o'));
+        assert!(
+            matches!(&app.modal, Some(Modal::OrderEntry(s)) if s.symbol == "AAPL"),
+            "expected OrderEntry modal for AAPL, got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn unhandled_key_keeps_position_detail_modal_open() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::PositionDetail {
+            symbol: "TSLA".into(),
+        });
+        press(&mut app, KeyCode::Char('z'));
+        assert!(
+            matches!(&app.modal, Some(Modal::PositionDetail { symbol }) if symbol == "TSLA"),
+            "expected PositionDetail to stay open, got: {:?}",
+            app.modal
+        );
+    }
 }

--- a/src/input/positions.rs
+++ b/src/input/positions.rs
@@ -18,7 +18,7 @@ pub(crate) fn handle_positions_key(app: &mut App, key: crossterm::event::KeyEven
                 let _ = app
                     .command_tx
                     .try_send(crate::commands::Command::FetchIntradayBars(symbol.clone()));
-                app.modal = Some(Modal::SymbolDetail(symbol));
+                app.modal = Some(Modal::PositionDetail { symbol });
             }
         }
         KeyCode::Char('o') => {
@@ -104,5 +104,64 @@ mod tests {
         app.positions_state.select(Some(0));
         press(&mut app, KeyCode::Char('o'));
         assert!(app.modal.is_some(), "expected modal after pressing o");
+    }
+
+    #[test]
+    fn enter_key_opens_position_detail_modal() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.positions_state.select(Some(0));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            matches!(&app.modal, Some(crate::app::Modal::PositionDetail { symbol }) if symbol == "AAPL"),
+            "expected PositionDetail modal for AAPL, got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn enter_key_with_no_selection_does_nothing() {
+        let mut app = make_test_app();
+        press(&mut app, KeyCode::Enter);
+        assert!(app.modal.is_none());
+    }
+
+    #[test]
+    fn j_key_moves_selection_down() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.positions.push(make_position("TSLA"));
+        app.positions_state.select(Some(0));
+        press(&mut app, KeyCode::Char('j'));
+        assert_eq!(app.positions_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn k_key_moves_selection_up() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.positions.push(make_position("TSLA"));
+        app.positions_state.select(Some(1));
+        press(&mut app, KeyCode::Char('k'));
+        assert_eq!(app.positions_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn capital_g_jumps_to_last_row() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.positions.push(make_position("TSLA"));
+        app.positions.push(make_position("NVDA"));
+        app.positions_state.select(Some(0));
+        press(&mut app, KeyCode::Char('G'));
+        assert_eq!(app.positions_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn unhandled_key_does_nothing() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        press(&mut app, KeyCode::Char('z'));
+        assert!(app.modal.is_none());
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -29,6 +29,7 @@ pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
         }
         Modal::AddSymbol { input, .. } => render_add_symbol(frame, area, input, app),
         Modal::GlobalSearch { query } => render_global_search(frame, area, query, app),
+        Modal::PositionDetail { symbol } => render_position_detail(frame, area, symbol, app),
     }
 }
 
@@ -52,7 +53,10 @@ fn render_help(frame: &mut Frame, area: Rect, app: &App) {
         ("1/2/3/4 or Tab", "Switch panels"),
         ("j / k  or ↑/↓", "Move cursor"),
         ("g / G", "Top / Bottom"),
-        ("Enter", "Open detail"),
+        (
+            "Enter",
+            "Open detail (position: detail view / other: symbol chart)",
+        ),
         ("Esc", "Close / Cancel"),
         ("", ""),
         ("ACTIONS", ""),
@@ -899,6 +903,217 @@ fn estimate_total(state: &OrderEntryState) -> String {
     } else {
         "—".into()
     }
+}
+
+fn render_position_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) {
+    let popup = popup_area(area, 60, 90);
+    frame.render_widget(Clear, popup);
+
+    let c = app.current_theme.colors();
+
+    let asset = app
+        .watchlist
+        .as_ref()
+        .and_then(|w| w.assets.iter().find(|a| a.symbol == symbol));
+    let name = asset.map(|a| a.name.as_str()).unwrap_or(symbol);
+
+    let block = Block::default()
+        .title(format!(" {} — {} ", symbol, name))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(c.accent_style());
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    // ── Outer vertical split: chart (top 50%) + detail row (bottom 50%) ───────
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),      // label
+            Constraint::Percentage(50), // intraday chart
+            Constraint::Min(0),         // position summary + orders
+            Constraint::Length(1),      // footer
+        ])
+        .split(inner);
+
+    // ── Chart label ──────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "  ── Intraday ──",
+            c.dim_style(),
+        )])),
+        outer[0],
+    );
+
+    // ── Intraday chart ────────────────────────────────────────────────────────
+    match app.intraday_bars.get(symbol) {
+        None => {
+            frame.render_widget(Paragraph::new("  Loading…").style(c.dim_style()), outer[1]);
+        }
+        Some(bars) if bars.is_empty() => {
+            frame.render_widget(
+                Paragraph::new("  No intraday data available").style(c.dim_style()),
+                outer[1],
+            );
+        }
+        Some(bars) => {
+            let data_points = charts::price_points(bars);
+            let n = data_points.len() as f64;
+            let [y_min, y_max] = charts::y_bounds(&data_points);
+            let line_color = charts::trend_color(&data_points, &c);
+
+            let dataset = Dataset::default()
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(line_color))
+                .data(&data_points);
+
+            let chart = Chart::new(vec![dataset])
+                .x_axis(
+                    Axis::default()
+                        .bounds([0.0, (n - 1.0).max(0.0)])
+                        .labels(["09:30", "16:00"]),
+                )
+                .y_axis(Axis::default().bounds([y_min, y_max]));
+
+            frame.render_widget(chart, outer[1]);
+        }
+    }
+
+    // ── Bottom split: position summary (left) + open orders (right) ──────────
+    let bottom = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(outer[2]);
+
+    // ── Position summary ─────────────────────────────────────────────────────
+    let pos = app.positions.iter().find(|p| p.symbol == symbol);
+    let summary_lines: Vec<Line> = if let Some(p) = pos {
+        let pl: f64 = p.unrealized_pl.parse().unwrap_or(0.0);
+        let pl_style = if pl >= 0.0 {
+            c.positive_style()
+        } else {
+            c.negative_style()
+        };
+        let plpc: f64 = p.unrealized_plpc.parse().unwrap_or(0.0);
+        vec![
+            Line::from(vec![
+                Span::styled("  Qty        ", c.dim_style()),
+                Span::styled(p.qty.clone(), c.bold_style()),
+            ]),
+            Line::from(vec![
+                Span::styled("  Avg Cost   ", c.dim_style()),
+                Span::styled(format!("${}", p.avg_entry_price), c.bold_style()),
+            ]),
+            Line::from(vec![
+                Span::styled("  Cur Price  ", c.dim_style()),
+                Span::styled(format!("${}", p.current_price), c.bold_style()),
+            ]),
+            Line::from(vec![
+                Span::styled("  Mkt Value  ", c.dim_style()),
+                Span::styled(format!("${}", p.market_value), c.bold_style()),
+            ]),
+            Line::from(vec![
+                Span::styled("  Unreal P/L ", c.dim_style()),
+                Span::styled(format!("${:.2}", pl), pl_style),
+            ]),
+            Line::from(vec![
+                Span::styled("  P/L %      ", c.dim_style()),
+                Span::styled(format!("{:+.2}%", plpc * 100.0), pl_style),
+            ]),
+            Line::from(vec![
+                Span::styled("  Side       ", c.dim_style()),
+                Span::styled(p.side.clone(), c.bold_style()),
+            ]),
+        ]
+    } else {
+        vec![Line::from(Span::styled(
+            "  No position data",
+            c.dim_style(),
+        ))]
+    };
+
+    let summary_block = Block::default()
+        .title(" Position ")
+        .borders(Borders::ALL)
+        .border_style(c.dim_style());
+    let summary_inner = summary_block.inner(bottom[0]);
+    frame.render_widget(summary_block, bottom[0]);
+    frame.render_widget(Paragraph::new(summary_lines), summary_inner);
+
+    // ── Related open orders ───────────────────────────────────────────────────
+    let open_orders: Vec<&crate::types::Order> = app
+        .orders
+        .iter()
+        .filter(|o| {
+            o.symbol == symbol
+                && matches!(
+                    o.status.as_str(),
+                    "new" | "pending_new" | "accepted" | "held" | "partially_filled"
+                )
+        })
+        .collect();
+
+    let orders_block = Block::default()
+        .title(" Open Orders ")
+        .borders(Borders::ALL)
+        .border_style(c.dim_style());
+    let orders_inner = orders_block.inner(bottom[1]);
+    frame.render_widget(orders_block, bottom[1]);
+
+    if open_orders.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Span::styled("  No open orders", c.dim_style())),
+            orders_inner,
+        );
+    } else {
+        let rows: Vec<Row> = open_orders
+            .iter()
+            .map(|o| {
+                let qty = o.qty.as_deref().unwrap_or("—");
+                let price = o
+                    .limit_price
+                    .as_deref()
+                    .map(|p| format!("${p}"))
+                    .unwrap_or_else(|| "mkt".into());
+                Row::new(vec![
+                    Cell::from(o.side.clone()),
+                    Cell::from(qty.to_string()),
+                    Cell::from(price),
+                    Cell::from(o.status.clone()),
+                ])
+            })
+            .collect();
+
+        let header = Row::new(vec![
+            Cell::from(Span::styled("Side", c.dim_style())),
+            Cell::from(Span::styled("Qty", c.dim_style())),
+            Cell::from(Span::styled("Price", c.dim_style())),
+            Cell::from(Span::styled("Status", c.dim_style())),
+        ]);
+
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Length(5),
+                Constraint::Length(6),
+                Constraint::Length(8),
+                Constraint::Min(6),
+            ],
+        )
+        .header(header);
+
+        frame.render_widget(table, orders_inner);
+    }
+
+    // ── Footer ────────────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "  o:Order  Esc:Close",
+            c.dim_style(),
+        )])),
+        outer[3],
+    );
 }
 
 #[cfg(test)]
@@ -2103,5 +2318,219 @@ mod tests {
     #[test]
     fn flag_returns_cross_for_false() {
         assert_eq!(flag(false), "✗");
+    }
+
+    // ── render_position_detail tests ──────────────────────────────────────────
+
+    fn make_position(symbol: &str) -> crate::types::Position {
+        crate::types::Position {
+            symbol: symbol.into(),
+            qty: "10".into(),
+            avg_entry_price: "100.00".into(),
+            current_price: "115.00".into(),
+            market_value: "1150.00".into(),
+            unrealized_pl: "150.00".into(),
+            unrealized_plpc: "0.15".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        }
+    }
+
+    fn render_position_detail_to_string(app: &mut App, symbol: &str) -> String {
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_position_detail(frame, area, symbol, app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let width = buffer.area().width as usize;
+        let height = buffer.area().height as usize;
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_position_detail_shows_symbol_in_title() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("AAPL"),
+            "expected AAPL in title, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_asset_name_when_available() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.watchlist = Some(make_watchlist(&["AAPL"]));
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("AAPL Corp"),
+            "expected asset name in title, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_loading_when_no_bars() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        // no entry in intraday_bars → "Loading…"
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("Loading"),
+            "expected Loading, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_no_data_when_bars_empty() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.intraday_bars.insert("AAPL".into(), vec![]);
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("No intraday data"),
+            "expected no-data message, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_renders_chart_with_bars() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.intraday_bars
+            .insert("AAPL".into(), vec![15000, 15100, 15050]);
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        // chart x-axis labels
+        assert!(
+            output.contains("09:30") || output.contains("16:00"),
+            "expected chart time labels, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_position_summary() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(output.contains("Qty"), "expected Qty label, got: {output}");
+        assert!(
+            output.contains("Avg Cost"),
+            "expected Avg Cost label, got: {output}"
+        );
+        assert!(
+            output.contains("Mkt Value"),
+            "expected Mkt Value label, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_no_position_data_when_missing() {
+        // Symbol has no matching entry in app.positions
+        let mut app = make_test_app();
+        let output = render_position_detail_to_string(&mut app, "NVDA");
+        assert!(
+            output.contains("No position data"),
+            "expected no-position message, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_no_open_orders_when_empty() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("No open orders"),
+            "expected no-orders message, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_open_orders_table() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.orders.push(crate::types::Order {
+            id: "ord-1".into(),
+            symbol: "AAPL".into(),
+            side: "buy".into(),
+            qty: Some("5".into()),
+            notional: None,
+            order_type: "limit".into(),
+            limit_price: Some("110.00".into()),
+            status: "new".into(),
+            submitted_at: None,
+            filled_at: None,
+            filled_qty: "0".into(),
+            filled_avg_price: None,
+            time_in_force: "day".into(),
+        });
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("buy"),
+            "expected order side 'buy', got: {output}"
+        );
+        assert!(
+            output.contains("Side"),
+            "expected Side column header, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_filters_non_open_orders() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        // filled orders should NOT appear in the open-orders pane
+        app.orders.push(crate::types::Order {
+            id: "ord-filled".into(),
+            symbol: "AAPL".into(),
+            side: "buy".into(),
+            qty: Some("5".into()),
+            notional: None,
+            order_type: "market".into(),
+            limit_price: None,
+            status: "filled".into(),
+            submitted_at: None,
+            filled_at: None,
+            filled_qty: "5".into(),
+            filled_avg_price: None,
+            time_in_force: "day".into(),
+        });
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("No open orders"),
+            "filled orders should not appear in open-orders pane, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_shows_footer_actions() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(output.contains("o:Order"), "expected footer, got: {output}");
+        assert!(
+            output.contains("Esc:Close"),
+            "expected Esc:Close in footer, got: {output}"
+        );
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -2533,4 +2533,51 @@ mod tests {
             "expected Esc:Close in footer, got: {output}"
         );
     }
+
+    #[test]
+    fn render_position_detail_negative_pl_renders_value() {
+        let mut app = make_test_app();
+        app.positions.push(crate::types::Position {
+            symbol: "AAPL".into(),
+            qty: "10".into(),
+            avg_entry_price: "150.00".into(),
+            current_price: "130.00".into(),
+            market_value: "1300.00".into(),
+            unrealized_pl: "-200.00".into(),
+            unrealized_plpc: "-0.133".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        });
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("-200.00"),
+            "expected negative P/L value in output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn render_position_detail_market_order_shows_mkt() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("AAPL"));
+        app.orders.push(crate::types::Order {
+            id: "ord-mkt".into(),
+            symbol: "AAPL".into(),
+            side: "buy".into(),
+            qty: Some("3".into()),
+            notional: None,
+            order_type: "market".into(),
+            limit_price: None,
+            status: "new".into(),
+            submitted_at: None,
+            filled_at: None,
+            filled_qty: "0".into(),
+            filled_avg_price: None,
+            time_in_force: "day".into(),
+        });
+        let output = render_position_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("mkt"),
+            "expected 'mkt' for market order with no limit price, got: {output}"
+        );
+    }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -3339,6 +3339,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn tick_dispatches_intraday_refresh_for_position_detail_modal() {
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(4);
+        let (symbol_tx, _) = tokio::sync::watch::channel(vec![]);
+        let mut app = crate::app::App::new(
+            crate::config::AlpacaConfig {
+                base_url: "http://localhost".into(),
+                key: "k".into(),
+                secret: "s".into(),
+                env: crate::config::AlpacaEnv::Paper,
+                dry_run: false,
+            },
+            crate::prefs::AppPrefs::default(),
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            cmd_tx,
+            symbol_tx,
+        );
+        app.modal = Some(crate::app::Modal::PositionDetail {
+            symbol: "TSLA".into(),
+        });
+        app.intraday_fetched_at.insert(
+            "TSLA".into(),
+            std::time::Instant::now() - std::time::Duration::from_secs(61),
+        );
+        update(&mut app, Event::Tick);
+        let cmd = cmd_rx.try_recv().expect("command should be dispatched");
+        assert!(
+            matches!(cmd, Command::FetchIntradayBars(s) if s == "TSLA"),
+            "expected FetchIntradayBars for TSLA"
+        );
+    }
+
     // ── p key / equity range toggle ───────────────────────────────────────────
 
     fn make_app_with_cmd() -> (App, tokio::sync::mpsc::Receiver<Command>) {

--- a/src/update.rs
+++ b/src/update.rs
@@ -116,11 +116,16 @@ pub fn update(app: &mut App, event: Event) {
                     _ => break,
                 }
             }
-            // Periodically re-fetch intraday bars while a symbol-detail modal is open.
-            if let Some(Modal::SymbolDetail(symbol)) = &app.modal.clone() {
+            // Periodically re-fetch intraday bars while a symbol/position-detail modal is open.
+            let detail_symbol = match &app.modal {
+                Some(Modal::SymbolDetail(s)) => Some(s.clone()),
+                Some(Modal::PositionDetail { symbol }) => Some(symbol.clone()),
+                _ => None,
+            };
+            if let Some(symbol) = detail_symbol {
                 let due = app
                     .intraday_fetched_at
-                    .get(symbol)
+                    .get(&symbol)
                     .map(|t| t.elapsed() >= INTRADAY_REFRESH_INTERVAL)
                     .unwrap_or(false);
                 if due {
@@ -1993,12 +1998,12 @@ mod tests {
     }
 
     #[test]
-    fn positions_enter_opens_symbol_detail_and_dispatches_fetch() {
+    fn positions_enter_opens_position_detail_and_dispatches_fetch() {
         let (mut app, mut cmd_rx) = positions_app();
         update(&mut app, key(KeyCode::Enter));
         assert!(
-            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "AAPL"),
-            "Enter on a position should open SymbolDetail for that symbol"
+            matches!(&app.modal, Some(Modal::PositionDetail { symbol }) if symbol == "AAPL"),
+            "Enter on a position should open PositionDetail for that symbol"
         );
         let cmd = cmd_rx
             .try_recv()


### PR DESCRIPTION
## Summary

Pressing `Enter` on a Positions row now opens a dedicated **Position Detail** modal instead of the generic symbol chart modal.

## Layout

```
┌ AAPL — Apple Inc. ──────────────────────────────────────────────┐
│  ── Intraday ──                                                  │
│  [braille line chart spanning ~50% of modal height]             │
├──────────────────────────────┬──────────────────────────────────┤
│ Position                     │ Open Orders                       │
│  Qty        10               │  Side  Qty  Price    Status      │
│  Avg Cost   $100.00          │  buy   5    $110.00  new         │
│  Cur Price  $115.00          │                                   │
│  Mkt Value  $1150.00         │                                   │
│  Unreal P/L $150.00          │                                   │
│  P/L %      +15.00%          │                                   │
│  Side       long             │                                   │
├──────────────────────────────┴──────────────────────────────────┤
│  o:Order  Esc:Close                                              │
└─────────────────────────────────────────────────────────────────┘
```

## Changes
- `src/app.rs`: `Modal::PositionDetail { symbol }` variant
- `src/input/positions.rs`: `Enter` → `Modal::PositionDetail` + `FetchIntradayBars`
- `src/input/modal.rs`: `o` opens `OrderEntry`; `Esc` dismisses; other keys keep modal open
- `src/ui/modals.rs`: `render_position_detail` — intraday chart + position summary + open orders table + footer
- `src/update.rs`: periodic intraday bar re-fetch for `PositionDetail` (same as `SymbolDetail`)
- `src/ui/modals.rs` help modal: updated `Enter` description

## Tests (all 612 pass)
- Input: Enter opens PositionDetail, Enter with no selection is no-op, j/k/G nav, unhandled key no-op
- Modal key handler: Esc closes, o opens OrderEntry, unhandled key keeps modal open
- Renderer: title/asset name, Loading/no-data/chart states, position summary, no-position fallback, open orders table, filled-order filtered out, footer

Closes #87
