### PR TITLE
feat(ui): keyboard shortcut help overlay (? key)

### DIFF
--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -19,13 +19,8 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
     };
 
     let new_modal = match modal {
-        Modal::Help => {
-            if key.code != KeyCode::Esc {
-                None
-            } else {
-                Some(Modal::Help)
-            }
-        }
+        // Esc is already handled above; any other key also closes the help overlay.
+        Modal::Help => None,
 
         Modal::About => None,
 
@@ -331,6 +326,40 @@ mod tests {
     fn press(app: &mut crate::app::App, code: KeyCode) {
         let event = KeyEvent::new(code, KeyModifiers::NONE);
         super::handle_modal_key(app, event);
+    }
+
+    // ── Help modal ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn esc_closes_help_modal() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        press(&mut app, KeyCode::Esc);
+        assert!(app.modal.is_none(), "Esc should close the Help modal");
+    }
+
+    #[test]
+    fn any_key_closes_help_modal() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            app.modal.is_none(),
+            "any key should close Help; got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn question_mark_closes_help_modal_when_open() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        press(&mut app, KeyCode::Char('?'));
+        assert!(
+            app.modal.is_none(),
+            "? should dismiss Help when already open; got: {:?}",
+            app.modal
+        );
     }
 
     // ── PositionDetail modal ───────────────────────────────────────────────────

--- a/src/update.rs
+++ b/src/update.rs
@@ -779,6 +779,25 @@ mod tests {
     }
 
     #[test]
+    fn key_question_mark_toggles_help_closed_when_open() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        update(&mut app, key(KeyCode::Char('?')));
+        assert!(
+            app.modal.is_none(),
+            "second ? should dismiss the Help overlay"
+        );
+    }
+
+    #[test]
+    fn help_modal_any_key_closes() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        update(&mut app, key(KeyCode::Enter));
+        assert!(app.modal.is_none(), "any key should close Help modal");
+    }
+
+    #[test]
     fn key_uppercase_a_opens_about() {
         let mut app = make_test_app();
         update(&mut app, key(KeyCode::Char('A')));


### PR DESCRIPTION
## Summary

Closes #91

Implements the keyboard shortcut help overlay accessible via the `?` key.

## Behaviour
- Press `?` from any context (when no modal is open) to open the Keyboard Shortcuts overlay
- `Esc`, `?` again, or any other key dismisses it
- Two-column table grouped by **NAVIGATION**, **ACTIONS**, and **GLOBAL** sections

## Changes

### `src/input/modal.rs`
- Simplified `Modal::Help` match arm: the previous `else { Some(Modal::Help) }` branch was dead code (unreachable — `Esc` is caught by the early-return guard at the top of `handle_modal_key`). Replaced with `Modal::Help => None` (any remaining key closes the overlay)
- Added 3 tests: `Esc` closes, any key closes, `?` closes when already open

### `src/update.rs`
- Added 2 tests: `?` toggles Help closed when already open, any key closes Help modal

## Testing
All 620 tests pass, clippy clean.