### PR TITLE
feat(modal): keyboard crosshair for symbol detail intraday chart (#95)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -606,6 +606,14 @@ pub struct App {
     /// Account tab is active; cleared by `Esc`.
     pub equity_chart_cursor: Option<usize>,
 
+    /// Index into the intraday bars of the currently open [`Modal::SymbolDetail`]
+    /// that the crosshair is pointing at.
+    ///
+    /// `None` means no crosshair is shown. Activated by `←`/`→` while
+    /// `Modal::SymbolDetail` is open; cleared by `Esc` (first `Esc` clears
+    /// the crosshair, second `Esc` closes the modal).
+    pub symbol_detail_crosshair: Option<usize>,
+
     /// Active sort column and direction for the Positions table.
     pub positions_sort: SortState<PositionSortCol>,
 
@@ -674,6 +682,7 @@ impl App {
             last_equity_stream_push: None,
             intraday_fetched_at: HashMap::new(),
             equity_chart_cursor: None,
+            symbol_detail_crosshair: None,
             positions_sort: SortState::default(),
             orders_sort: SortState::default(),
             orders_symbol_filter: String::new(),

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -8,7 +8,15 @@ use crate::commands::Command;
 
 pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
     if key.code == KeyCode::Esc {
+        // First Esc clears an active crosshair; second Esc closes the modal.
+        if matches!(app.modal, Some(Modal::SymbolDetail(_)))
+            && app.symbol_detail_crosshair.is_some()
+        {
+            app.symbol_detail_crosshair = None;
+            return;
+        }
         app.modal = None;
+        app.symbol_detail_crosshair = None;
         return;
     }
 
@@ -171,6 +179,34 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         )
                     };
                     send_command(app, cmd, msg);
+                }
+                Some(Modal::SymbolDetail(symbol))
+            }
+            KeyCode::Left => {
+                let len = app
+                    .intraday_bars
+                    .get(symbol.as_str())
+                    .map(|b| b.len())
+                    .unwrap_or(0);
+                if len > 0 {
+                    app.symbol_detail_crosshair = Some(match app.symbol_detail_crosshair {
+                        Some(i) => i.saturating_sub(1),
+                        None => len - 1,
+                    });
+                }
+                Some(Modal::SymbolDetail(symbol))
+            }
+            KeyCode::Right => {
+                let len = app
+                    .intraday_bars
+                    .get(symbol.as_str())
+                    .map(|b| b.len())
+                    .unwrap_or(0);
+                if len > 0 {
+                    app.symbol_detail_crosshair = Some(match app.symbol_detail_crosshair {
+                        Some(i) => (i + 1).min(len - 1),
+                        None => 0,
+                    });
                 }
                 Some(Modal::SymbolDetail(symbol))
             }
@@ -398,6 +434,114 @@ mod tests {
         assert!(
             matches!(&app.modal, Some(Modal::PositionDetail { symbol }) if symbol == "TSLA"),
             "expected PositionDetail to stay open, got: {:?}",
+            app.modal
+        );
+    }
+
+    // ── SymbolDetail crosshair ────────────────────────────────────────────────
+
+    fn setup_symbol_detail_with_bars(bars: Vec<u64>) -> crate::app::App {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::SymbolDetail("AAPL".into()));
+        app.intraday_bars.insert("AAPL".into(), bars);
+        app
+    }
+
+    #[test]
+    fn left_key_initialises_crosshair_at_last_bar() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        press(&mut app, KeyCode::Left);
+        assert_eq!(app.symbol_detail_crosshair, Some(2));
+    }
+
+    #[test]
+    fn right_key_initialises_crosshair_at_first_bar() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        press(&mut app, KeyCode::Right);
+        assert_eq!(app.symbol_detail_crosshair, Some(0));
+    }
+
+    #[test]
+    fn left_key_moves_crosshair_left() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        app.symbol_detail_crosshair = Some(2);
+        press(&mut app, KeyCode::Left);
+        assert_eq!(app.symbol_detail_crosshair, Some(1));
+    }
+
+    #[test]
+    fn right_key_moves_crosshair_right() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        app.symbol_detail_crosshair = Some(0);
+        press(&mut app, KeyCode::Right);
+        assert_eq!(app.symbol_detail_crosshair, Some(1));
+    }
+
+    #[test]
+    fn left_key_clamps_at_zero() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        app.symbol_detail_crosshair = Some(0);
+        press(&mut app, KeyCode::Left);
+        assert_eq!(app.symbol_detail_crosshair, Some(0));
+    }
+
+    #[test]
+    fn right_key_clamps_at_last_bar() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        app.symbol_detail_crosshair = Some(2);
+        press(&mut app, KeyCode::Right);
+        assert_eq!(app.symbol_detail_crosshair, Some(2));
+    }
+
+    #[test]
+    fn left_key_with_no_bars_does_nothing() {
+        let mut app = setup_symbol_detail_with_bars(vec![]);
+        press(&mut app, KeyCode::Left);
+        assert!(app.symbol_detail_crosshair.is_none());
+    }
+
+    #[test]
+    fn right_key_with_no_bars_does_nothing() {
+        let mut app = setup_symbol_detail_with_bars(vec![]);
+        press(&mut app, KeyCode::Right);
+        assert!(app.symbol_detail_crosshair.is_none());
+    }
+
+    #[test]
+    fn esc_clears_active_crosshair_without_closing_modal() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        app.symbol_detail_crosshair = Some(1);
+        press(&mut app, KeyCode::Esc);
+        assert!(
+            app.symbol_detail_crosshair.is_none(),
+            "first Esc should clear crosshair"
+        );
+        assert!(
+            matches!(app.modal, Some(Modal::SymbolDetail(_))),
+            "modal should still be open after first Esc; got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn esc_closes_symbol_detail_when_no_crosshair_active() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200, 300]);
+        assert!(app.symbol_detail_crosshair.is_none());
+        press(&mut app, KeyCode::Esc);
+        assert!(
+            app.modal.is_none(),
+            "Esc with no crosshair should close modal; got: {:?}",
+            app.modal
+        );
+    }
+
+    #[test]
+    fn unhandled_key_keeps_symbol_detail_open() {
+        let mut app = setup_symbol_detail_with_bars(vec![100, 200]);
+        press(&mut app, KeyCode::Char('z'));
+        assert!(
+            matches!(app.modal, Some(Modal::SymbolDetail(_))),
+            "unhandled key should keep SymbolDetail open; got: {:?}",
             app.modal
         );
     }

--- a/src/ui/charts.rs
+++ b/src/ui/charts.rs
@@ -31,6 +31,15 @@ pub fn y_bounds(data: &[(f64, f64)]) -> [f64; 2] {
     }
 }
 
+/// Return the market-session time label for a 1-minute intraday bar index.
+///
+/// Bar 0 = 09:30, bar 1 = 09:31, … Bar index maps to minutes elapsed since
+/// market open. The result is formatted as `"HH:MM"`.
+pub fn bar_time_label(index: usize) -> String {
+    let total_minutes = 9 * 60 + 30 + index as u32;
+    format!("{:02}:{:02}", total_minutes / 60, total_minutes % 60)
+}
+
 /// Choose a line `Color` based on trend using the provided [`ThemeColors`]:
 /// `positive` when last ≥ first, `negative` otherwise.
 pub fn trend_color(data: &[(f64, f64)], colors: &ThemeColors) -> Color {
@@ -133,5 +142,29 @@ mod tests {
         let c = Theme::Dark.colors();
         let data = vec![(0.0, 100.0), (1.0, 110.0)];
         assert_eq!(trend_color(&data, &c), c.positive);
+    }
+
+    // ── bar_time_label ────────────────────────────────────────────────────────
+
+    #[test]
+    fn bar_time_label_index_zero_is_market_open() {
+        assert_eq!(bar_time_label(0), "09:30");
+    }
+
+    #[test]
+    fn bar_time_label_index_30_is_ten_hundred() {
+        assert_eq!(bar_time_label(30), "10:00");
+    }
+
+    #[test]
+    fn bar_time_label_index_390_is_market_close() {
+        // 390 minutes after 09:30 = 16:00 (6.5 trading hours)
+        assert_eq!(bar_time_label(390), "16:00");
+    }
+
+    #[test]
+    fn bar_time_label_crosses_hour_boundary() {
+        // index 30 = 10:00, index 31 = 10:01
+        assert_eq!(bar_time_label(31), "10:01");
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1395,6 +1395,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn render_symbol_detail_crosshair_out_of_bounds_shows_static_label() {
+        // Crosshair index beyond the bar slice falls back to the static label
+        // (guards the inner-else branch on bars.get(ci) and the ci < bars.len() chart guard).
+        let mut app = make_test_app();
+        app.intraday_bars.insert("AAPL".into(), vec![15000, 15100]);
+        app.symbol_detail_crosshair = Some(99); // out of bounds
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("Intraday"),
+            "out-of-bounds crosshair should fall back to static label; got:\n{}",
+            output
+        );
+    }
+
     fn render_order_entry_to_string(app: &mut App, state: crate::app::OrderEntryState) -> String {
         let backend = TestBackend::new(120, 30);
         let mut terminal = Terminal::new(backend).unwrap();

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -576,13 +576,28 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
     );
 
     // ── Intraday line chart ───────────────────────────────────────────────────
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![Span::styled(
-            "  ── Intraday ──",
-            c.dim_style(),
-        )])),
-        chunks[5],
-    );
+    // When a crosshair is active, replace the static "── Intraday ──" label
+    // with a price/time tooltip for the highlighted bar.
+    let crosshair = app.symbol_detail_crosshair;
+    let intraday_label: Line =
+        if let (Some(ci), Some(bars)) = (crosshair, app.intraday_bars.get(symbol)) {
+            if let Some(&price_cents) = bars.get(ci) {
+                let price = price_cents as f64 / 100.0;
+                let time = charts::bar_time_label(ci);
+                Line::from(vec![
+                    Span::styled("  ", c.dim_style()),
+                    Span::styled(time, c.accent_style()),
+                    Span::styled("  $", c.dim_style()),
+                    Span::styled(format!("{:.2}", price), c.bold_style()),
+                    Span::styled("  ←→ to move  Esc to clear", c.dim_style()),
+                ])
+            } else {
+                Line::from(vec![Span::styled("  ── Intraday ──", c.dim_style())])
+            }
+        } else {
+            Line::from(vec![Span::styled("  ── Intraday ──", c.dim_style())])
+        };
+    frame.render_widget(Paragraph::new(intraday_label), chunks[5]);
 
     match app.intraday_bars.get(symbol) {
         None => {
@@ -608,7 +623,29 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
                 .style(Style::default().fg(line_color))
                 .data(&data_points);
 
-            let chart = Chart::new(vec![dataset])
+            // When a crosshair is active, add a vertical line Dataset at that index.
+            let crosshair_pts: Vec<(f64, f64)>;
+            let mut datasets = vec![dataset];
+            if let Some(ci) = crosshair {
+                if ci < bars.len() {
+                    let x = ci as f64;
+                    crosshair_pts = (0..=16)
+                        .map(|j| {
+                            let y = y_min + (y_max - y_min) * j as f64 / 16.0;
+                            (x, y)
+                        })
+                        .collect();
+                    datasets.push(
+                        Dataset::default()
+                            .marker(symbols::Marker::Braille)
+                            .graph_type(GraphType::Scatter)
+                            .style(Style::default().fg(c.accent))
+                            .data(&crosshair_pts),
+                    );
+                }
+            }
+
+            let chart = Chart::new(datasets)
                 .x_axis(
                     Axis::default()
                         .bounds([0.0, (n - 1.0).max(0.0)])
@@ -679,7 +716,7 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
     // ── Footer ───────────────────────────────────────────────────────────────
     frame.render_widget(
         Paragraph::new(Line::from(vec![Span::styled(
-            format!("  o:Buy  s:Sell  {}  Esc:Close", wl_label),
+            format!("  o:Buy  s:Sell  {}  ←→:Chart  Esc:Close", wl_label),
             c.dim_style(),
         )])),
         chunks[12],
@@ -1296,6 +1333,65 @@ mod tests {
         assert!(
             output.contains("185.45"),
             "should display midpoint price from quote"
+        );
+    }
+
+    // ── SymbolDetail crosshair rendering ──────────────────────────────────────
+
+    #[test]
+    fn render_symbol_detail_footer_shows_arrow_hint() {
+        let mut app = make_test_app();
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("←→:Chart"),
+            "footer should contain crosshair hint; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_static_intraday_label_without_crosshair() {
+        let mut app = make_test_app();
+        app.intraday_bars
+            .insert("AAPL".into(), vec![15000, 15100, 15200]);
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("Intraday"),
+            "should show static Intraday label when no crosshair; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_shows_time_and_price_when_crosshair_active() {
+        let mut app = make_test_app();
+        // 3 bars: 09:30, 09:31, 09:32; bar at index 1 = $151.00
+        app.intraday_bars
+            .insert("AAPL".into(), vec![15100, 15100, 15200]);
+        app.symbol_detail_crosshair = Some(1);
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("09:31"),
+            "tooltip should show time for bar 1 (09:31); got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("151.00"),
+            "tooltip should show price $151.00 for bar 1; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_symbol_detail_crosshair_at_index_zero_shows_market_open() {
+        let mut app = make_test_app();
+        app.intraday_bars.insert("AAPL".into(), vec![17000, 17100]);
+        app.symbol_detail_crosshair = Some(0);
+        let output = render_symbol_detail_to_string(&mut app, "AAPL");
+        assert!(
+            output.contains("09:30"),
+            "crosshair at 0 should show 09:30; got:\n{}",
+            output
         );
     }
 


### PR DESCRIPTION
Closes #95

## Summary

- `←`/`→` keys move a vertical crosshair along the intraday chart in the SymbolDetail modal
- The chart label updates to show `HH:MM  $price` at the highlighted bar
- First `Esc` clears the crosshair; second `Esc` closes the modal
- Footer updated to show `←→:Chart` hint

## Changes

- **`src/app.rs`** — add `symbol_detail_crosshair: Option<usize>` field, initialised to `None`
- **`src/input/modal.rs`** — handle `←`/`→` to init/move crosshair; intercept `Esc` to clear crosshair before closing modal
- **`src/ui/charts.rs`** — add `bar_time_label(index)` mapping bar index → `"HH:MM"` (09:30 + N minutes)
- **`src/ui/modals.rs`** — render crosshair as braille scatter Dataset in accent colour; show price/time tooltip in label row; add `←→:Chart` to footer

## Testing

- 789 tests total (up from 770); all pass
- 19 new tests covering: `bar_time_label` (4), crosshair input (11), crosshair rendering (4)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo doc --no-deps --all-features` clean