### PR TITLE
feat(mouse): double-click to open detail modal and outside-click dismiss

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -506,6 +506,9 @@ pub struct HitAreas {
     /// Full area of the equity chart block on the Account tab.
     /// Used to hit-test mouse clicks and map column → data-point index.
     pub equity_chart_area: Rect,
+    /// Bounding box of the currently rendered modal popup.
+    /// A left-click outside this area dismisses the modal.
+    pub modal_popup_area: Option<Rect>,
 }
 
 pub struct App {
@@ -571,6 +574,13 @@ pub struct App {
 
     /// Interactive element positions from the last rendered frame.
     pub hit_areas: HitAreas,
+
+    /// Tracks the last left-click's (row, time) for double-click detection.
+    ///
+    /// A second click on the same terminal row within
+    /// [`DOUBLE_CLICK_INTERVAL`] is treated as a double-click and opens
+    /// the detail modal (equivalent to pressing `Enter`).
+    pub last_click: Option<(u16, Instant)>,
 
     /// Timestamp of the first `g` keypress for `gg` (jump-to-top) detection.
     ///
@@ -660,6 +670,7 @@ impl App {
             market_stream_ok: false,
             account_stream_ok: false,
             hit_areas: HitAreas::default(),
+            last_click: None,
             pending_g_at: None,
             last_equity_stream_push: None,
             intraday_fetched_at: HashMap::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -577,9 +577,8 @@ pub struct App {
 
     /// Tracks the last left-click's (row, time) for double-click detection.
     ///
-    /// A second click on the same terminal row within
-    /// [`DOUBLE_CLICK_INTERVAL`] is treated as a double-click and opens
-    /// the detail modal (equivalent to pressing `Enter`).
+    /// A second click on the same terminal row within 400 ms is treated as a
+    /// double-click and opens the detail modal (equivalent to pressing `Enter`).
     pub last_click: Option<(u16, Instant)>,
 
     /// Timestamp of the first `g` keypress for `gg` (jump-to-top) detection.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -110,3 +110,18 @@ pub(crate) fn send_command(app: &mut App, cmd: Command, success_msg: impl Into<S
         }
     }
 }
+
+/// Simulate pressing `Enter` on the active tab.
+///
+/// Used by the mouse double-click handler to open the detail modal for the
+/// currently selected row without duplicating the per-tab Enter logic.
+pub(crate) fn handle_key_as_enter(app: &mut App) {
+    use crossterm::event::{KeyEvent, KeyModifiers};
+    let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+    match app.active_tab {
+        crate::app::Tab::Watchlist => watchlist::handle_watchlist_key(app, enter),
+        crate::app::Tab::Positions => positions::handle_positions_key(app, enter),
+        crate::app::Tab::Orders => orders::handle_orders_key(app, enter),
+        crate::app::Tab::Account => {}
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -125,3 +125,27 @@ pub(crate) fn handle_key_as_enter(app: &mut App) {
         crate::app::Tab::Account => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::app::test_helpers::make_test_app;
+    use crate::app::Tab;
+
+    #[test]
+    fn handle_key_as_enter_orders_tab_is_noop() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Orders;
+        // Enter on Orders with no selection should not crash and not open a modal.
+        super::handle_key_as_enter(&mut app);
+        assert!(app.modal.is_none());
+    }
+
+    #[test]
+    fn handle_key_as_enter_account_tab_is_noop() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Account;
+        // Account tab has no Enter action; should be a no-op.
+        super::handle_key_as_enter(&mut app);
+        assert!(app.modal.is_none());
+    }
+}

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -549,4 +549,38 @@ mod tests {
         // handle_modal_mouse falls through to other handlers and nothing changes)
         // This test just verifies no panic occurs.
     }
+
+    #[test]
+    fn click_outside_about_modal_dismisses_it() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::About);
+        app.hit_areas.modal_popup_area = Some(Rect::new(20, 5, 40, 25));
+        super::handle_mouse(&mut app, left_click(0, 0));
+        assert!(app.modal.is_none(), "click outside About should dismiss it");
+    }
+
+    #[test]
+    fn single_click_orders_row_selects_item() {
+        use crate::types::Order;
+        let mut app = make_test_app();
+        app.active_tab = Tab::Orders;
+        app.orders.push(Order {
+            id: "o1".into(),
+            symbol: "AAPL".into(),
+            side: "buy".into(),
+            qty: Some("1".into()),
+            notional: None,
+            order_type: "market".into(),
+            limit_price: None,
+            status: "new".into(),
+            submitted_at: None,
+            filled_at: None,
+            filled_qty: "0".into(),
+            filled_avg_price: None,
+            time_in_force: "day".into(),
+        });
+        app.hit_areas.list_data_start_y = 4;
+        super::handle_mouse(&mut app, left_click(10, 4));
+        assert_eq!(app.orders_state.selected(), Some(0));
+    }
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,7 +1,12 @@
+use std::time::{Duration, Instant};
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use crate::app::{App, Modal, OrderField, OrdersSubTab, Tab};
+
+/// Maximum interval between two clicks on the same row to be considered a double-click.
+const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(400);
 
 /// The tab labels exactly as rendered by the `Tabs` widget in `dashboard::render_tabs`.
 /// Each tab renders as ` <label> ` (one leading/trailing space), width = label.len() + 2.
@@ -110,30 +115,71 @@ pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
             Tab::Account => return,
         };
         let idx = data_row + offset;
-        match app.active_tab {
+
+        let row_in_bounds = match app.active_tab {
             Tab::Watchlist => {
                 let len = app.watchlist.as_ref().map(|w| w.assets.len()).unwrap_or(0);
                 if idx < len {
                     app.watchlist_state.select(Some(idx));
+                    true
+                } else {
+                    false
                 }
             }
             Tab::Positions => {
                 if idx < app.positions.len() {
                     app.positions_state.select(Some(idx));
+                    true
+                } else {
+                    false
                 }
             }
             Tab::Orders => {
                 let len = app.filtered_orders().len();
                 if idx < len {
                     app.orders_state.select(Some(idx));
+                    true
+                } else {
+                    false
                 }
             }
-            Tab::Account => {}
+            Tab::Account => false,
+        };
+
+        if row_in_bounds {
+            // Double-click: same row within DOUBLE_CLICK_INTERVAL → open detail (Enter)
+            let is_double = app.last_click.as_ref().is_some_and(|(last_row, last_at)| {
+                *last_row == row && last_at.elapsed() < DOUBLE_CLICK_INTERVAL
+            });
+            if is_double {
+                app.last_click = None;
+                crate::input::handle_key_as_enter(app);
+            } else {
+                app.last_click = Some((row, Instant::now()));
+            }
         }
     }
 }
 
 fn handle_modal_mouse(app: &mut App, col: u16, row: u16) {
+    // ── Click outside modal popup → dismiss ───────────────────────────────────
+    if let Some(popup) = app.hit_areas.modal_popup_area {
+        if !hit(popup, col, row) {
+            // Only dismiss modals that don't require explicit confirmation.
+            let dismissable = matches!(
+                &app.modal,
+                Some(Modal::Help)
+                    | Some(Modal::About)
+                    | Some(Modal::SymbolDetail(_))
+                    | Some(Modal::PositionDetail { .. })
+            );
+            if dismissable {
+                app.modal = None;
+                return;
+            }
+        }
+    }
+
     // ── OrderEntry: submit button ─────────────────────────────────────────────
     if let Some(submit_rect) = app.hit_areas.modal_submit {
         if hit(submit_rect, col, row) {
@@ -195,5 +241,312 @@ fn handle_modal_mouse(app: &mut App, col: u16, row: u16) {
             };
             crate::input::handle_modal_key(app, KeyEvent::new(code, KeyModifiers::NONE));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::layout::Rect;
+
+    use crate::app::test_helpers::make_test_app;
+    use crate::app::{Modal, Tab};
+
+    fn left_click(col: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: col,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    fn right_click(col: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Right),
+            column: col,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    fn scroll_down(col: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: col,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    // ── non-Left-click is a no-op ─────────────────────────────────────────────
+
+    #[test]
+    fn right_click_is_ignored() {
+        let mut app = make_test_app();
+        app.hit_areas.tab_bar = Rect::new(0, 0, 80, 1);
+        super::handle_mouse(&mut app, right_click(5, 0));
+        // No tab switch
+        assert_eq!(app.active_tab, Tab::Account);
+    }
+
+    #[test]
+    fn scroll_event_is_ignored() {
+        let mut app = make_test_app();
+        app.hit_areas.tab_bar = Rect::new(0, 0, 80, 1);
+        super::handle_mouse(&mut app, scroll_down(5, 0));
+        assert_eq!(app.active_tab, Tab::Account);
+    }
+
+    // ── Tab bar ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn click_tab_bar_switches_to_watchlist() {
+        let mut app = make_test_app();
+        // Tab bar at row 0. "1:Account"=11 chars → width 13, then "|" → x=14.
+        // "2:Watchlist"=11 chars → width 13, starts at x=14.
+        app.hit_areas.tab_bar = Rect::new(0, 0, 80, 1);
+        // x=15 is inside "2:Watchlist" tab rect
+        super::handle_mouse(&mut app, left_click(15, 0));
+        assert_eq!(app.active_tab, Tab::Watchlist);
+    }
+
+    #[test]
+    fn click_tab_bar_outside_any_tab_is_noop() {
+        let mut app = make_test_app();
+        // height=0 → tab bar disabled
+        app.hit_areas.tab_bar = Rect::new(0, 0, 80, 0);
+        super::handle_mouse(&mut app, left_click(5, 0));
+        assert_eq!(app.active_tab, Tab::Account);
+    }
+
+    // ── List row selection ────────────────────────────────────────────────────
+
+    #[test]
+    fn single_click_row_selects_position() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Positions;
+        app.positions.push(crate::types::Position {
+            symbol: "AAPL".into(),
+            qty: "1".into(),
+            avg_entry_price: "100".into(),
+            current_price: "110".into(),
+            market_value: "110".into(),
+            unrealized_pl: "10".into(),
+            unrealized_plpc: "0.1".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        });
+        app.positions.push(crate::types::Position {
+            symbol: "TSLA".into(),
+            qty: "2".into(),
+            avg_entry_price: "200".into(),
+            current_price: "210".into(),
+            market_value: "420".into(),
+            unrealized_pl: "20".into(),
+            unrealized_plpc: "0.05".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        });
+        app.hit_areas.list_data_start_y = 5;
+        // Click on row 6 → data_row=1 (second position)
+        super::handle_mouse(&mut app, left_click(10, 6));
+        assert_eq!(app.positions_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn single_click_out_of_bounds_row_is_ignored() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Positions;
+        app.hit_areas.list_data_start_y = 5;
+        // No positions, click at row 6 → idx=1 >= len=0 → noop
+        super::handle_mouse(&mut app, left_click(10, 6));
+        assert_eq!(app.positions_state.selected(), None);
+    }
+
+    // ── Double-click opens detail modal ───────────────────────────────────────
+
+    #[test]
+    fn double_click_watchlist_row_opens_symbol_detail() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Watchlist;
+        app.watchlist = Some(crate::types::Watchlist {
+            id: "w1".into(),
+            name: "Default".into(),
+            assets: vec![crate::types::Asset {
+                exchange: "NASDAQ".into(),
+                tradable: true,
+                shortable: true,
+                fractionable: true,
+                easy_to_borrow: true,
+                id: "a1".into(),
+                symbol: "AAPL".into(),
+                name: "Apple Inc.".into(),
+                asset_class: "us_equity".into(),
+            }],
+        });
+        app.watchlist_state.select(Some(0));
+        app.hit_areas.list_data_start_y = 3;
+
+        // First click: selects row, records last_click
+        super::handle_mouse(&mut app, left_click(10, 3));
+        assert!(app.modal.is_none(), "first click should not open modal");
+        assert!(app.last_click.is_some(), "last_click should be set");
+
+        // Second click immediately after: should open SymbolDetail
+        super::handle_mouse(&mut app, left_click(10, 3));
+        assert!(
+            matches!(&app.modal, Some(Modal::SymbolDetail(s)) if s == "AAPL"),
+            "double-click should open SymbolDetail, got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn double_click_positions_row_opens_position_detail() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Positions;
+        app.positions.push(crate::types::Position {
+            symbol: "TSLA".into(),
+            qty: "5".into(),
+            avg_entry_price: "200".into(),
+            current_price: "220".into(),
+            market_value: "1100".into(),
+            unrealized_pl: "100".into(),
+            unrealized_plpc: "0.1".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        });
+        app.positions_state.select(Some(0));
+        app.hit_areas.list_data_start_y = 3;
+
+        super::handle_mouse(&mut app, left_click(10, 3));
+        assert!(app.modal.is_none());
+
+        super::handle_mouse(&mut app, left_click(10, 3));
+        assert!(
+            matches!(&app.modal, Some(Modal::PositionDetail { symbol }) if symbol == "TSLA"),
+            "double-click should open PositionDetail, got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn double_click_on_different_row_does_not_open_modal() {
+        let mut app = make_test_app();
+        app.active_tab = Tab::Positions;
+        app.positions.push(crate::types::Position {
+            symbol: "A".into(),
+            qty: "1".into(),
+            avg_entry_price: "1".into(),
+            current_price: "1".into(),
+            market_value: "1".into(),
+            unrealized_pl: "0".into(),
+            unrealized_plpc: "0".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        });
+        app.positions.push(crate::types::Position {
+            symbol: "B".into(),
+            qty: "1".into(),
+            avg_entry_price: "1".into(),
+            current_price: "1".into(),
+            market_value: "1".into(),
+            unrealized_pl: "0".into(),
+            unrealized_plpc: "0".into(),
+            side: "long".into(),
+            asset_class: "us_equity".into(),
+        });
+        app.hit_areas.list_data_start_y = 3;
+
+        // Click row 3 (first position)
+        super::handle_mouse(&mut app, left_click(10, 3));
+        // Click row 4 (second position) — different row, no modal
+        super::handle_mouse(&mut app, left_click(10, 4));
+        assert!(
+            app.modal.is_none(),
+            "clicks on different rows should not trigger double-click"
+        );
+    }
+
+    // ── Outside-modal dismiss ─────────────────────────────────────────────────
+
+    #[test]
+    fn click_outside_help_modal_dismisses_it() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        // Popup occupies columns 20-60, rows 5-30
+        app.hit_areas.modal_popup_area = Some(Rect::new(20, 5, 40, 25));
+        // Click at (0, 0) — outside the popup
+        super::handle_mouse(&mut app, left_click(0, 0));
+        assert!(app.modal.is_none(), "click outside Help should dismiss it");
+    }
+
+    #[test]
+    fn click_inside_help_modal_does_not_dismiss() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        app.hit_areas.modal_popup_area = Some(Rect::new(20, 5, 40, 25));
+        // Click inside popup
+        super::handle_mouse(&mut app, left_click(30, 10));
+        // Help modal stays (no other interactive elements inside it to change modal to None)
+        // It stays as Help unless a key dismisses it
+        assert!(
+            app.modal.is_some(),
+            "click inside Help should not dismiss it"
+        );
+    }
+
+    #[test]
+    fn click_outside_order_entry_modal_does_not_dismiss() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::OrderEntry(crate::app::OrderEntryState::new(
+            "AAPL".into(),
+        )));
+        app.hit_areas.modal_popup_area = Some(Rect::new(20, 5, 40, 40));
+        // Click outside — OrderEntry is not in the dismissable set
+        super::handle_mouse(&mut app, left_click(0, 0));
+        assert!(
+            app.modal.is_some(),
+            "OrderEntry should not be dismissable by outside click"
+        );
+    }
+
+    #[test]
+    fn click_outside_symbol_detail_dismisses_it() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::SymbolDetail("AAPL".into()));
+        app.hit_areas.modal_popup_area = Some(Rect::new(10, 3, 60, 40));
+        super::handle_mouse(&mut app, left_click(0, 0));
+        assert!(
+            app.modal.is_none(),
+            "click outside SymbolDetail should dismiss it"
+        );
+    }
+
+    #[test]
+    fn click_outside_position_detail_dismisses_it() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::PositionDetail {
+            symbol: "TSLA".into(),
+        });
+        app.hit_areas.modal_popup_area = Some(Rect::new(10, 3, 60, 40));
+        super::handle_mouse(&mut app, left_click(0, 0));
+        assert!(
+            app.modal.is_none(),
+            "click outside PositionDetail should dismiss it"
+        );
+    }
+
+    #[test]
+    fn no_modal_popup_area_does_not_panic() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        app.hit_areas.modal_popup_area = None;
+        // Should not dismiss (no popup area registered) and not panic
+        super::handle_mouse(&mut app, left_click(0, 0));
+        // Help stays (no popup registered, so no dismiss logic runs, but
+        // handle_modal_mouse falls through to other handlers and nothing changes)
+        // This test just verifies no panic occurs.
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -2594,4 +2594,50 @@ mod tests {
             "expected 'mkt' for market order with no limit price, got: {output}"
         );
     }
+
+    #[test]
+    fn render_dispatch_position_detail_modal() {
+        let mut app = make_test_app();
+        app.positions.push(make_position("TSLA"));
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render(
+                    frame,
+                    area,
+                    &Modal::PositionDetail {
+                        symbol: "TSLA".into(),
+                    },
+                    &mut app,
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let output: String = (0..buffer.area().height as usize)
+            .map(|row| {
+                (0..buffer.area().width as usize)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            output.contains("TSLA"),
+            "render() with Modal::PositionDetail should display the symbol"
+        );
+        assert!(
+            app.hit_areas.modal_popup_area.is_some(),
+            "render() should set modal_popup_area for PositionDetail"
+        );
+    }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -14,6 +14,20 @@ use crate::app::{App, ConfirmAction, Modal, OrderEntryState, OrderField};
 use crate::ui::{charts, popup_area};
 
 pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
+    // Register the popup bounding box so the mouse handler can dismiss the modal
+    // when the user clicks outside it.
+    app.hit_areas.modal_popup_area = Some(match modal {
+        Modal::Help => popup_area(area, 50, 70),
+        Modal::About => popup_area(area, 50, 60),
+        Modal::OrderEntry(_) => popup_area(area, 45, 65),
+        Modal::SymbolDetail(_) => popup_area(area, 55, 88),
+        Modal::Confirm { .. } => popup_area(area, 40, 25),
+        Modal::ConfirmRemoveWatchlist { .. } => popup_area(area, 42, 22),
+        Modal::AddSymbol { .. } => popup_area(area, 35, 20),
+        Modal::GlobalSearch { .. } => popup_area(area, 35, 20),
+        Modal::PositionDetail { .. } => popup_area(area, 60, 90),
+    });
+
     match modal {
         Modal::Help => render_help(frame, area, app),
         Modal::About => render_about(frame, area, app),


### PR DESCRIPTION
## Summary

Implements the remaining mouse interaction features described in #92:

### Double-click to open detail modal
- Added `last_click: Option<(u16, Instant)>` to `App` struct for tracking the last clicked row and timestamp
- Detecting a second click on the same terminal row within 400 ms triggers `handle_key_as_enter`, which dispatches a synthetic `Enter` event to the active tab handler
- Added `handle_key_as_enter` in `src/input/mod.rs` — forwards to Watchlist (SymbolDetail), Positions (PositionDetail), or Orders (no-op)

### Click outside modal to dismiss it
- Added `modal_popup_area: Option<Rect>` to `HitAreas` struct
- `src/ui/modals.rs` now stores the computed popup area in `hit_areas` before each modal render
- `handle_modal_mouse` checks whether a click falls outside the registered area and dismisses dismissable modals: `Help`, `About`, `SymbolDetail`, `PositionDetail`
- `OrderEntry`, `Confirm`, `ConfirmRemoveWatchlist`, `AddSymbol`, `GlobalSearch` require explicit input and are intentionally not dismissable

### Tests (15 new in `src/input/mouse.rs`)
- Non-left-click events ignored
- Tab-bar click changes active tab
- Single click selects a row
- Double-click on same row opens detail modal (Watchlist + Positions)
- Double-click on different row does not open modal
- Outside-click dismisses Help, SymbolDetail, PositionDetail
- Inside-click keeps modal open
- OrderEntry not dismissable by outside-click
- `None` popup area does not panic

Closes #92