### PR TITLE
docs(readme): update key bindings, feature list, and test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,26 +10,84 @@
 
 An Alpaca Markets trading toolkit for Rust — ships as both an **integratable library** and a **standalone TUI trading app**.
 
-- **Library** (`alpaca_trader_rs` crate): typed async REST client, shared domain types, and WebSocket streaming primitives — embed it in your own Rust application.
-- **App** (`alpaca-trader` binary): a full interactive terminal dashboard built on the library, with live account data, positions, orders, watchlist management, and order entry.
+- **Library** (`alpaca_trader_rs` crate): typed async REST client, shared domain types, and WebSocket streaming primitives.
+- **App** (`alpaca-trader` binary): full interactive terminal dashboard with live account data, positions, orders, watchlist management, and order entry.
 
 ---
 
-## Installing the App
+## Contents
 
-### From crates.io (recommended)
+- [Features](#features)
+- [Installing](#installing)
+- [Credentials](#credentials)
+- [Running](#running)
+- [Key Bindings](#key-bindings)
+- [Library Usage](#library-usage)
+- [Crate Structure](#crate-structure)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Licensing](#licensing)
+
+---
+
+## Features
+
+### TUI App
+
+| Feature | |
+|---|---|
+| Account panel — equity, buying power, cash, long/short market value | ✅ |
+| Account panel — Day P&L, Open P&L, day-trade count (X/3), PDT flag | ✅ |
+| Equity chart with crosshair (keyboard + mouse) and range toggle (1D/1W/1M/YTD) | ✅ |
+| Watchlist panel — Volume, Change%, live search | ✅ |
+| Positions panel — totals footer, column sorting, position detail modal | ✅ |
+| Orders panel — Open/Filled/Cancelled sub-tabs, column sorting, symbol filter | ✅ |
+| Order Entry modal — Side, Type, TIF dropdowns | ✅ |
+| Symbol Detail modal — OHLCV, intraday chart, watchlist toggle | ✅ |
+| Global symbol search (Ctrl-F / `/`) | ✅ |
+| Help and About overlays | ✅ |
+| Mouse — row selection, double-click to open detail, click outside to dismiss | ✅ |
+| Runtime colour theme switching (`T`) | ✅ |
+| Header market-session state (PRE-MARKET / OPEN / AFTER-HOURS / CLOSED) | ✅ |
+| Instant redraw on terminal resize | ✅ |
+
+### Library
+
+| Feature | |
+|---|---|
+| Typed async REST client (`AlpacaClient`) | ✅ |
+| WebSocket market data + account/trade streaming | ✅ |
+| Live order submission and cancellation | ✅ |
+| Watchlist add / remove | ✅ |
+
+### Infrastructure
+
+| Feature | |
+|---|---|
+| Paper / Live switching (`--paper` / `--live`) | ✅ |
+| `--dry-run` mode — simulate orders without sending to Alpaca | ✅ |
+| OS-native keychain credential storage | ✅ |
+| Interactive first-run credential prompt | ✅ |
+| Persistent user preferences (TOML config file) | ✅ |
+| Windows, macOS, and Linux support | ✅ |
+| GitHub Actions CI, security audit, Codecov, release builds | ✅ |
+| 800 tests (unit + integration) | ✅ |
+
+---
+
+## Installing
+
+**From crates.io (recommended):**
 
 ```bash
 cargo install alpaca-trader-rs
 ```
 
-This compiles and installs the `alpaca-trader` binary to `~/.cargo/bin/`. Requires Rust 1.88+.
+Installs the `alpaca-trader` binary to `~/.cargo/bin/`. Requires Rust 1.88+.
 
-### Pre-compiled binaries
+**Pre-compiled binaries:** Download from the [Releases page](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases).
 
-Download the latest binary for your platform from the [Releases page](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases).
-
-### From source
+**From source:**
 
 ```bash
 git clone https://github.com/arunkumar-mourougappane/alpaca-trader-rs
@@ -40,43 +98,38 @@ cargo build --release
 
 ---
 
-## Credential Setup
+## Credentials
 
-The app resolves credentials in priority order (highest wins):
+Credentials are resolved in priority order (highest wins):
 
-| Priority | Method | When to use |
+| Priority | Source | When to use |
 |---|---|---|
-| 1 | `ALPACA_API_KEY` + `ALPACA_API_SECRET` env vars | CI, Docker, systemd — single pair for both environments |
-| 2 | `LIVE_ALPACA_KEY`/`SECRET` or `PAPER_ALPACA_KEY`/`SECRET` env vars | Per-environment `.env` file on developer machines |
-| 3 | OS-native keychain | Desktop users — keys are saved once and reused |
-| 4 | Interactive TTY prompt (first run) | No credentials configured yet — app prompts and offers to save to keychain |
+| 1 | `ALPACA_API_KEY` + `ALPACA_API_SECRET` | CI, Docker, systemd |
+| 2 | `LIVE_ALPACA_KEY`/`SECRET` or `PAPER_ALPACA_KEY`/`SECRET` | Developer `.env` file |
+| 3 | OS-native keychain | Desktop — saved once on first run |
+| 4 | Interactive TTY prompt | No credentials found yet |
 
-**Option A — First run (interactive, recommended for desktop):**
+**First run:** Just run the app — it prompts and saves to the OS keychain automatically.
 
-Just run the app. If no credentials are found, it prompts for your API key and secret, then
-offers to save them to the OS keychain (macOS Keychain, Windows Credential Store, or Linux keyutils).
-
-```bash
-alpaca-trader --paper   # prompted for paper keys on first run
-alpaca-trader           # prompted for live keys on first run
-```
-
-**Option B — `.env` file (recommended for development):**
+**`.env` file:**
 
 ```bash
-cp .env.example .env
-# Edit .env and fill in your API keys — see docs/credentials-setup.md
+cp .env.example .env   # fill in your keys
 ```
 
-**Option C — Environment variables (CI / containers):**
+**Environment variables (CI):**
 
 ```bash
 export ALPACA_API_KEY=your-key-id
 export ALPACA_API_SECRET=your-secret-key
-alpaca-trader --paper
 ```
 
-> See [docs/credentials-setup.md](docs/credentials-setup.md) for obtaining keys from the Alpaca dashboard.
+```bash
+alpaca-trader --reset paper   # remove paper keychain entries
+alpaca-trader --reset live    # remove live keychain entries
+```
+
+> Full credential setup guide: [docs/credentials-setup.md](docs/credentials-setup.md)
 
 ---
 
@@ -85,79 +138,39 @@ alpaca-trader --paper
 ```bash
 alpaca-trader           # live trading (real money — default)
 alpaca-trader --paper   # paper trading (simulated funds)
-alpaca-trader --dry-run # simulate order submissions (no real orders sent)
+alpaca-trader --dry-run # simulate order submissions, no real orders sent
 ```
 
 The header badge shows **[PAPER]** in cyan or **[LIVE]** in red at all times.
-
-> If you installed from source, use `./run.sh --paper` / `./run.sh` instead of `alpaca-trader`.
-
-### Managing Stored Credentials
 
 ```bash
 alpaca-trader --reset paper   # remove paper keychain entries
 alpaca-trader --reset live    # remove live keychain entries
 ```
 
+> If installed from source, use `./run.sh --paper` / `./run.sh` instead.
+
 ---
 
 ## Key Bindings
 
-### Global
-
 | Key | Action |
 |-----|--------|
-| `1` / `2` / `3` | Switch panel (Account / Watchlist / Positions) — or switch Orders sub-tab when on Orders panel |
-| `4` | Switch to Orders panel |
-| `Tab` / `Shift-Tab` | Cycle panels forward / backward |
-| `j` / `k` or `↑` / `↓` | Navigate rows |
-| `gg` / `G` | Jump to first / last row |
+| `1`–`4` / `Tab` / `Shift-Tab` | Switch panels |
+| `j`/`k` · `↑`/`↓` · `gg`/`G` | Navigate · jump first/last |
 | `Enter` | Open symbol / position detail |
-| `o` | New order (pre-fills selected symbol) |
-| `c` | Copy symbol to clipboard (Positions / Watchlist / Account) |
-| `c` | Cancel selected order (Orders panel) |
-| `a` | Add symbol to watchlist |
-| `d` | Remove symbol from watchlist |
-| `/` | Symbol filter on Watchlist; global symbol search on all other panels |
-| `Ctrl-F` | Global symbol search (any panel) |
-| `r` | Force refresh |
-| `?` | Help overlay |
-| `A` | About overlay |
-| `Esc` | Close modal / clear filter |
-| `T` | Toggle colour theme |
+| `o` | New order · `c` Copy symbol / Cancel order · `a`/`d` Add/remove from watchlist |
+| `/` · `Ctrl-F` | Search (watchlist filter on Watchlist tab; global search on all others) |
+| `s` / `S` | Cycle sort column / toggle direction (Positions & Orders) |
+| `f` | Symbol filter (Orders panel) |
+| `←`/`→` · `p` | Chart crosshair · cycle range 1D/1W/1M/YTD (Account panel) |
+| `r` · `T` · `?`/`A` | Refresh · theme · Help/About |
+| `Esc` | Dismiss modal / clear filter |
 | `q` / `Ctrl-C` | Quit |
 
-### Sorting (Positions & Orders panels)
+**Mouse:** click to select · double-click to open detail · click outside modal to dismiss.
 
-| Key | Action |
-|-----|--------|
-| `s` | Cycle sort column |
-| `S` | Toggle sort direction (asc / desc) |
-
-### Orders panel
-
-| Key | Action |
-|-----|--------|
-| `f` | Activate symbol filter (type to filter, Enter/Esc to clear) |
-
-### Account panel — equity chart
-
-| Key | Action |
-|-----|--------|
-| `←` / `→` or `h` / `l` | Move crosshair left / right |
-| `p` | Cycle chart range: 1D → 1W → 1M → YTD |
-| `Esc` | Clear crosshair |
-| Mouse click | Set crosshair to clicked column |
-
-### Mouse
-
-| Action | Effect |
-|--------|--------|
-| Single click | Select row |
-| Double-click row | Open detail modal (same as Enter) |
-| Click outside modal | Dismiss Help / About / Symbol Detail / Position Detail |
-
-Full interaction spec: [docs/ui-mockups.md](docs/ui-mockups.md)
+> Full keyboard/mouse interaction spec: [docs/ui-mockups.md](docs/ui-mockups.md)
 
 ---
 
@@ -171,175 +184,39 @@ alpaca-trader-rs = "0.6"
 tokio = { version = "1", features = ["full"] }
 ```
 
-### Fetch account info
+Quick example — fetch account info:
 
 ```rust
-use alpaca_trader_rs::client::AlpacaClient;
-use alpaca_trader_rs::config::AlpacaConfig;
+use alpaca_trader_rs::{client::AlpacaClient, config::AlpacaConfig};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
-    let config = AlpacaConfig::from_env()?;
-    let client = AlpacaClient::new(config);
-
+    let client = AlpacaClient::new(AlpacaConfig::from_env()?);
     let account = client.get_account().await?;
-    println!("Equity:        ${}", account.equity);
-    println!("Buying power:  ${}", account.buying_power);
-
+    println!("Equity: ${} | Buying power: ${}", account.equity, account.buying_power);
     Ok(())
 }
 ```
 
-### Place an order
-
-```rust
-use alpaca_trader_rs::types::{OrderRequest, OrderSide, OrderType, TimeInForce};
-
-let order = client.submit_order(&OrderRequest {
-    symbol: "AAPL".into(),
-    qty: Some("10".into()),
-    notional: None,
-    side: OrderSide::Buy.as_str().into(),
-    order_type: OrderType::Limit.as_str().into(),
-    time_in_force: TimeInForce::Day.as_str().into(),
-    limit_price: Some("185.00".into()),
-}).await?;
-
-println!("Order submitted: {}", order.id);
-```
-
-### Manage watchlists
-
-```rust
-let summaries = client.list_watchlists().await?;
-let wl = client.get_watchlist(&summaries[0].id).await?;
-
-for asset in &wl.assets {
-    println!("{} — {} ({})", asset.symbol, asset.name, asset.exchange);
-}
-
-client.add_to_watchlist(&wl.id, "NVDA").await?;
-client.remove_from_watchlist(&wl.id, "TLRY").await?;
-```
-
-### Public Library API
-
-| Module | Exposed items |
-|---|---|
-| `config` | `AlpacaConfig`, `AlpacaEnv` |
-| `client` | `AlpacaClient` — `get_account()`, `get_positions()`, `get_orders()`, `submit_order()`, `cancel_order()`, `get_clock()`, `list_watchlists()`, `get_watchlist()`, `add_to_watchlist()`, `remove_from_watchlist()` |
-| `types` | `AccountInfo`, `Position`, `Order`, `OrderRequest`, `OrderSide`, `OrderType`, `TimeInForce`, `Quote`, `MarketClock`, `Watchlist`, `WatchlistSummary`, `Asset` |
-| `events` | `Event` — unified event enum consumed by the TUI app |
-| `stream` | `MarketStream`, `AccountStream` — WebSocket live data |
+> Full API reference, order placement, and watchlist examples: [docs/library.md](docs/library.md)
 
 ---
 
 ## Crate Structure
 
 ```
-alpaca-trader-rs/
-├── src/
-│   ├── lib.rs              # Library root — public API
-│   ├── main.rs             # Binary entry point — TUI app
-│   ├── credentials.rs      # Credential resolution: env vars → keychain → TTY prompt
-│   ├── config.rs           # AlpacaConfig: env resolution, paper/live selection
-│   ├── client.rs           # AlpacaClient: all REST methods
-│   ├── types.rs            # Shared domain types (serde-deserializable)
-│   ├── events.rs           # Event enum
-│   ├── app.rs              # App state — TEA Model
-│   ├── update.rs           # update(state, event) + key routing
-│   ├── input/              # Per-panel keyboard input handlers
-│   │   ├── mod.rs
-│   │   ├── watchlist.rs
-│   │   ├── positions.rs
-│   │   ├── orders.rs
-│   │   ├── modal.rs
-│   │   └── search.rs
-│   ├── handlers/
-│   │   ├── input.rs        # crossterm EventStream → Event
-│   │   └── rest.rs         # Periodic REST polling task
-│   └── ui/
-│       ├── mod.rs          # render(frame, app) + popup_area()
-│       ├── dashboard.rs    # Header, tab bar, status bar
-│       ├── account.rs      # Account panel + sparkline
-│       ├── watchlist.rs    # Watchlist table + search
-│       ├── positions.rs    # Positions table + totals
-│       ├── orders.rs       # Orders table + sub-tabs
-│       ├── modals.rs       # Order entry, detail, help, about, confirm modals
-│       └── theme.rs        # Colours and styles
-├── tests/
-│   └── client_tests.rs     # AlpacaClient integration tests (wiremock)
-├── docs/                   # Full documentation
-├── .env.example            # Credential template
-├── run.sh                  # Run script (--paper / --live)
-├── Cargo.toml
-├── LICENSE-MIT
-├── LICENSE-APACHE
-└── README.md
+src/
+├── lib.rs / main.rs      # Library root + binary entry point
+├── client.rs             # AlpacaClient — all REST methods
+├── types.rs              # Shared domain types (serde)
+├── app.rs / update.rs    # TEA Model state + event → state reducer
+├── input/                # Per-panel keyboard handlers
+├── handlers/             # crossterm event stream + REST polling tasks
+└── ui/                   # render(frame, app) + per-panel renderers + theme
 ```
 
----
-
-## Environment Variables
-
-Credentials are loaded from the environment (or a `.env` file via `dotenvy`). Only the
-variables for the active environment are used — the opposing set is ignored.
-
-### Unified pair (highest priority)
-
-| Variable | Description |
-|---|---|
-| `ALPACA_API_KEY` | API key ID — used for whichever environment (`--paper` or live) is active |
-| `ALPACA_API_SECRET` | API secret key — paired with `ALPACA_API_KEY` |
-
-### Per-environment variables
-
-| Variable | Description |
-|---|---|
-| `PAPER_ALPACA_ENDPOINT` | `https://paper-api.alpaca.markets/v2` — optional override |
-| `PAPER_ALPACA_KEY` | Paper API key ID |
-| `PAPER_ALPACA_SECRET` | Paper API secret key |
-| `LIVE_ALPACA_ENDPOINT` | `https://api.alpaca.markets` — optional override |
-| `LIVE_ALPACA_KEY` | Live API key ID |
-| `LIVE_ALPACA_SECRET` | Live API secret key |
-
----
-
-## Features
-
-| Feature | Status |
-|---|---|
-| Typed async REST client (`AlpacaClient`) | ✅ |
-| TUI — header, tabs, status bar, braille line charts | ✅ |
-| Account panel — equity, buying power, cash, long/short market value | ✅ |
-| Account panel — Day P&L, Open P&L, day-trade count (X/3), PDT flag | ✅ |
-| Equity chart crosshair — keyboard navigation + mouse click | ✅ |
-| Equity chart range toggle: 1D / 1W / 1M / YTD (`p` key) | ✅ |
-| Watchlist panel — Volume, Change%, live search | ✅ |
-| Positions panel with totals footer and column sorting | ✅ |
-| Position detail modal — OHLCV stats + intraday chart | ✅ |
-| Orders panel — Open / Filled / Cancelled sub-tabs with column sorting | ✅ |
-| Orders panel — symbol filter (`f` key) | ✅ |
-| Order Entry modal with Side, Type, TIF dropdowns (↑/↓) | ✅ |
-| Symbol Detail modal — OHLCV, intraday chart, watchlist toggle | ✅ |
-| Global symbol search modal (Ctrl-F / `/`) | ✅ |
-| Help and About overlays | ✅ |
-| Mouse support — row selection, double-click to open detail, outside-click to dismiss | ✅ |
-| Paper / Live switching (`--paper` / `--live`) | ✅ |
-| `--dry-run` mode — simulate orders without sending to Alpaca | ✅ |
-| Persistent user preferences (TOML config file) | ✅ |
-| Runtime colour theme switching (`T` key) | ✅ |
-| Header market-session state (PRE-MARKET / OPEN / AFTER-HOURS / CLOSED) | ✅ |
-| Instant UI redraw on terminal resize | ✅ |
-| WebSocket market data + account/trade streaming | ✅ |
-| Live order submission and cancellation | ✅ |
-| Watchlist add / remove (wired to REST) | ✅ |
-| OS-native keychain credential storage | ✅ |
-| Interactive first-run credential prompt | ✅ |
-| Windows, macOS, and Linux support | ✅ |
-| GitHub Actions CI, security audit, Codecov (Linux + Windows), release builds | ✅ |
-| 800 tests (unit + integration) | ✅ |
+> Architecture deep-dive: [docs/architecture.md](docs/architecture.md)
 
 ---
 
@@ -347,28 +224,25 @@ variables for the active environment are used — the opposing set is ignored.
 
 | Document | Description |
 |---|---|
+| [docs/library.md](docs/library.md) | Full library API reference and usage examples |
 | [docs/architecture.md](docs/architecture.md) | System design, library/app boundary, data flow, crate choices |
 | [docs/credentials-setup.md](docs/credentials-setup.md) | Obtaining and configuring Alpaca API keys |
 | [docs/ui-mockups.md](docs/ui-mockups.md) | ASCII mockups and full keyboard/mouse interaction spec |
 | [docs/api-research.md](docs/api-research.md) | REST endpoint shapes and live test results |
-| [docs/testing.md](docs/testing.md) | Testing strategy: mock patterns, crate rationale, full test case inventory |
+| [docs/testing.md](docs/testing.md) | Testing strategy, mock patterns, test case inventory |
 | [docs/licensing.md](docs/licensing.md) | License overview and contribution terms |
 
 ---
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
 
 ---
 
 ## Licensing
 
-Licensed under either of
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.
 
-- [Apache License, Version 2.0](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0
-- [MIT license](LICENSE-MIT) or http://opensource.org/licenses/MIT
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be dual licensed as above, without any additional terms or conditions.
 
-at your option.
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ alpaca-trader --reset live    # remove live keychain entries
 
 ## Key Bindings
 
+### Global
+
 | Key | Action |
 |-----|--------|
 | `1` / `2` / `3` | Switch panel (Account / Watchlist / Positions) — or switch Orders sub-tab when on Orders panel |
@@ -110,22 +112,52 @@ alpaca-trader --reset live    # remove live keychain entries
 | `Tab` / `Shift-Tab` | Cycle panels forward / backward |
 | `j` / `k` or `↑` / `↓` | Navigate rows |
 | `gg` / `G` | Jump to first / last row |
-| `Enter` | Open symbol detail |
+| `Enter` | Open symbol / position detail |
 | `o` | New order (pre-fills selected symbol) |
-| `s` | SELL SHORT order (Positions panel) |
-| `c` | Copy symbol to clipboard (Positions / Watchlist) |
+| `c` | Copy symbol to clipboard (Positions / Watchlist / Account) |
 | `c` | Cancel selected order (Orders panel) |
 | `a` | Add symbol to watchlist |
 | `d` | Remove symbol from watchlist |
-| `/` | Search / filter watchlist |
+| `/` | Symbol filter on Watchlist; global symbol search on all other panels |
+| `Ctrl-F` | Global symbol search (any panel) |
 | `r` | Force refresh |
 | `?` | Help overlay |
 | `A` | About overlay |
-| `Esc` | Close modal |
+| `Esc` | Close modal / clear filter |
 | `T` | Toggle colour theme |
 | `q` / `Ctrl-C` | Quit |
 
-Full interaction spec (including mouse): [docs/ui-mockups.md](docs/ui-mockups.md)
+### Sorting (Positions & Orders panels)
+
+| Key | Action |
+|-----|--------|
+| `s` | Cycle sort column |
+| `S` | Toggle sort direction (asc / desc) |
+
+### Orders panel
+
+| Key | Action |
+|-----|--------|
+| `f` | Activate symbol filter (type to filter, Enter/Esc to clear) |
+
+### Account panel — equity chart
+
+| Key | Action |
+|-----|--------|
+| `←` / `→` or `h` / `l` | Move crosshair left / right |
+| `p` | Cycle chart range: 1D → 1W → 1M → YTD |
+| `Esc` | Clear crosshair |
+| Mouse click | Set crosshair to clicked column |
+
+### Mouse
+
+| Action | Effect |
+|--------|--------|
+| Single click | Select row |
+| Double-click row | Open detail modal (same as Enter) |
+| Click outside modal | Dismiss Help / About / Symbol Detail / Position Detail |
+
+Full interaction spec: [docs/ui-mockups.md](docs/ui-mockups.md)
 
 ---
 
@@ -280,18 +312,24 @@ variables for the active environment are used — the opposing set is ignored.
 |---|---|
 | Typed async REST client (`AlpacaClient`) | ✅ |
 | TUI — header, tabs, status bar, braille line charts | ✅ |
-| Account panel with Day P&L, Open P&L, Account # | ✅ |
+| Account panel — equity, buying power, cash, long/short market value | ✅ |
+| Account panel — Day P&L, Open P&L, day-trade count (X/3), PDT flag | ✅ |
+| Equity chart crosshair — keyboard navigation + mouse click | ✅ |
+| Equity chart range toggle: 1D / 1W / 1M / YTD (`p` key) | ✅ |
 | Watchlist panel — Volume, Change%, live search | ✅ |
-| Positions panel with totals footer | ✅ |
-| Orders panel — Open / Filled / Cancelled sub-tabs | ✅ |
+| Positions panel with totals footer and column sorting | ✅ |
+| Position detail modal — OHLCV stats + intraday chart | ✅ |
+| Orders panel — Open / Filled / Cancelled sub-tabs with column sorting | ✅ |
+| Orders panel — symbol filter (`f` key) | ✅ |
 | Order Entry modal with Side, Type, TIF dropdowns (↑/↓) | ✅ |
 | Symbol Detail modal — OHLCV, intraday chart, watchlist toggle | ✅ |
+| Global symbol search modal (Ctrl-F / `/`) | ✅ |
 | Help and About overlays | ✅ |
+| Mouse support — row selection, double-click to open detail, outside-click to dismiss | ✅ |
 | Paper / Live switching (`--paper` / `--live`) | ✅ |
 | `--dry-run` mode — simulate orders without sending to Alpaca | ✅ |
 | Persistent user preferences (TOML config file) | ✅ |
 | Runtime colour theme switching (`T` key) | ✅ |
-| SELL SHORT from Positions panel (`s` key) | ✅ |
 | Header market-session state (PRE-MARKET / OPEN / AFTER-HOURS / CLOSED) | ✅ |
 | Instant UI redraw on terminal resize | ✅ |
 | WebSocket market data + account/trade streaming | ✅ |
@@ -301,7 +339,7 @@ variables for the active environment are used — the opposing set is ignored.
 | Interactive first-run credential prompt | ✅ |
 | Windows, macOS, and Linux support | ✅ |
 | GitHub Actions CI, security audit, Codecov (Linux + Windows), release builds | ✅ |
-| 540 tests (unit + integration) | ✅ |
+| 800 tests (unit + integration) | ✅ |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,10 +68,11 @@ The TUI header will show **[PAPER]** to confirm you are in simulation mode.
 
 | Document | Description |
 |---|---|
+| [library.md](library.md) | Full library API reference and usage examples |
 | [credentials-setup.md](credentials-setup.md) | How to get and configure Alpaca API keys for paper and live trading |
 | [architecture.md](architecture.md) | System design, data flow, crate choices, and module layout |
 | [api-research.md](api-research.md) | Live API test results: watchlist endpoints, response shapes, auth notes |
-| [ui-mockups.md](ui-mockups.md) | ASCII mockups for all panels and modals, keyboard/mouse interaction spec, ratatui widget mapping |
+| [ui-mockups.md](ui-mockups.md) | ASCII mockups for all panels and modals, keyboard/mouse interaction spec |
 | [testing.md](testing.md) | Testing strategy: mock patterns, dev-dependency rationale, full test case inventory per module |
 | [github-actions.md](github-actions.md) | GitHub Actions reference: CI, security, coverage, releases, matrix builds, caching |
 | [phase2-research.md](phase2-research.md) | Phase 2 implementation plan: WebSocket streaming, mutation operations, command channel pattern |
@@ -82,25 +83,6 @@ The TUI header will show **[PAPER]** to confirm you are in simulation mode.
 ---
 
 ## Key Bindings
-
-| Key | Action |
-|-----|--------|
-| `1` / `2` / `3` / `4` | Switch to Account / Watchlist / Positions / Orders |
-| `Tab` / `Shift-Tab` | Cycle panels forward / backward |
-| `j` / `k` or `↑` / `↓` | Navigate rows |
-| `g` / `G` | Jump to first / last row |
-| `Enter` | Open symbol detail modal |
-| `o` | New order (pre-fills selected symbol) |
-| `s` | SELL SHORT order entry (Positions panel) |
-| `c` | Cancel selected order |
-| `a` | Add symbol to watchlist |
-| `d` | Remove symbol from watchlist |
-| `/` | Search / filter |
-| `r` | Force refresh |
-| `?` | Show help overlay |
-| `A` | About overlay |
-| `Esc` | Close modal |
-| `q` / `Ctrl-C` | Quit |
 
 See [ui-mockups.md](ui-mockups.md) for the full per-panel and per-modal keyboard and mouse interaction spec.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ The TUI header will show **[PAPER]** to confirm you are in simulation mode.
 
 | Document | Description |
 |---|---|
+| [account-management.md](account-management.md) | Design spec for in-app credential entry, multi-profile support, and settings modal |
 | [library.md](library.md) | Full library API reference and usage examples |
 | [credentials-setup.md](credentials-setup.md) | How to get and configure Alpaca API keys for paper and live trading |
 | [architecture.md](architecture.md) | System design, data flow, crate choices, and module layout |

--- a/docs/account-management.md
+++ b/docs/account-management.md
@@ -1,0 +1,1088 @@
+# Account Management Design
+
+> **Status:** Design draft — v0.1  
+> **Scope:** In-app credential entry, multi-account profiles, and a settings modal  
+> **Codebase base:** v0.6.0  
+
+---
+
+## Overview
+
+`alpaca-trader-rs` currently resolves credentials before entering raw mode, persists
+preferences in `~/.config/alpaca-trader/config.toml`, and has no way to change
+credentials or settings without restarting the process. This document specifies three
+related features that close that gap:
+
+| Sub-feature | User story |
+|---|---|
+| **A. In-app Credential Entry** | Enter, update, or clear API keys from inside the TUI without restarting |
+| **B. Multi-Profile Support** | Define named account profiles in `config.toml`; switch at runtime |
+| **C. Settings Modal** | Edit all `AppPrefs` fields from inside the TUI with immediate persistence |
+
+All three features share the same event/command bus, the same modal rendering
+pipeline (`src/ui/modals.rs` → `src/input/modal.rs`), and the same TEA update
+loop (`src/update.rs`).
+
+---
+
+## Current Architecture (Brief Reference)
+
+- **Credential resolution** happens entirely in `src/credentials.rs::resolve()`, which
+  calls `rpassword` if the keychain is empty. It **must** run before
+  `enable_raw_mode()` because it writes to `stderr` and reads from `stdin`.
+- **Configuration** lives in `src/config.rs` (`AlpacaConfig` / `AlpacaEnv` /
+  `ResolvedCredentials`). After startup `AlpacaConfig` is immutable — it's cloned
+  into every background task.
+- **Preferences** are loaded via `AppPrefs::load()` at startup and stored on `App`.
+  `AppPrefs::write_to()` already exists but is never called at runtime.
+- **Modals** are a `Option<Modal>` on `App`; the renderer in `src/ui/modals.rs` is a
+  single `match` dispatch; the input handler in `src/input/modal.rs` follows the
+  same pattern.
+- **Async boundary**: all mutations cross from synchronous `update()` to the async
+  world via `command_tx: mpsc::Sender<Command>`. Results come back as `Event`
+  variants on the main event channel.
+- **Task lifecycle**: five long-running `tokio::spawn` tasks share a single
+  `CancellationToken`. There is currently no mechanism to replace a running task
+  after startup.
+
+---
+
+## Feature Scope
+
+### A. In-App Credential Management
+
+- First-run setup: detect missing keychain credentials *after* entering raw mode
+  and launch `Modal::CredentialEntry` before data polling starts.
+- Update credentials for the active profile without restarting.
+- Clear/reset credentials for any profile from within the TUI.
+- Trigger a full reconnect (cancel old tasks, rebuild `AlpacaClient`, re-spawn tasks)
+  after new credentials are confirmed.
+
+### B. Multi-Account / Profile Support
+
+- Named profiles defined in `config.toml` under a `[[profiles]]` array.
+- Runtime switching via `Modal::AccountSwitcher`.
+- Header badge shows active profile display name and environment.
+- Keychain entries namespaced by profile `name` field.
+- Backward compatible: a config without `[[profiles]]` behaves exactly as before.
+
+### C. Preferences / Settings Modal
+
+- `Modal::Settings` with per-section navigation (App / UI / Stream / Notifications
+  / Safety / Proxy).
+- Edits apply immediately to `App::prefs` and are written to disk via
+  `AppPrefs::write_to()`.
+- Theme changes apply in-frame (same path as the current `T` key) and are now
+  also persisted.
+- No restart required for any setting except `proxy.*` (noted in the UI).
+
+---
+
+## Data Model
+
+### Profile Schema (`config.toml`)
+
+#### New format (with profiles)
+
+```toml
+[app]
+default_env        = "live"
+refresh_interval_ms = 5000
+active_profile     = "personal-live"   # NEW — omit to fall back to legacy behaviour
+
+[ui]
+theme              = "default"
+# ... unchanged
+
+[[profiles]]
+name         = "personal-live"         # machine key, used as keychain namespace
+display_name = "Personal Live"         # shown in header badge and switcher
+env          = "live"                  # "live" | "paper"
+
+[[profiles]]
+name         = "personal-paper"
+display_name = "Personal Paper"
+env          = "paper"
+
+[[profiles]]
+name         = "ira"
+display_name = "IRA Account"
+env          = "live"
+```
+
+#### Rust representation
+
+```rust
+// src/prefs.rs — new structs
+
+/// A named account profile. Credentials are stored in the OS keychain,
+/// namespaced by `name`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProfileConfig {
+    /// Machine key used as the keychain namespace (e.g. `"personal-live"`).
+    /// Must be non-empty, contain only ASCII alphanumerics and hyphens.
+    pub name: String,
+    /// Human-readable label shown in the header badge and account switcher.
+    pub display_name: String,
+    /// Which Alpaca environment this profile targets.
+    pub env: String,   // "live" | "paper"; parsed to AlpacaEnv on use
+}
+
+// AppSection gains one new optional field:
+pub struct AppSection {
+    pub default_env: String,
+    pub refresh_interval_ms: u64,
+    pub active_profile: Option<String>,   // NEW — None means legacy single-account mode
+}
+
+// AppPrefs gains a new optional section:
+pub struct AppPrefs {
+    pub app: AppSection,
+    pub ui: UiSection,
+    pub stream: StreamSection,
+    pub notifications: NotificationsSection,
+    pub safety: SafetySection,
+    pub proxy: ProxySection,
+    #[serde(default)]
+    pub profiles: Vec<ProfileConfig>,     // NEW — empty = legacy mode
+}
+```
+
+`ProfileConfig::env` is stored as a `String` rather than `AlpacaEnv` to keep
+`prefs.rs` free of `config.rs` imports (the `AlpacaEnv` parse happens in
+`credentials.rs` where it is already imported).
+
+### Keychain Namespacing
+
+#### Current scheme (unchanged for legacy mode)
+
+| Entry | Service | Username |
+|---|---|---|
+| Live key    | `alpaca-trader-rs` | `live-api-key` |
+| Live secret | `alpaca-trader-rs` | `live-api-secret` |
+| Paper key   | `alpaca-trader-rs` | `paper-api-key` |
+| Paper secret| `alpaca-trader-rs` | `paper-api-secret` |
+
+#### Profile-namespaced scheme
+
+When `[[profiles]]` are defined, the profile `name` field replaces the
+`live`/`paper` prefix:
+
+| Profile `name` | Username (key) | Username (secret) |
+|---|---|---|
+| `personal-live`  | `personal-live-api-key`  | `personal-live-api-secret`  |
+| `personal-paper` | `personal-paper-api-key` | `personal-paper-api-secret` |
+| `ira`            | `ira-api-key`            | `ira-api-secret`            |
+
+The service name `"alpaca-trader-rs"` is unchanged across all entries.
+
+The helper in `credentials.rs` is already parameterised by a string prefix
+(`kr_prefix`). Extending it to accept a profile name requires no structural
+change — only the string passed in changes.
+
+### Backward Compatibility
+
+| `config.toml` state | Behaviour |
+|---|---|
+| No `[[profiles]]`, no `active_profile` | Existing startup flow; `resolve(env)` called with env from CLI/`default_env`; no profile switcher shown |
+| `[[profiles]]` present, `active_profile` set | Profile mode; profile-namespaced keychain lookup; account switcher available |
+| `[[profiles]]` present, `active_profile` absent | First profile in array is treated as active; user is nudged to set one explicitly |
+| `[[profiles]]` present, named profile has no keychain entry | `CredentialEntry` modal opened automatically for that profile |
+
+No migration step is needed. The existing `[app]`, `[ui]`, `[stream]` etc. sections
+are parsed identically. The new `[[profiles]]` table and `active_profile` key default
+to absent / `None`, which reproduces legacy behaviour exactly.
+
+---
+
+## UI Design
+
+### Modal — Credential Entry (`Modal::CredentialEntry`)
+
+Handles both first-run setup and in-app credential update.
+
+```
+┌─ Credentials — Personal Live ──────────────────────────────┐
+│                                                             │
+│  Profile:   Personal Live  [LIVE]                           │
+│                                                             │
+│  Key ID      ┌───────────────────────────────────────┐      │
+│  (focused) ▶ │ APCA-API-KEYID-XXXXXXXXXXXXXXXXXXXX   │      │
+│              └───────────────────────────────────────┘      │
+│                                                             │
+│  Secret Key  ┌───────────────────────────────────────┐      │
+│              │ ••••••••••••••••••••••••••••••••••••• │      │
+│              └───────────────────────────────────────┘      │
+│                                 [space] Show/hide secret    │
+│                                                             │
+│  [ Save to Keychain ]          [ Cancel ]                   │
+│                                                             │
+│  ─────────────────────────────────────────────────────     │
+│  ⚠  Credentials are stored in the OS keychain, never on   │
+│     disk. They are zero-filled in memory after saving.      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### State
+
+```rust
+// src/app.rs
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CredentialField {
+    KeyId,
+    Secret,
+    Save,
+    Cancel,
+}
+
+impl CredentialField {
+    pub fn next(&self) -> Self { /* KeyId→Secret→Save→Cancel→KeyId */ }
+    pub fn prev(&self) -> Self { /* reverse cycle */ }
+}
+
+// Variant added to Modal enum:
+CredentialEntry {
+    /// Profile name being edited; empty string = legacy single-account mode.
+    profile_name: String,
+    /// Profile display label shown in the modal title.
+    profile_display_name: String,
+    /// Environment badge ("LIVE" / "PAPER").
+    env_label: String,
+    /// Contents of the Key ID text field.
+    key_input: String,
+    /// Contents of the Secret Key text field.
+    secret_input: String,
+    /// Which field currently has keyboard focus.
+    focused_field: CredentialField,
+    /// When `true`, secret is shown in plaintext instead of bullet characters.
+    secret_visible: bool,
+    /// `true` while `Command::SaveCredentials` is in-flight; disables Save button.
+    saving: bool,
+}
+```
+
+#### Keyboard Interaction
+
+| Key | Focused on | Action |
+|---|---|---|
+| `Tab` / `↓` | Any field | Focus next field |
+| `Shift+Tab` / `↑` | Any field | Focus previous field |
+| Printable char | `KeyId` or `Secret` | Append to input buffer |
+| `Backspace` | `KeyId` or `Secret` | Delete last character |
+| `Space` | Any | Toggle `secret_visible` |
+| `Enter` | `KeyId` or `Secret` | Move focus to next field |
+| `Enter` | `Save` | Validate → open `Confirm` modal → emit `Command::SaveCredentials` |
+| `Enter` | `Cancel` | Close modal, discard inputs |
+| `Esc` | Any | Close modal, discard inputs |
+| `Ctrl+U` | `KeyId` or `Secret` | Clear entire field |
+
+#### Validation
+
+Before the `Confirm` step, the handler checks:
+- `key_input` is non-empty
+- `secret_input` is non-empty
+- `key_input` starts with `"PK"` (paper) or `"AK"` (live) — optional soft warning,
+  not a hard error, to accommodate future Alpaca key formats
+
+If validation fails, a transient status message is pushed: `"Key ID and secret must not be empty"`.
+
+#### States and Transitions
+
+```
+[App starts, no credentials for active profile]
+        │
+        ▼
+  Modal::CredentialEntry opened
+        │
+        ├─[Esc / Cancel]──▶ if first-run wizard: app.should_quit = true (cannot proceed)
+        │                   else: modal closed, no change
+        │
+        ├─[Enter on Save]──▶ Modal::Confirm {
+        │                      message: "Save credentials for '{profile}' to OS keychain?",
+        │                      action: ConfirmAction::SaveCredentials { profile_name, key, secret }
+        │                    }
+        │
+        └─[Confirm Yes]────▶ Command::SaveCredentials sent
+                                    │
+                  ┌─────────────────┴─────────────────────────┐
+                  │ Success                                    │ Error
+                  ▼                                            ▼
+         Event::CredentialsSaved              Event::CredentialSaveError
+                  │                                            │
+                  ▼                                            ▼
+         Event::Reconnect { config }            StatusMsg "Keychain error: {e}"
+         (modal closed, data reload)            (modal stays open)
+```
+
+---
+
+### Modal — Account Switcher (`Modal::AccountSwitcher`)
+
+```
+┌─ Switch Account ───────────────────────────────────────────┐
+│                                                             │
+│   ▶  Personal Live   [LIVE]   ● active                      │
+│      Personal Paper  [PAPER]                                │
+│      IRA             [LIVE]                                 │
+│                                                             │
+│  ──────────────────────────────────────────────────────    │
+│  Enter: Switch    e: Edit credentials    d: Delete creds    │
+│  n: New Profile   Esc: Close                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Active profile row is rendered with `selected_style()` (bold + accent background).
+The `● active` badge uses the accent colour.
+
+#### State
+
+```rust
+// Variant added to Modal enum:
+AccountSwitcher {
+    /// Index of the currently highlighted row (not necessarily the active profile).
+    selected_idx: usize,
+}
+```
+
+`App::profiles` (added below) holds the profile list; the switcher renders from
+that slice. No additional state is needed beyond `selected_idx`.
+
+#### Keyboard Interaction
+
+| Key | Action |
+|---|---|
+| `j` / `↓` | Move highlight down |
+| `k` / `↑` | Move highlight up |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+| `Enter` | Emit `Command::SwitchProfile(profiles[selected_idx].name.clone())` |
+| `e` | Open `Modal::CredentialEntry` for the highlighted profile |
+| `d` | Open `Modal::Confirm` → `ConfirmAction::ResetCredentials { profile_name }` |
+| `n` | Open `Modal::CredentialEntry` for a new (unsaved) profile — pre-populated with empty fields; profile is written to `config.toml` on save |
+| `Esc` | Close modal |
+
+#### States and Transitions
+
+```
+[User presses `S` global shortcut or navigates to Account → profile badge]
+        │
+        ▼
+  Modal::AccountSwitcher { selected_idx: current active profile index }
+        │
+        ├─[Esc]─────────────────────────────────▶ modal closed
+        │
+        ├─[Enter on non-active profile]──────────▶ Command::SwitchProfile
+        │                                                  │
+        │                              ┌──────────────────┴──────────────────┐
+        │                              │ resolve keychain creds               │ no creds
+        │                              ▼                                      ▼
+        │                   Event::Reconnect { config }        Modal::CredentialEntry
+        │                   (modal closed, data reload)        (for target profile)
+        │
+        └─[Enter on active profile]──────────────▶ modal closed (no-op)
+```
+
+---
+
+### Modal — Settings (`Modal::Settings`)
+
+```
+┌─ Settings ─────────────────────────────────────────────────┐
+│                                                             │
+│  [ App ]  [ UI ]  [ Stream ]  [ Notifications ]  [ Safety ] │
+│  ─────────────────────────────────────────────────────     │
+│                                                             │
+│  ── App ───────────────────────────────────────────────    │
+│                                                             │
+│  Default Environment    ◀  live  ▶                          │
+│  Refresh Interval (ms)  ┌──────┐                           │
+│                       ▶ │ 5000 │ ◀                          │
+│                         └──────┘                           │
+│                                                             │
+│  ── UI ────────────────────────────────────────────────    │
+│                                                             │
+│  Theme                  ◀  Default  ▶                       │
+│  Show Account Panel        [✓]                              │
+│  Show Watchlist            [✓]                              │
+│  Show Positions            [✓]                              │
+│  Show Orders               [✓]                              │
+│  Default Equity Range   ◀  1D  ▶                            │
+│                                                             │
+│  [ Save ]                             [ Cancel ]            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+All sections are rendered in a single scrollable view separated by `──` dividers.
+The section tab bar at the top allows jumping directly to a section. The modal
+uses ~70 % of screen width and ~85 % of screen height.
+
+#### State
+
+```rust
+// src/app.rs
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SettingsField {
+    // [app] section
+    DefaultEnv,
+    RefreshIntervalMs,
+    // [ui] section
+    Theme,
+    ShowAccountPanel,
+    ShowWatchlist,
+    ShowPositions,
+    ShowOrders,
+    DefaultEquityRange,
+    // [stream] section
+    ReconnectMaxAttempts,
+    ReconnectBackoffBaseMs,
+    // [notifications] section
+    FillNotificationsEnabled,
+    FillNotificationTtlMs,
+    StatusMessageTtlMs,
+    // [safety] section
+    ConfirmWatchlistRemove,
+    // --- action row ---
+    Save,
+    Cancel,
+}
+
+impl SettingsField {
+    pub fn next(&self) -> Self { /* full ordered cycle */ }
+    pub fn prev(&self) -> Self { /* reverse */ }
+    /// True for toggle (boolean) fields.
+    pub fn is_toggle(&self) -> bool { /* ShowAccountPanel, ShowWatchlist, ... */ }
+    /// True for fields edited with Left/Right cycle (enum/string fields).
+    pub fn is_cyclic(&self) -> bool { /* DefaultEnv, Theme, DefaultEquityRange */ }
+    /// True for numeric text-edit fields.
+    pub fn is_text(&self) -> bool { /* RefreshIntervalMs, Ttl fields, backoff */ }
+}
+
+// Variant added to Modal enum:
+Settings {
+    /// Working copy of preferences being edited.  Not written to disk until Save.
+    draft: AppPrefs,
+    /// Which field is currently focused.
+    focused: SettingsField,
+    /// `true` while the focused text field is in character-entry mode.
+    editing: bool,
+    /// Raw text buffer for numeric field under edit.
+    edit_buffer: String,
+}
+```
+
+The `draft: AppPrefs` copy is cloned from `App::prefs` when the modal is opened.
+Edits mutate `draft` in place. Pressing Save writes `draft` to `App::prefs` and
+calls `Command::SavePrefs(draft)`. Pressing Cancel discards the draft.
+
+#### Keyboard Interaction
+
+| Key | Action |
+|---|---|
+| `Tab` / `j` / `↓` | Move focus to next field |
+| `Shift+Tab` / `k` / `↑` | Move focus to previous field |
+| `1`–`5` | Jump to section (App / UI / Stream / Notifications / Safety) |
+| `←` / `→` | Cycle value for cyclic fields (DefaultEnv, Theme, DefaultEquityRange) |
+| `Space` / `Enter` | Toggle boolean fields; begin/commit text edit for numeric fields |
+| `Backspace` | Delete last char while editing a text field |
+| `0`–`9` | Append digit while editing a numeric text field |
+| `Enter` on `Save` | Commit draft → `Command::SavePrefs` → close modal |
+| `Enter` on `Cancel` / `Esc` | Discard draft, close modal |
+
+#### UX Notes
+
+- Theme change is applied immediately to `App::current_theme` on each `←`/`→`
+  press in the draft (live preview), but reverted if the user cancels.
+- Boolean fields render as `[✓]` (filled) or `[ ]` (empty) using the accent color.
+- Cyclic fields show a `◀ value ▶` widget.
+- Proxy settings are shown read-only with the note `(restart required)`.
+
+---
+
+## State & Event Model
+
+### App Struct Additions
+
+```rust
+// src/app.rs — additions to App struct
+
+/// Named account profiles loaded from config.toml.
+///
+/// Empty in legacy single-account mode (no [[profiles]] in config.toml).
+pub profiles: Vec<crate::prefs::ProfileConfig>,
+
+/// Name of the currently active profile.
+///
+/// `None` in legacy mode. Corresponds to a `ProfileConfig::name` in `profiles`.
+pub active_profile_name: Option<String>,
+```
+
+`App::new()` receives `prefs: AppPrefs` already, so `profiles` and
+`active_profile_name` can be initialised from `prefs.profiles` and
+`prefs.app.active_profile` without signature changes.
+
+### New Command Variants
+
+```rust
+// src/commands.rs
+
+/// Save API credentials for a named profile to the OS keychain.
+///
+/// `profile_name` is the raw keychain prefix (e.g. `"personal-live"` or
+/// `"live"` in legacy mode). The async handler calls `save_keychain_pair()`
+/// from `credentials.rs`.  The secret string is zero-filled after the call.
+SaveCredentials {
+    profile_name: String,
+    key: String,
+    secret: String,
+},
+
+/// Delete the keychain entries for a named profile.
+///
+/// Calls `credentials::reset_profile()`. Sends `Event::StatusMsg` with
+/// confirmation or error.
+ResetCredentials {
+    profile_name: String,
+},
+
+/// Switch the active profile to the one with the given name.
+///
+/// The handler resolves credentials from the keychain for the target profile,
+/// builds a new `AlpacaConfig`, and emits `Event::Reconnect { config }`.
+/// On failure emits `Event::ProfileSwitchError`.
+SwitchProfile(String),
+
+/// Persist an edited AppPrefs snapshot to disk.
+///
+/// The handler calls `AppPrefs::write_to()` and emits `Event::PrefsSaved`
+/// or `Event::PrefsSaveError`.
+SavePrefs(AppPrefs),
+```
+
+### New Event Variants
+
+```rust
+// src/events.rs
+
+/// Keychain save completed successfully for the named profile.
+CredentialsSaved {
+    profile_name: String,
+},
+
+/// Keychain save failed.
+CredentialSaveError {
+    profile_name: String,
+    error: String,
+},
+
+/// Keychain reset completed.
+CredentialsReset {
+    profile_name: String,
+},
+
+/// Profile switch succeeded; carry the new config so the main loop can
+/// rebuild the client and re-spawn all background tasks.
+///
+/// This event is handled in the **main loop** (not in `update()`), because
+/// it requires cancelling running tasks and spawning new ones — operations
+/// that are impossible in the synchronous `update()` function.
+Reconnect {
+    config: AlpacaConfig,
+    /// Display name of the newly active profile (for the status message).
+    profile_display_name: String,
+},
+
+/// Profile switch or credential resolve failed.
+ProfileSwitchError {
+    profile_name: String,
+    error: String,
+},
+
+/// AppPrefs successfully written to disk.
+PrefsSaved,
+
+/// AppPrefs write failed.
+PrefsSaveError(String),
+```
+
+### `update()` Changes
+
+`Event::Reconnect` is deliberately **not** handled in `update()`. The main loop
+in `src/main.rs` intercepts it before calling `update()`:
+
+```rust
+// src/main.rs — main loop (conceptual diff)
+loop {
+    terminal.draw(|f| ui::render(f, &mut app))?;
+
+    match rx.recv().await {
+        Some(Event::Quit) | None => break,
+
+        // NEW: reconnect is handled here, not in update(), because it
+        // requires cancelling the CancellationToken and re-spawning tasks.
+        Some(Event::Reconnect { config, profile_display_name }) => {
+            reconnect(
+                &mut app, config, profile_display_name,
+                &tx, &mut cancel, &mut client,
+                &refresh_notify, &prefs,
+            ).await;
+        }
+
+        Some(event) => update(&mut app, event),
+    }
+    // ...
+}
+```
+
+The `reconnect()` helper (new function in `src/main.rs`):
+
+```rust
+async fn reconnect(
+    app: &mut App,
+    config: AlpacaConfig,
+    profile_display_name: String,
+    tx: &mpsc::Sender<Event>,
+    cancel: &mut CancellationToken,
+    client: &mut Arc<AlpacaClient>,
+    refresh_notify: &Arc<Notify>,
+    prefs: &AppPrefs,
+) {
+    // 1. Cancel all running background tasks
+    cancel.cancel();
+    // Brief yield so tasks can clean up before we replace the token
+    tokio::task::yield_now().await;
+    *cancel = CancellationToken::new();
+
+    // 2. Build a new client from the new config
+    *client = Arc::new(AlpacaClient::new(config.clone()));
+
+    // 3. Update app state
+    app.config = config.clone();
+    app.clear_data();   // new helper: zeroes positions/orders/account/quotes/etc.
+    app.push_status(StatusMessage::persistent(
+        format!("Connecting to {}…", profile_display_name)
+    ));
+
+    // 4. Re-spawn all background tasks (same as main() startup block)
+    tokio::spawn(handlers::input::run(tx.clone(), cancel.clone()));
+    tokio::spawn(handlers::rest::run(
+        tx.clone(), cancel.clone(), client.clone(),
+        refresh_notify.clone(), prefs.clone(),
+    ));
+    tokio::spawn(handlers::commands::run(
+        command_rx, tx.clone(), client.clone(),
+        refresh_notify.clone(), cancel.clone(),
+    ));
+    tokio::spawn(alpaca_trader_rs::stream::market::run(
+        tx.clone(), cancel.clone(), config.clone(),
+        symbol_rx, prefs.clone(),
+    ));
+    tokio::spawn(alpaca_trader_rs::stream::account::run(
+        tx.clone(), cancel.clone(), config.clone(), prefs.clone(),
+    ));
+
+    tokio::spawn(handlers::rest::poll_once(tx.clone(), client.clone()));
+}
+```
+
+> **Note on `command_rx` / `symbol_rx`**: because the channel receivers are moved
+> into the spawned tasks they are consumed. On reconnect, new channels must be
+> created. The senders (`command_tx`, `symbol_tx`) stored on `App` must also be
+> replaced. This is achieved by declaring them `mut` in `main()` and replacing
+> them as part of `reconnect()`. `App::command_tx` and `App::symbol_tx` are
+> updated to the new senders after channel creation.
+
+`Event::CredentialsSaved`, `Event::PrefsSaved`, and `Event::PrefsSaveError` are
+handled in `update()` as simple status message pushes and modal close operations.
+
+---
+
+## Startup Flow Changes
+
+### Current Flow
+
+```
+main()
+  │
+  ├── load AppPrefs
+  ├── determine AlpacaEnv (CLI --paper or prefs.app.default_env)
+  ├── credentials::resolve(env)          ← may print/prompt on stderr/stdin
+  ├── AlpacaConfig::from_credentials()
+  ├── enable_raw_mode()
+  ├── spawn tasks
+  └── main loop
+```
+
+### New Flow
+
+```
+main()
+  │
+  ├── load AppPrefs
+  ├── determine startup_env (CLI --paper or prefs.app.default_env)
+  ├── [PROFILE MODE: prefs.profiles non-empty]
+  │     ├── select active_profile from prefs.app.active_profile
+  │     │   (fall back to profiles[0] if unset)
+  │     ├── try credentials::resolve_profile(&profile)
+  │     │     ├── [env vars] → Ok(creds)
+  │     │     ├── [keychain] → Ok(creds)
+  │     │     └── [no creds] → Ok(None)   ← NEW: returns None instead of prompting
+  │     │
+  │     ├── if Ok(Some(creds)) → build AlpacaConfig, continue
+  │     └── if Ok(None) → launch TUI, then open Modal::CredentialEntry for profile
+  │
+  ├── [LEGACY MODE: prefs.profiles empty]
+  │     ├── credentials::resolve(env)     ← unchanged; may prompt before raw mode
+  │     └── AlpacaConfig::from_credentials()
+  │
+  ├── enable_raw_mode()
+  ├── spawn tasks
+  │     ├── [PROFILE MODE, no creds] → REST tasks start in "standby" state
+  │     │   and wait for Event::Reconnect before polling
+  │     └── [all other cases] → normal task startup
+  │
+  └── main loop
+        ├── [PROFILE MODE, no creds at startup]
+        │     → immediately open Modal::CredentialEntry before first render
+        └── normal event loop
+```
+
+#### `credentials::resolve_profile()` — New Function
+
+```rust
+// src/credentials.rs
+
+/// Resolve credentials for a named profile without prompting.
+///
+/// Returns `Ok(Some(creds))` if env vars or keychain provide credentials.
+/// Returns `Ok(None)` if no credentials are found (caller opens CredentialEntry).
+/// Returns `Err` only on hard keychain errors.
+pub fn resolve_profile(profile: &ProfileConfig) -> Result<Option<ResolvedCredentials>> {
+    let env = match profile.env.as_str() {
+        "paper" => AlpacaEnv::Paper,
+        _       => AlpacaEnv::Live,
+    };
+    let prefix = &profile.name;  // e.g. "personal-live"
+    let (env_prefix, default_ep) = match env {
+        AlpacaEnv::Live  => ("LIVE_ALPACA", DEFAULT_LIVE_ENDPOINT),
+        AlpacaEnv::Paper => ("PAPER_ALPACA", DEFAULT_PAPER_ENDPOINT),
+    };
+    let endpoint = std::env::var(format!("{env_prefix}_ENDPOINT"))
+        .unwrap_or_else(|_| default_ep.to_string());
+
+    // Step 1a: unified env vars
+    // ... (same as resolve())
+
+    // Step 1b: per-environment env vars
+    // ... (same as resolve())
+
+    // Step 2: keychain lookup using profile name as prefix
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    match try_keychain_load(prefix) {
+        Ok(Some((key, secret))) => return Ok(Some(ResolvedCredentials {
+            endpoint, key, secret, env,
+        })),
+        Ok(None) => {}    // not found — caller opens CredentialEntry
+        Err(KeychainStatus::Unavailable(msg)) => {
+            tracing::warn!("keychain unavailable for profile {}: {}", prefix, msg);
+        }
+        Err(KeychainStatus::Hard(e)) => return Err(e),
+    }
+
+    Ok(None)   // no credentials found; caller opens CredentialEntry
+}
+```
+
+`credentials::resolve()` (the existing function) is unchanged to maintain
+legacy mode behaviour.
+
+---
+
+## Security Model
+
+### Secret Display
+
+- The `secret_input` buffer is rendered as `•` characters when `secret_visible == false`.
+- When `secret_visible == true`, the secret is shown in plaintext — the modal title
+  flashes `[secret visible]` in the neutral/yellow colour.
+- The secret is **never** written to any log file. `tracing` calls involving
+  `ResolvedCredentials` log only the profile name and env label, never the key or secret.
+
+### Memory Safety
+
+Add the `zeroize` crate (already implied by the `secrecy` ecosystem, zero new deps if
+`secrecy` is chosen) to zero credential buffers after use:
+
+```toml
+# Cargo.toml
+zeroize = { version = "1", features = ["derive"] }
+```
+
+```rust
+use zeroize::Zeroize;
+
+// In the CredentialEntry modal handler, after SaveCredentials is dispatched:
+state.key_input.zeroize();
+state.secret_input.zeroize();
+
+// In handlers/commands.rs, SaveCredentials handler, after keychain write:
+key.zeroize();
+secret.zeroize();
+```
+
+`ResolvedCredentials` is short-lived (constructed in the command handler, used
+once to build `AlpacaConfig`, then dropped). `AlpacaConfig::key` and
+`AlpacaConfig::secret` are currently plain `String`s; they are passed by clone
+into each background task. Wrapping them in `zeroize::Zeroizing<String>` is
+desirable but a larger refactor — tracked as a follow-up in Phase 3.
+
+### Confirmation Gating
+
+Every destructive credential operation goes through a `Modal::Confirm` step:
+- Save to keychain: `"Save credentials for '{profile}' to OS keychain?"`
+- Delete from keychain: `"Delete stored credentials for '{profile}'? You will be
+  prompted to re-enter them next time."`
+- Switch profile: if current profile has unsaved orders, add `"You have open orders
+  on {current_profile}. Switch anyway?"` warning.
+
+### Key Validation
+
+The handler rejects `key_input` values that are empty or contain whitespace, and
+warns (soft) when the prefix doesn't match the expected Alpaca format for the
+selected environment (`PK…` for paper, `AK…` for live). This guards against common
+copy-paste mistakes but does not prevent entry of unconventional key formats.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Settings Modal
+
+**Scope:** `Modal::Settings` only. No credential handling. No profile support.
+
+**Why first:** Lowest risk. Exercises the modal → command → disk-write → event
+pipeline without touching credentials or reconnect logic. Delivers immediate user
+value (persist theme choice, change poll interval without restart).
+
+**Deliverables:**
+
+1. `SettingsField` enum + `Modal::Settings` variant in `src/app.rs`
+2. `Command::SavePrefs(AppPrefs)` in `src/commands.rs`
+3. `Event::PrefsSaved` and `Event::PrefsSaveError(String)` in `src/events.rs`
+4. Settings modal renderer in `src/ui/modals.rs`
+5. Settings modal keyboard handler in `src/input/modal.rs`
+6. `handlers/commands.rs`: match arm for `Command::SavePrefs` — calls
+   `AppPrefs::write_to(&AppPrefs::default_path().unwrap())`
+7. `update.rs`: match arms for `Event::PrefsSaved` / `Event::PrefsSaveError`
+8. `update.rs` `handle_key`: bind `,` or `S` (shift) as global shortcut to open
+   `Modal::Settings`
+9. Theme live-preview: on each `←`/`→` press on the Theme field in the draft,
+   call `app.current_theme = Theme::from_str(&draft.ui.theme)`; revert on Cancel
+
+**Tests:**
+
+- `settings_draft_cloned_from_app_prefs` — open modal, verify `draft == app.prefs`
+- `settings_cancel_does_not_mutate_prefs` — edit a field, cancel, verify `app.prefs`
+  unchanged
+- `settings_save_writes_draft_to_app_prefs` — edit, save, verify `app.prefs` updated
+- `save_prefs_command_writes_file` — integration test using `tempfile`, verify TOML
+  round-trips
+- `theme_live_preview_reverted_on_cancel` — open modal, cycle theme, cancel, verify
+  `app.current_theme == original`
+
+---
+
+### Phase 2 — In-App Credential Entry
+
+**Scope:** `Modal::CredentialEntry` and the first-run TUI wizard. No multi-profile
+support yet — this phase works in legacy mode only (single live/paper account).
+
+**Why second:** Eliminates the only reason a user must restart the app (stale
+credentials). Also lays the pipe (SaveCredentials command, reconnect event, task
+re-spawn) that Phase 3 reuses for profile switching.
+
+**Deliverables:**
+
+1. `CredentialField` enum + `Modal::CredentialEntry` variant in `src/app.rs`
+2. `Command::SaveCredentials` and `Command::ResetCredentials` in `src/commands.rs`
+3. `Event::CredentialsSaved`, `Event::CredentialSaveError`, `Event::CredentialsReset`,
+   `Event::Reconnect { config, profile_display_name }` in `src/events.rs`
+4. Credential entry modal renderer in `src/ui/modals.rs`
+5. Credential entry keyboard handler in `src/input/modal.rs`
+6. `handlers/commands.rs` match arms for `SaveCredentials` (async keychain write),
+   `ResetCredentials` (async keychain delete)
+7. `credentials::save_keychain_pair_async()` — thin async wrapper that offloads
+   the blocking `keyring` call to `tokio::task::spawn_blocking`
+8. `reconnect()` helper function in `src/main.rs`
+9. `Event::Reconnect` interception in the main loop (before `update()` call)
+10. `App::clear_data()` helper (zeroes positions, orders, account, quotes, etc.)
+11. First-run wizard: in `main()`, after spawning tasks, if credentials could not
+    be resolved pre-TUI in profile mode, push `Modal::CredentialEntry` onto `app.modal`
+12. Global keybinding `Ctrl+K` → open `Modal::CredentialEntry` for the active env
+13. `zeroize` added to `Cargo.toml`; zero `key_input`/`secret_input` after dispatch
+
+**Tests:**
+
+- `credential_entry_backspace_clears_last_char` — unit test on modal key handler
+- `credential_entry_esc_closes_without_save` — modal closed, no command sent
+- `credential_entry_secret_toggle` — space toggles `secret_visible`
+- `save_credentials_command_calls_keychain` — mock `save_keychain_pair`, verify called
+  with correct profile prefix and key/secret values
+- `reconnect_clears_app_data` — after `App::clear_data()`, all data fields are empty
+- Integration test (with `wiremock`): new credentials → reconnect → REST poll delivers
+  fresh `AccountInfo`
+
+---
+
+### Phase 3 — Multi-Profile Support
+
+**Scope:** `ProfileConfig`, `[[profiles]]` TOML schema, `Modal::AccountSwitcher`,
+profile-namespaced keychain, profile switching with reconnect, `--reset` profile
+option in CLI.
+
+**Why last:** Requires config schema changes (breaking for `to_toml_string()`),
+the most new state on `App`, and depends on the reconnect pipeline built in Phase 2.
+
+**Deliverables:**
+
+1. `ProfileConfig` struct in `src/prefs.rs`; `AppSection::active_profile: Option<String>`;
+   `AppPrefs::profiles: Vec<ProfileConfig>`
+2. `AppPrefs::to_toml_string()` updated to serialise `[[profiles]]` and
+   `active_profile` (only when profiles are non-empty — preserves legacy output)
+3. `credentials::resolve_profile(profile: &ProfileConfig)` in `src/credentials.rs`
+4. `AccountSwitcher` variant in `Modal` enum
+5. Account switcher renderer in `src/ui/modals.rs`
+6. Account switcher keyboard handler in `src/input/modal.rs`
+7. `Command::SwitchProfile(String)` in `src/commands.rs`
+8. `handlers/commands.rs`: `SwitchProfile` handler — resolves keychain creds for
+   target profile, emits `Event::Reconnect` or opens `Modal::CredentialEntry`
+9. `App::profiles` and `App::active_profile_name` fields; initialised in `App::new()`
+10. Header badge updated: shows `profile.display_name [ENV]` when in profile mode
+11. `App::active_profile()` helper — returns `Option<&ProfileConfig>` for the active name
+12. `--reset` CLI flag extended to accept profile names (in addition to `paper`/`live`)
+13. Startup flow: call `resolve_profile()` instead of `resolve()` when profiles exist
+14. `AppPrefs::add_profile()` / `AppPrefs::remove_profile()` helpers used by the
+    account switcher's `n` (new) and `d` (delete) commands
+
+**Tests:**
+
+- `profile_config_round_trips_toml` — serialise `AppPrefs` with profiles, parse back
+- `legacy_toml_no_profiles_is_compatible` — existing `config.toml` parses with zero
+  profile entries
+- `resolve_profile_returns_none_when_no_keychain_entry` — mock keychain returns
+  `NoEntry`; verify `Ok(None)` returned
+- `account_switcher_enter_sends_switch_command` — unit test for key handler
+- `switch_profile_reconnects_with_new_config` — integration test: emit
+  `Command::SwitchProfile`, verify `Event::Reconnect` emitted with correct env
+- `header_badge_shows_profile_display_name` — unit test on header renderer
+
+---
+
+## File Changes Inventory
+
+| File | Change |
+|---|---|
+| `src/prefs.rs` | Add `ProfileConfig`, `AppSection::active_profile`, `AppPrefs::profiles`, update `to_toml_string()`, add `add_profile()` / `remove_profile()` helpers |
+| `src/app.rs` | Add `Modal::CredentialEntry`, `Modal::AccountSwitcher`, `Modal::Settings`; add `CredentialField`, `SettingsField` enums; add `App::profiles`, `App::active_profile_name`, `App::clear_data()`, `App::active_profile()` |
+| `src/commands.rs` | Add `SaveCredentials`, `ResetCredentials`, `SwitchProfile`, `SavePrefs` variants |
+| `src/events.rs` | Add `CredentialsSaved`, `CredentialSaveError`, `CredentialsReset`, `Reconnect`, `ProfileSwitchError`, `PrefsSaved`, `PrefsSaveError` variants |
+| `src/credentials.rs` | Add `resolve_profile()`, `save_keychain_pair_async()`, `reset_profile()` functions; keep `resolve()` unchanged |
+| `src/handlers/commands.rs` | Add match arms for `SaveCredentials`, `ResetCredentials`, `SwitchProfile`, `SavePrefs` |
+| `src/update.rs` | Add match arms for new events; add `Modal::CredentialEntry`, `Modal::AccountSwitcher`, `Modal::Settings` open shortcuts in `handle_key()` |
+| `src/input/modal.rs` | Add match arms for `Modal::CredentialEntry`, `Modal::AccountSwitcher`, `Modal::Settings` |
+| `src/ui/modals.rs` | Add renderers for the three new modals; register `popup_area` sizes for hit-test; add popup_area constants for the new modal sizes |
+| `src/main.rs` | Add `Event::Reconnect` intercept before `update()` call; add `reconnect()` async helper; update startup flow for profile mode; extend `--reset` CLI flag |
+| `src/ui/dashboard.rs` | Update header badge to show profile display name when in profile mode |
+| `Cargo.toml` | Add `zeroize = { version = "1", features = ["derive"] }` |
+| `tests/` | New integration tests for credential save, profile switch, prefs persistence |
+
+---
+
+## Test Strategy
+
+### Unit Tests (in-module `#[cfg(test)]`)
+
+| Module | What to test |
+|---|---|
+| `src/prefs.rs` | `ProfileConfig` TOML round-trip; `AppPrefs` with `[[profiles]]` parses correctly; legacy TOML (no profiles) still loads; `to_toml_string()` emits `[[profiles]]` only when non-empty; `add_profile` / `remove_profile` maintain sorted order |
+| `src/credentials.rs` | `resolve_profile` returns `Ok(None)` when keychain empty (mock via `temp-env`); `resolve_profile` prefers unified env vars; `save_keychain_pair_async` compiles (integration only, no CI keychain) |
+| `src/app.rs` | `App::clear_data()` zeroes all data vectors; `App::active_profile()` returns the matching profile; `CredentialField::next/prev` cycles correctly; `SettingsField::is_toggle/is_cyclic/is_text` classification |
+| `src/ui/theme.rs` | Already has tests; verify `Theme::from_str` is the canonical parse used by both `Settings` draft and `App::current_theme` |
+
+### Integration Tests (`tests/`)
+
+| Test | Approach |
+|---|---|
+| `test_save_prefs_writes_toml` | Create `AppPrefs`, mutate one field, call `write_to(tempfile)`, parse back with `load_from()`, assert equality |
+| `test_settings_modal_save_command` | Build test app, open `Modal::Settings`, mutate a field in draft, press Save, verify `command_tx` receives `Command::SavePrefs` |
+| `test_credential_entry_dispatches_command` | Open `Modal::CredentialEntry`, type key/secret, press Save, confirm, verify `Command::SaveCredentials` dispatched with correct profile and values |
+| `test_reconnect_clears_state_and_respawns` | Start app with `wiremock` server, emit `Event::Reconnect { config }`, verify `App::account` is `None` after reconnect and a new REST poll populates it |
+| `test_account_switcher_no_creds_opens_credential_entry` | `Command::SwitchProfile` for profile with no keychain entry → verify `Modal::CredentialEntry` is opened |
+| `test_profile_toml_backward_compat` | Parse existing v0.6 `config.toml` fixture (no `[[profiles]]`), verify `profiles` is empty and startup succeeds |
+
+### Mock Patterns
+
+- **Keychain**: use `temp-env` to set `{PREFIX}_KEY` / `{PREFIX}_SECRET` env vars
+  so `resolve_profile()` returns a result without touching the real keychain. The
+  `keyring` crate is never called in unit tests.
+- **REST**: existing `wiremock` test infrastructure in `tests/` continues unchanged.
+- **TUI render**: do not test pixel output; test that the correct `Modal` variant is
+  set on `App` and the correct `Command` is sent through the channel. The render
+  functions are exercised by visual inspection and snapshot tests as a stretch goal.
+
+---
+
+## Open Questions
+
+1. **`command_rx` / `symbol_rx` on reconnect**: Both channel receivers are moved
+   into their respective tasks on startup, making them unavailable for re-use on
+   reconnect. The simplest resolution is to create new channels in `reconnect()`
+   and update `app.command_tx` / `app.symbol_tx` to the new senders. However, any
+   in-flight `Command` in the old `command_rx` will be lost. Should we drain the
+   old channel before replacing it? Or is it acceptable to drop pending commands
+   on profile switch (they would be for the wrong account anyway)?
+
+2. **`--reset` for profiles**: The existing `--reset live` / `--reset paper` CLI
+   interface conflicts with profile names (e.g., `--reset personal-live`). Options:
+   - Accept any string: `--reset <profile-name-or-env>` and try both legacy and
+     profile keychain namespaces.
+   - Add `--reset-profile <name>` as a separate flag.
+   Recommendation: unified `--reset <name>` where `paper` and `live` are treated as
+   legacy aliases, any other string as a profile name.
+
+3. **Profile creation UI**: Phase 3 allows creating a new profile from the
+   `AccountSwitcher` via `n`. This requires a form with `name`, `display_name`, and
+   `env` fields before opening `CredentialEntry`. Should this be a separate
+   `Modal::NewProfile` or extend `CredentialEntry` with extra fields? A separate
+   modal keeps each modal focused but adds a new renderer; extending `CredentialEntry`
+   reduces file count but increases its complexity.
+
+4. **`zeroize` scope for `AlpacaConfig`**: Wrapping `AlpacaConfig::key` and
+   `AlpacaConfig::secret` in `Zeroizing<String>` would require changes across
+   all callers (stream tasks, REST client headers). The `reqwest` client copies
+   header values into an internal buffer anyway, so zeroing `AlpacaConfig::secret`
+   does not zero the copy in the HTTP client. A full secret-hygiene pass is a larger
+   cross-cutting refactor best scoped as a separate issue.
+
+5. **Proxy settings in Settings modal**: The `[proxy]` section contains `Option<String>`
+   fields. Since proxy changes require rebuilding the `reqwest::Client`, they cannot
+   be hot-reloaded without a reconnect. The Settings modal should mark these fields
+   as `(restart required)` and skip calling `Command::SavePrefs`-triggered reconnect
+   automatically. Should proxy settings appear in the modal at all in Phase 1, or
+   wait until the reconnect pipeline is in place (Phase 2)?
+
+6. **Multiple profiles with the same `name`**: The schema does not enforce uniqueness
+   on `ProfileConfig::name`. Should `AppPrefs::add_profile()` return an error on
+   duplicate names, or silently replace the existing entry? The keychain namespace
+   collision would silently overwrite the old credentials.
+
+7. **Paper mode watchlist unavailability notice**: Currently `Event::WatchlistUnavailable`
+   is a one-shot event. When switching from a live profile (which has watchlists) to a
+   paper profile, `app.watchlist_unavailable` should be reset to `false` in
+   `App::clear_data()` and re-set when the REST handler fires the event again for the
+   new profile.
+```
+
+---
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,30 +4,37 @@
 
 `alpaca-trader-rs` is two things in one crate:
 
-- **Library** (`src/lib.rs`): a public async API for Alpaca Markets — typed REST client, WebSocket streams, and shared domain types. Intended to be embedded in other Rust applications.
+- **Library** (`src/lib.rs`): a public async API for Alpaca Markets — typed REST client, WebSocket streams, shared domain types, and app infrastructure (prefs, commands, logging). Intended to be embedded in other Rust applications.
 - **Binary** (`src/main.rs`): a full terminal UI (TUI) trading dashboard built on top of the library using the Elm Architecture (TEA).
 
-The library/app boundary is explicit: `client`, `config`, `types`, `events`, and `stream` modules are public and form the library surface. `app`, `update`, and `ui` are app-only and not re-exported from `lib.rs`.
+The library exports `client`, `config`, `types`, `events`, `stream`, `commands`, `prefs`, `logging`, and `clipboard`. App-only code (`app`, `update`, `input`, `ui`) lives in the binary and is not re-exported from `lib.rs`.
 
 ---
 
 ## Technology Stack
 
-| Layer | Crate | Scope | Purpose |
-|---|---|---|---|
-| Async runtime | `tokio` 1.x | Library + App | Async tasks, timers, channels |
-| HTTP client | `apca` 0.30 | Library | Typed Alpaca REST client |
-| HTTP fallback | `reqwest` 0.13 | Library | Endpoints not covered by `apca` |
-| WebSocket | `tokio-tungstenite` 0.26 | Library | Market data and account streams |
-| Serialization | `serde` + `serde_json` | Library | JSON encode/decode |
-| Config | `dotenvy` | Library + App | `.env` loading |
-| TUI rendering | `ratatui` 0.30 | App only | Immediate-mode terminal widgets |
-| Terminal backend | `crossterm` 0.29 | App only | Cross-platform raw-mode I/O |
-| Text input | `ratatui-textarea` 0.9 | App only | Symbol, Qty, Price input fields |
+| Layer | Crate | Version | Scope | Purpose |
+|---|---|---|---|---|
+| Async runtime | `tokio` | 1.x | Library + App | Async tasks, timers, channels, `select!` |
+| HTTP client | `reqwest` | 0.13 | Library | All Alpaca REST calls |
+| WebSocket | `tokio-tungstenite` | 0.29 | Library | Market data and account streams |
+| Serialization | `serde` + `serde_json` | 1 | Library | JSON encode/decode |
+| Config | `dotenvy` | 0.15 | Library + App | `.env` loading |
+| Date/time | `chrono` | 0.4 | Library + App | Timestamps, date formatting |
+| Async utils | `tokio-util` | 0.7 | App | `CancellationToken` for graceful shutdown |
+| TUI rendering | `ratatui` | 0.30 | App only | Immediate-mode terminal widgets |
+| Terminal backend | `crossterm` | 0.29 | App only | Cross-platform raw-mode I/O, mouse support |
+| CLI args | `clap` | 4 | App only | `--paper`, `--dry-run` flags |
+| Preferences | `toml` | 1.1 | App only | Serialize/deserialize `config.toml` |
+| Credentials | `keyring` | 3 | App only | Native OS keychain (macOS/Windows/Linux) |
+| Credentials | `rpassword` | 7 | App only | Interactive secure password prompt |
+| Clipboard | `arboard` | 3 | App only | Cross-platform clipboard write (`c` key) |
+| Logging | `tracing` + `tracing-subscriber` + `tracing-appender` | 0.1 / 0.3 / 0.2 | App only | Structured file + syslog logging |
+| Paths | `dirs` | 6 | App only | Platform config/data directory resolution |
 
-### Why `apca` over raw `reqwest`?
+### Why `reqwest` directly (no wrapper library)?
 
-`apca` mirrors the Alpaca API with typed request/response structs and built-in async support, eliminating hand-written JSON deserialization for common operations. `reqwest` is retained for endpoints and streaming patterns not covered by `apca`.
+`reqwest` gives full control over request shape, headers, and error handling. Using raw `reqwest` lets the codebase match Alpaca's API surface exactly without an intermediate abstraction layer that could lag behind API changes. All endpoints are unit-tested via `wiremock`.
 
 ### Why `ratatui` + `crossterm`?
 
@@ -97,11 +104,15 @@ alpaca-trader-rs/
 `src/lib.rs` re-exports:
 
 ```rust
-pub mod config;   // AlpacaConfig
-pub mod client;   // AlpacaClient
-pub mod types;    // All domain types
-pub mod events;   // Event enum
-pub mod stream;   // MarketStream, AccountStream
+pub mod client;    // AlpacaClient
+pub mod clipboard; // cross-platform clipboard write
+pub mod commands;  // Command enum (mutation requests)
+pub mod config;    // AlpacaConfig
+pub mod events;    // Event enum
+pub mod logging;   // tracing subscriber setup
+pub mod prefs;     // AppPrefs (config.toml persistence)
+pub mod stream;    // MarketStream, AccountStream
+pub mod types;     // All domain types
 ```
 
 ### `AlpacaConfig`
@@ -123,26 +134,33 @@ impl AlpacaConfig {
 
 ### `AlpacaClient`
 
-Async REST client. All methods return `Result<T, ClientError>`:
+Async REST client. All methods return `Result<T>` (`anyhow::Result`):
 
 ```rust
 impl AlpacaClient {
     pub fn new(config: AlpacaConfig) -> Self;
+    pub fn is_paper(&self) -> bool;
 
+    // Account & portfolio
     pub async fn get_account(&self) -> Result<AccountInfo>;
-    pub async fn get_positions(&self) -> Result<Vec<Position>>;
-    pub async fn get_orders(&self, status: OrderStatus) -> Result<Vec<Order>>;
-    pub async fn submit_order(&self, req: OrderRequest) -> Result<Order>;
-    pub async fn cancel_order(&self, order_id: &str) -> Result<()>;
-    pub async fn get_clock(&self) -> Result<MarketClock>;
-    pub async fn get_asset(&self, symbol: &str) -> Result<Asset>;
+    pub async fn get_portfolio_history(&self, period: &str, timeframe: &str) -> Result<Vec<f64>>;
 
+    // Positions & orders
+    pub async fn get_positions(&self) -> Result<Vec<Position>>;
+    pub async fn get_orders(&self, status: &str) -> Result<Vec<Order>>;
+    pub async fn submit_order(&self, req: &OrderRequest) -> Result<Order>;
+    pub async fn cancel_order(&self, order_id: &str) -> Result<()>;
+
+    // Market data
+    pub async fn get_clock(&self) -> Result<MarketClock>;
+    pub async fn get_snapshots(&self, symbols: &[String]) -> Result<HashMap<String, Snapshot>>;
+    pub async fn get_intraday_bars(&self, symbol: &str) -> Result<Vec<MinuteBar>>;
+
+    // Watchlists
     pub async fn list_watchlists(&self) -> Result<Vec<WatchlistSummary>>;
     pub async fn get_watchlist(&self, id: &str) -> Result<Watchlist>;
-    pub async fn get_watchlist_by_name(&self, name: &str) -> Result<Watchlist>;
     pub async fn add_to_watchlist(&self, id: &str, symbol: &str) -> Result<Watchlist>;
     pub async fn remove_from_watchlist(&self, id: &str, symbol: &str) -> Result<Watchlist>;
-    pub async fn replace_watchlist(&self, id: &str, name: &str, symbols: &[&str]) -> Result<Watchlist>;
 }
 ```
 
@@ -178,31 +196,36 @@ Event → update(App, Event) → App → render(Frame, App) → Terminal
 ### Data Flow
 
 ```
-  ┌─────────────────────────────────────────────────────────────────┐
-  │                        tokio runtime                            │
-  │                                                                 │
-  │  ┌──────────────┐   Event::Input   ┌────────────────────────┐  │
-  │  │  input task  │ ──────────────►  │                        │  │
-  │  │  (crossterm  │                  │      main loop         │  │
-  │  │  EventStream)│                  │                        │  │
-  │  └──────────────┘                  │  tokio::select! on     │  │
-  │                                    │  mpsc::Receiver<Event> │  │
-  │  ┌──────────────┐   Event::Data    │                        │  │
-  │  │  REST poller │ ──────────────►  │  1. update(app, evt)   │  │
-  │  │  AlpacaClient│                  │  2. terminal.draw(ui)  │  │
-  │  └──────────────┘                  │                        │  │
-  │                                    └────────────────────────┘  │
-  │  ┌──────────────┐   Event::Market                              │
-  │  │ MarketStream │ ──────────────►  (tx clone → same receiver)  │
-  │  └──────────────┘                                              │
-  │                                                                 │
-  │  ┌──────────────┐   Event::Account                             │
-  │  │AccountStream │ ──────────────►  (tx clone → same receiver)  │
-  │  └──────────────┘                                              │
-  └─────────────────────────────────────────────────────────────────┘
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │                          tokio runtime                              │
+  │                                                                     │
+  │  ┌──────────────┐  Event::Input   ┌─────────────────────────────┐  │
+  │  │  input task  │ ─────────────►  │                             │  │
+  │  │  (crossterm  │                 │         main loop           │  │
+  │  │  EventStream)│                 │                             │  │
+  │  └──────────────┘                 │  tokio::select! on          │  │
+  │                                   │  mpsc::Receiver<Event>      │  │
+  │  ┌──────────────┐  Event::*Data   │                             │  │
+  │  │  REST poller │ ─────────────►  │  1. update(app, evt)        │  │
+  │  │  AlpacaClient│                 │  2. terminal.draw(render)   │  │
+  │  └──────▲───────┘                 │                             │  │
+  │         │ Command                 └─────────────────────────────┘  │
+  │  ┌──────┴───────┐                           │ Command              │
+  │  │  command_tx  │ ◄─────────────────────────┘                      │
+  │  │  (mpsc chan) │   input handlers send mutation requests           │
+  │  └──────────────┘   (submit_order, cancel, watchlist mutations)     │
+  │                                                                     │
+  │  ┌──────────────┐  Event::MarketQuote                              │
+  │  │ MarketStream │ ─────────────►  (tx clone → same receiver)       │
+  │  └──────────────┘                                                   │
+  │                                                                     │
+  │  ┌──────────────┐  Event::TradeUpdate                              │
+  │  │AccountStream │ ─────────────►  (tx clone → same receiver)       │
+  │  └──────────────┘                                                   │
+  └─────────────────────────────────────────────────────────────────────┘
 ```
 
-All producers clone a `tokio::sync::mpsc::Sender<Event>`. The main loop holds the single `Receiver<Event>`.
+All event producers clone a `tokio::sync::mpsc::Sender<Event>`. The main loop holds the single `Receiver<Event>`. Mutation commands (order submit, cancel, watchlist add/remove) flow through a separate `mpsc::Sender<Command>` → REST handler channel, keeping the event flow unidirectional.
 
 ### State Model (`app.rs`)
 
@@ -302,16 +325,54 @@ pub enum Event {
 ```rust
 pub fn update(app: &mut App, event: Event) {
     match event {
-        Event::Input(key) => handle_input(app, key),
-        Event::Mouse(m)   => handle_mouse(app, m),
-        Event::AccountUpdated(a)   => app.account = Some(a),
-        Event::PositionsUpdated(p) => app.positions = p,
-        Event::OrdersUpdated(o)    => app.orders = o,
-        Event::WatchlistUpdated(w) => app.watchlist = Some(w),
-        Event::MarketQuote(q) => { app.quotes.insert(q.symbol.clone(), q); }
-        Event::TradeUpdate(u) => apply_trade_update(app, u),
-        Event::Quit => app.should_quit = true,
-        _ => {}
+        Event::Input(key)  => handle_key(app, key),
+        Event::Mouse(m)    => handle_mouse(app, m),
+        Event::Resize(..)  => { app.needs_redraw = true; }
+
+        Event::AccountUpdated(a) => {
+            app.account = Some(a);
+            app.push_equity();          // append to sparkline history
+        }
+        Event::PositionsUpdated(p)  => { app.positions = p; /* auto-select */ }
+        Event::OrdersUpdated(o)     => { app.orders = o;    /* auto-select */ }
+        Event::ClockUpdated(c)      => { app.clock = Some(c); }
+        Event::WatchlistUpdated(w)  => {
+            let _ = app.symbol_tx.send(/* symbol list for stream resubscription */);
+            app.watchlist = Some(w);
+        }
+        Event::WatchlistUnavailable => { app.watchlist_unavailable = true; }
+        Event::MarketQuote(q) => {
+            app.quotes.insert(q.symbol.clone(), q);
+            app.push_equity_from_quotes();  // stream equity samples between polls
+        }
+        Event::TradeUpdate { order: o, event_type } => {
+            // Flash fill notification then upsert order into the list
+            if let Some(msg) = fill_notification_text(&o, &event_type) {
+                app.push_fill_notification(msg);
+            }
+            if let Some(existing) = app.orders.iter_mut().find(|x| x.id == o.id) {
+                *existing = o;
+            } else {
+                app.orders.insert(0, o);
+            }
+        }
+        Event::StatusMsg(msg)          => { app.push_status(StatusMessage::persistent(msg)); }
+        Event::StreamConnected(kind)   => { /* set market_stream_ok / account_stream_ok */ }
+        Event::StreamDisconnected(kind)=> { /* clear stream ok flag */ }
+        Event::PortfolioHistoryLoaded(data) => {
+            app.equity_history = data.into_iter().map(|v| (v * 100.0) as u64).collect();
+        }
+        Event::SnapshotsUpdated(s)     => { app.snapshots = s; }
+        Event::IntradayBarsReceived { symbol, bars } => {
+            app.intraday_bars.insert(symbol, bars);
+        }
+        Event::FetchStarted  => app.request_started(),
+        Event::FetchComplete => app.request_finished(),
+        Event::Tick => {
+            app.tick_spinner();
+            // expire timed status messages, schedule intraday refreshes, etc.
+        }
+        Event::Quit => { app.should_quit = true; }
     }
 }
 ```
@@ -321,27 +382,42 @@ No I/O, no async — pure and unit-testable.
 ### View Function (`ui/mod.rs`)
 
 ```rust
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &mut App) {
+    // Reset hit areas so stale click rects are never used.
+    app.hit_areas = HitAreas::default();
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),  // header + market clock
+            Constraint::Length(1),  // tab bar
             Constraint::Min(0),     // active panel
             Constraint::Length(1),  // status bar
         ])
         .split(frame.area());
 
-    render_header(frame, chunks[0], app);
-    render_panel(frame, chunks[1], app);
-    render_status(frame, chunks[2], app);
+    app.hit_areas.tab_bar = chunks[1];
 
-    if let Some(modal) = &app.modal {
-        render_modal(frame, frame.area(), modal, app);
+    dashboard::render_header(frame, chunks[0], app);
+    dashboard::render_tabs(frame, chunks[1], app);
+
+    match app.active_tab {
+        Tab::Account   => account::render(frame, chunks[2], app),
+        Tab::Watchlist => watchlist::render(frame, chunks[2], app),
+        Tab::Positions => positions::render(frame, chunks[2], app),
+        Tab::Orders    => orders::render(frame, chunks[2], app),
+    }
+
+    dashboard::render_status(frame, chunks[3], app);
+
+    // Modals rendered last (always on top)
+    if let Some(modal) = app.modal.clone() {
+        modals::render(frame, frame.area(), &modal, app);
     }
 }
 ```
 
-Pure read of `&App`, writes only to `Frame` — no side effects.
+`render` takes `&mut App` (not `&App`) because it records click hit-areas into `app.hit_areas` on each frame. Pure data read otherwise — no I/O, no side effects beyond hit-area tracking.
 
 ---
 
@@ -365,17 +441,17 @@ Controlled by the `--paper` CLI flag. The binary defaults to **live**. All downs
 |---|---|---|
 | GET | `/v2/account` | `get_account()` |
 | GET | `/v2/positions` | `get_positions()` |
-| GET | `/v2/orders` | `get_orders()` |
-| POST | `/v2/orders` | `submit_order()` |
-| DELETE | `/v2/orders/{id}` | `cancel_order()` |
+| GET | `/v2/orders?status=all` | `get_orders(status)` |
+| POST | `/v2/orders` | `submit_order(req)` |
+| DELETE | `/v2/orders/{id}` | `cancel_order(id)` |
 | GET | `/v2/clock` | `get_clock()` |
-| GET | `/v2/assets/{symbol}` | `get_asset()` |
 | GET | `/v2/watchlists` | `list_watchlists()` |
-| GET | `/v2/watchlists/{id}` | `get_watchlist()` |
-| GET | `/v2/watchlists:by_name` | `get_watchlist_by_name()` |
-| POST | `/v2/watchlists/{id}` | `add_to_watchlist()` |
-| DELETE | `/v2/watchlists/{id}/{symbol}` | `remove_from_watchlist()` |
-| PUT | `/v2/watchlists/{id}` | `replace_watchlist()` |
+| GET | `/v2/watchlists/{id}` | `get_watchlist(id)` |
+| POST | `/v2/watchlists/{id}` | `add_to_watchlist(id, symbol)` |
+| DELETE | `/v2/watchlists/{id}/{symbol}` | `remove_from_watchlist(id, symbol)` |
+| GET | `/v2/account/portfolio/history` | `get_portfolio_history(period, timeframe)` |
+| GET | `/v2/stocks/snapshots` | `get_snapshots(symbols)` |
+| GET | `/v2/stocks/{symbol}/bars` | `get_intraday_bars(symbol)` |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,15 +56,32 @@ alpaca-trader-rs/
 │   ├── main.rs             # Binary entry point: runtime setup, main loop
 │   ├── app.rs              # App state — the TEA Model
 │   ├── update.rs           # update(state, event) — the TEA Update function
+│   ├── commands.rs         # Command enum: mutation requests from input to REST handler
+│   ├── prefs.rs            # AppPrefs: user preferences persisted to config.toml
+│   ├── credentials.rs      # 4-tier credential resolution (env → keychain → prompt)
+│   ├── clipboard.rs        # Cross-platform clipboard write helper
+│   ├── logging.rs          # File + syslog tracing subscriber setup
+│   ├── input/
+│   │   ├── mod.rs          # Shared nav helper (j/k/g/G) and key() / ctrl() factories
+│   │   ├── modal.rs        # Key handler for all modal states
+│   │   ├── mouse.rs        # Mouse event → hit-area dispatch
+│   │   ├── orders.rs       # handle_orders_key: sort, filter, sub-tabs, cancel
+│   │   ├── positions.rs    # handle_positions_key: sort, order entry, detail modal
+│   │   ├── search.rs       # Inline watchlist search and global search modal
+│   │   ├── validation.rs   # Pre-submit order validation (qty, price, buying power)
+│   │   └── watchlist.rs    # handle_watchlist_key: add, remove, navigate
 │   └── ui/
 │       ├── mod.rs          # render(frame, app) — the TEA View function
+│       ├── account.rs      # Account summary + equity sparkline + daytrade/PDT info
+│       ├── charts.rs       # Shared braille line-chart renderer and crosshair logic
 │       ├── dashboard.rs    # Header, tab bar, status bar layout
-│       ├── account.rs      # Account summary + sparkline
-│       ├── watchlist.rs    # Watchlist table
-│       ├── positions.rs    # Positions table
-│       ├── orders.rs       # Orders table + sub-tabs
-│       ├── modals.rs       # Order entry, symbol detail, help, confirmation
-│       └── theme.rs        # Color palette and styles
+│       ├── formatting.rs   # Currency, percentage, and volume formatting helpers
+│       ├── modals.rs       # All modals: OrderEntry, SymbolDetail, PositionDetail, Help, etc.
+│       ├── orders.rs       # Orders table + sub-tabs + sort/filter indicators
+│       ├── positions.rs    # Positions table + P&L footer + sort indicators
+│       ├── test_helpers.rs # Shared render-test utilities (terminal fixture, etc.)
+│       ├── theme.rs        # Color palette and styles (default / dark / high-contrast)
+│       └── watchlist.rs    # Watchlist table + inline search bar
 │
 ├── docs/                   # Full documentation
 ├── .env.example
@@ -191,17 +208,55 @@ All producers clone a `tokio::sync::mpsc::Sender<Event>`. The main loop holds th
 
 ```rust
 pub struct App {
+    // Config & preferences
+    pub config: AlpacaConfig,
+    pub prefs: AppPrefs,
+    pub current_theme: Theme,
+
+    // Data state
     pub account: Option<AccountInfo>,
     pub positions: Vec<Position>,
     pub orders: Vec<Order>,
     pub quotes: HashMap<String, Quote>,
     pub watchlist: Option<Watchlist>,
+    pub snapshots: HashMap<String, Snapshot>,
     pub clock: Option<MarketClock>,
+    pub equity_history: Vec<u64>,
+    pub equity_range: EquityRange,
+    pub intraday_bars: HashMap<String, Vec<u64>>,
+
+    // UI selection state
     pub active_tab: Tab,
-    pub selected_row: usize,
+    pub watchlist_state: TableState,
+    pub positions_state: TableState,
+    pub orders_state: TableState,
+    pub orders_subtab: OrdersSubTab,
     pub modal: Option<Modal>,
-    pub status: StatusMessage,
+
+    // Sort + filter state
+    pub positions_sort: SortState<PositionSortCol>,
+    pub orders_sort: SortState<OrderSortCol>,
+    pub orders_symbol_filter: String,
+    pub orders_filter_active: bool,
+
+    // Search
+    pub search_query: String,
+    pub searching: bool,
+
+    // Crosshair cursors
+    pub equity_chart_cursor: Option<usize>,
+    pub symbol_detail_crosshair: Option<usize>,
+
+    // Status / control
+    pub status_queue: VecDeque<StatusMessage>,
     pub should_quit: bool,
+    pub last_updated: Option<DateTime<Local>>,
+    pub spinner_tick: u8,
+
+    // Channels
+    pub command_tx: mpsc::Sender<Command>,
+    pub symbol_tx: watch::Sender<Vec<String>>,
+    pub refresh_notify: Arc<Notify>,
 }
 ```
 
@@ -222,15 +277,23 @@ pub enum Event {
     OrdersUpdated(Vec<Order>),
     ClockUpdated(MarketClock),
     WatchlistUpdated(Watchlist),
+    WatchlistUnavailable,
+    SnapshotsUpdated(HashMap<String, Snapshot>),
+    PortfolioHistoryLoaded(Vec<f64>),
+    IntradayBarsReceived { symbol: String, bars: Vec<u64> },
+    FetchStarted,
+    FetchComplete,
 
     // WebSocket streaming
     MarketQuote(Quote),
-    MarketBar(Bar),
-    TradeUpdate(TradeUpdate),
+    TradeUpdate { order: Order, event_type: String },
+    StreamConnected(StreamKind),
+    StreamDisconnected(StreamKind),
 
     // Control
     Tick,   // 250 ms UI refresh tick
     Quit,
+    StatusMsg(String),
 }
 ```
 

--- a/docs/future-features.md
+++ b/docs/future-features.md
@@ -69,16 +69,7 @@ Add a scrollable news section at the bottom of the Symbol Detail modal, populate
 Support Alpaca's multiple named watchlists. Use `[`/`]` to cycle between watchlists; the panel header shows the active watchlist name.
 
 - **API**: `GET /v2/watchlists` returns all lists; `GET /v2/watchlists/{id}` for symbols
-- **Paper mode**: falls back to local-file watchlist (see issue #59)
 - **Files**: `src/ui/watchlist.rs`, `src/app.rs`, `src/handlers/rest.rs`
-
----
-
-### Local-File Watchlist Fallback for Paper Mode
-When running in paper mode, the Alpaca watchlist API is unavailable. Store and load a watchlist from a local JSON file (`~/.config/alpaca-trader/watchlist.json`) so the panel is usable regardless of environment.
-
-- **Related**: issue #59 (paper mode watchlist silent failure)
-- **Files**: `src/handlers/rest.rs`, `src/ui/watchlist.rs`, new `src/local_watchlist.rs`
 
 ---
 
@@ -122,17 +113,17 @@ Filter the full universe of tradeable symbols by criteria (price range, volume, 
 
 ## Related Issues
 
-| Issue | Title |
-|-------|-------|
-| [#51](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/51) | Header: PRE-MARKET / AFTER-HOURS state detection |
-| [#52](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/52) | Account panel: Day P&L, Open P&L, Account #, equity sparkline |
-| [#53](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/53) | Watchlist: columns (Volume not Ask/Bid), Change%, color-coding |
-| [#54](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/54) | Symbol Detail modal: OHLCV, sparkline, w:Toggle Watchlist |
-| [#55](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/55) | Positions: `s` key for SELL SHORT + status bar hint |
-| [#56](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/56) | Order Entry: ↑/↓ cycling for dropdown fields |
-| [#57](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/57) | About modal with app/author metadata |
-| [#58](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/58) | Replace filled Sparkline with no-fill Chart + Braille line |
-| [#59](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/59) | Bug: watchlist silently fails in paper trading mode |
-| [#60](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/60) | `--dry-run` flag to simulate order submissions |
-| [#61](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/61) | Persist user preferences to `~/.config/alpaca-trader/config.toml` |
-| [#62](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/62) | Theme switching (default / dark / high-contrast) via `T` key |
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#51](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/51) | Header: PRE-MARKET / AFTER-HOURS state detection | Open |
+| [#52](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/52) | Account panel: Day P&L, Open P&L, Account #, equity sparkline | Open |
+| [#53](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/53) | Watchlist: columns (Volume not Ask/Bid), Change%, color-coding | Open |
+| [#54](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/54) | Symbol Detail modal: OHLCV, sparkline, w:Toggle Watchlist | Open |
+| [#55](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/55) | Positions: `s` key for column sorting | ✅ Implemented (#82) |
+| [#56](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/56) | Order Entry: ↑/↓ cycling for dropdown fields | Open |
+| [#57](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/57) | About modal with app/author metadata | ✅ Implemented |
+| [#58](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/58) | Replace filled Sparkline with no-fill Chart + Braille line | ✅ Implemented |
+| [#59](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/59) | Bug: watchlist silently fails in paper trading mode | ✅ Fixed |
+| [#60](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/60) | `--dry-run` flag to simulate order submissions | ✅ Implemented |
+| [#61](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/61) | Persist user preferences to `~/.config/alpaca-trader/config.toml` | ✅ Implemented |
+| [#62](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/62) | Theme switching (default / dark / high-contrast) via `T` key | ✅ Implemented |

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,0 +1,145 @@
+# Library Usage
+
+Full API reference and usage examples for the `alpaca-trader-rs` crate.
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+alpaca-trader-rs = "0.6"
+tokio = { version = "1", features = ["full"] }
+```
+
+---
+
+## Public API
+
+| Module | Exposed items |
+|---|---|
+| `config` | `AlpacaConfig`, `AlpacaEnv` |
+| `client` | `AlpacaClient` — `get_account()`, `get_positions()`, `get_orders()`, `submit_order()`, `cancel_order()`, `get_clock()`, `list_watchlists()`, `get_watchlist()`, `add_to_watchlist()`, `remove_from_watchlist()` |
+| `types` | `AccountInfo`, `Position`, `Order`, `OrderRequest`, `OrderSide`, `OrderType`, `TimeInForce`, `Quote`, `MarketClock`, `Watchlist`, `WatchlistSummary`, `Asset` |
+| `events` | `Event` — unified event enum consumed by the TUI app |
+| `stream` | `MarketStream`, `AccountStream` — WebSocket live data |
+
+---
+
+## Examples
+
+### Fetch account info
+
+```rust
+use alpaca_trader_rs::{client::AlpacaClient, config::AlpacaConfig};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+    let client = AlpacaClient::new(AlpacaConfig::from_env()?);
+
+    let account = client.get_account().await?;
+    println!("Equity:        ${}", account.equity);
+    println!("Buying power:  ${}", account.buying_power);
+    println!("Day trades:    {} / 3", account.daytrade_count);
+    println!("PDT:           {}", account.pattern_day_trader);
+    Ok(())
+}
+```
+
+### Place an order
+
+```rust
+use alpaca_trader_rs::types::{OrderRequest, OrderSide, OrderType, TimeInForce};
+
+let order = client.submit_order(&OrderRequest {
+    symbol: "AAPL".into(),
+    qty: Some("10".into()),
+    notional: None,
+    side: OrderSide::Buy.as_str().into(),
+    order_type: OrderType::Limit.as_str().into(),
+    time_in_force: TimeInForce::Day.as_str().into(),
+    limit_price: Some("185.00".into()),
+}).await?;
+println!("Order submitted: {}", order.id);
+```
+
+### Cancel an order
+
+```rust
+client.cancel_order(&order.id).await?;
+```
+
+### Fetch positions
+
+```rust
+let positions = client.get_positions().await?;
+for p in &positions {
+    println!("{}: {} shares @ ${} — P&L: ${}", p.symbol, p.qty, p.avg_entry_price, p.unrealized_pl);
+}
+```
+
+### Fetch open orders
+
+```rust
+let orders = client.get_orders("open").await?;
+for o in &orders {
+    println!("{} {} {} @ {} — status: {}", o.side, o.qty, o.symbol, o.limit_price.as_deref().unwrap_or("mkt"), o.status);
+}
+```
+
+### Manage watchlists
+
+```rust
+let summaries = client.list_watchlists().await?;
+let wl = client.get_watchlist(&summaries[0].id).await?;
+
+for asset in &wl.assets {
+    println!("{} — {} ({})", asset.symbol, asset.name, asset.exchange);
+}
+
+client.add_to_watchlist(&wl.id, "NVDA").await?;
+client.remove_from_watchlist(&wl.id, "TLRY").await?;
+```
+
+### Check market clock
+
+```rust
+let clock = client.get_clock().await?;
+println!("Market is open: {} | Next open: {}", clock.is_open, clock.next_open);
+```
+
+---
+
+## Error Handling
+
+All client methods return `anyhow::Result<T>`. HTTP errors (4xx/5xx) are surfaced as
+`anyhow::Error` with the response body included in the message. Build your own error
+handling on top with `anyhow::Context` or map to your crate's error type as needed.
+
+```rust
+use anyhow::Context;
+
+let account = client
+    .get_account()
+    .await
+    .context("failed to fetch account")?;
+```
+
+---
+
+## Configuration
+
+`AlpacaConfig::from_env()` reads credentials from environment variables using the
+four-tier priority chain described in [credentials-setup.md](credentials-setup.md).
+To construct a config manually:
+
+```rust
+use alpaca_trader_rs::config::{AlpacaConfig, AlpacaEnv};
+
+let config = AlpacaConfig {
+    base_url: "https://paper-api.alpaca.markets/v2".into(),
+    api_key: "your-key".into(),
+    api_secret: "your-secret".into(),
+    env: AlpacaEnv::Paper,
+};
+let client = AlpacaClient::new(config);
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,13 +2,14 @@
 
 Test coverage strategy, mock patterns, crate rationale, and test case inventory for `alpaca-trader-rs`.
 
-**Current state: 101 tests implemented and passing** (`cargo test`).
+**Current state: 800 tests implemented and passing** (`cargo test`).
 
 | Binary | Count | Scope |
 |---|---|---|
-| `lib` | 20 | `types`, `config` — serde, enum methods, env var parsing |
-| `bin` | 67 | `app`, `update`, `handlers/rest` — state logic, keyboard dispatch, REST polling |
-| `tests/client_tests.rs` | 14 | `AlpacaClient` — all 11 HTTP methods via wiremock |
+| `lib` (unit + UI) | 670 | `types`, `config`, `app`, `update`, `input/*`, `ui/*` — state logic, keyboard dispatch, render coverage |
+| `bin` (integration) | 100 | `AlpacaClient` — all HTTP methods via wiremock |
+| `bin` (doc tests) | 29 | Inline `# Example` blocks in public API docs |
+| `bin` (smoke) | 1 | Basic smoke test |
 
 ---
 
@@ -62,9 +63,30 @@ alpaca-trader-rs/
     ├── config.rs           ← #[cfg(test)] mod tests { }
     ├── app.rs              ← #[cfg(test)] mod tests { }
     ├── update.rs           ← #[cfg(test)] mod tests { }
-    └── handlers/
-        ├── rest.rs         ← #[cfg(test)] mod tests { }
-        └── input.rs        ← #[cfg(test)] mod tests { }
+    ├── prefs.rs            ← #[cfg(test)] mod tests { }
+    ├── credentials.rs      ← #[cfg(test)] mod tests { }
+    ├── handlers/
+    │   ├── rest.rs         ← #[cfg(test)] mod tests { }
+    │   └── input.rs        ← #[cfg(test)] mod tests { }
+    ├── input/
+    │   ├── mod.rs          ← #[cfg(test)] mod tests { }
+    │   ├── modal.rs        ← #[cfg(test)] mod tests { }
+    │   ├── mouse.rs        ← #[cfg(test)] mod tests { }
+    │   ├── orders.rs       ← #[cfg(test)] mod tests { }
+    │   ├── positions.rs    ← #[cfg(test)] mod tests { }
+    │   ├── search.rs       ← #[cfg(test)] mod tests { }
+    │   ├── validation.rs   ← #[cfg(test)] mod tests { }
+    │   └── watchlist.rs    ← #[cfg(test)] mod tests { }
+    └── ui/
+        ├── account.rs      ← #[cfg(test)] mod tests { }
+        ├── charts.rs       ← #[cfg(test)] mod tests { }
+        ├── dashboard.rs    ← #[cfg(test)] mod tests { }
+        ├── formatting.rs   ← #[cfg(test)] mod tests { }
+        ├── modals.rs       ← #[cfg(test)] mod tests { }
+        ├── orders.rs       ← #[cfg(test)] mod tests { }
+        ├── positions.rs    ← #[cfg(test)] mod tests { }
+        ├── theme.rs        ← #[cfg(test)] mod tests { }
+        └── watchlist.rs    ← #[cfg(test)] mod tests { }
 ```
 
 `client_tests.rs` lives in `tests/` (Rust integration test directory) so it links against the compiled library crate. All other test modules are inline `#[cfg(test)]` blocks.

--- a/docs/ui-mockups.md
+++ b/docs/ui-mockups.md
@@ -126,7 +126,7 @@ Every screen shares this outer chrome:
 │  b7c1…     NVDA    BUY      5   MARKET  —          PENDING    09:28:44      │
 │  f2d9…     INTC    SELL   100   LIMIT    $25.50    PENDING    09:15:02      │
 │                                                                              │
-│ o:New Order  c:Cancel Selected  Enter:Detail  1-3:Filter Tab                │
+│ o:New Order  c:Cancel  f:Filter  F:Clear  s/S:Sort  1/2/3:Sub-tabs          │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -134,6 +134,8 @@ Every screen shares this outer chrome:
 - BUY: green; SELL: red
 - Limit column shows `—` for MARKET orders
 - `c` cancels the highlighted order with a confirmation prompt
+- `f` opens an inline filter bar; type a ticker to filter the visible rows; `Enter` or `Esc` closes it; `F` clears the filter from normal mode
+- `s` / `S` cycle the sort column / toggle direction (same as Positions)
 - Order state updates arrive from `Event::TradeUpdate` via the account WebSocket stream
 
 ---
@@ -172,7 +174,7 @@ Triggered by `o` from any panel. Pre-fills Symbol if a row is selected.
 
 ## Modal — Symbol Detail
 
-Triggered by `Enter` on a Watchlist or Positions row.
+Triggered by `Enter` on a **Watchlist** row.
 
 ```
 ╔═ AMD — Advanced Micro Devices ═══════════╗
@@ -201,6 +203,33 @@ Triggered by `Enter` on a Watchlist or Positions row.
 
 ---
 
+## Modal — Position Detail
+
+Triggered by `Enter` on a **Positions** row.
+
+```
+╔═ AMD — Position Detail ══════════════════╗
+║                                          ║
+║  Qty       50       Avg Cost  $138.20    ║
+║  Cur Price $142.85  Mkt Value $7,142.50  ║
+║  Unrealized P&L     +$232.50  (+3.36%)   ║
+║                                          ║
+║  ── Intraday ──────────────────────────  ║
+║  ⠀⠀⠀⢀⣀⠤⠤⢄⡀⠀⠀⠀⣀⡠⠔⠒⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ║
+║  ⡠⠒⠉⠀⠀⠀⠀⠀⠈⠑⠒⠊⠀⠀⠀⠀⠀⠀⠀⠀⠙⠒⠤⣀⣀⡠⠔⠉⠁⠀  ║
+║  09:30                             16:00 ║
+║                                          ║
+║  o:New Order                        Esc  ║
+╚══════════════════════════════════════════╝
+```
+
+- Distinct from **Symbol Detail** — shows held-position metrics (Qty, Avg Cost, Unrealized P&L) rather than asset metadata
+- Intraday chart fetched via `Command::FetchIntradayBars` on open; same `Chart` widget as Symbol Detail
+- `o` opens Order Entry pre-filled with the position's symbol (SELL side)
+- `Esc` dismisses; no `s`, `w` actions (those belong to Symbol Detail only)
+
+---
+
 ## Modal — Help Overlay
 
 Triggered by `?` from any context.
@@ -214,7 +243,7 @@ Triggered by `?` from any context.
 ║  4 or Tab            Switch panels       ║
 ║  j / k  or ↑/↓    Move cursor           ║
 ║  gg / G            Top / Bottom          ║
-║  Enter             Open detail           ║
+║  Enter             Open detail (Watchlist/Positions)║
 ║  Esc               Close / Cancel        ║
 ║                                          ║
 ║  ACTIONS                                 ║
@@ -251,7 +280,7 @@ Triggered by `A` (uppercase) from any context. Displays app metadata, author inf
 ```
 ╔═ About alpaca-trader-rs ══════════════════╗
 ║                                           ║
-║   alpaca-trader-rs  v0.4.0                ║
+║   alpaca-trader-rs  v0.6.0                ║
 ║                                           ║
 ║   Alpaca Markets TUI trading terminal     ║
 ║   and async REST client library.          ║
@@ -323,7 +352,7 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `k` / `↑` | Move cursor up one row |
 | `g` | Jump to first row |
 | `G` | Jump to last row |
-| `Enter` | Open Symbol Detail modal for selected row |
+| `Enter` | Open detail modal for selected row (Symbol Detail on Watchlist; Position Detail on Positions) |
 
 ### Watchlist Panel
 
@@ -340,7 +369,7 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `o` | Open Order Entry pre-filled: selected symbol + SELL |
 | `s` | Cycle sort column (Symbol → Qty → Avg Cost → Cur Price → Mkt Value → P&L → None) |
 | `S` | Toggle sort direction (Asc ↔ Desc) |
-| `Enter` | Open Position Detail modal for selected row |
+| `Enter` | Open Position Detail modal for selected row (intraday chart + P&L) |
 
 ### Account Panel
 
@@ -371,6 +400,22 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `↑` / `↓` | Cycle values in dropdown fields (Side, Type) |
 | `Enter` | Advance to next field; submit when Submit button is focused |
 | `Esc` | Close modal without submitting |
+
+### Symbol Detail Modal (Watchlist)
+
+| Key | Action |
+|-----|--------|
+| `o` | Open Order Entry pre-filled with symbol (BUY) |
+| `s` | Open Order Entry pre-filled with symbol (SELL) |
+| `w` | Toggle symbol in/out of the active watchlist |
+| `Esc` | Close modal |
+
+### Position Detail Modal (Positions)
+
+| Key | Action |
+|-----|--------|
+| `o` | Open Order Entry pre-filled with symbol (SELL) |
+| `Esc` | Close modal |
 
 ---
 

--- a/docs/ui-mockups.md
+++ b/docs/ui-mockups.md
@@ -102,7 +102,7 @@ Every screen shares this outer chrome:
 │  ─────────────────────────────────────────────────────────────────────────  │
 │  Total Long: $21,202.50    Total Unrealized: +$322.50  (+1.54%)            │
 │                                                                              │
-│ o:Close  s:Short  Enter:Detail                                              │
+│ o:Order  s/S:Sort  Enter:Detail                                             │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -110,7 +110,7 @@ Every screen shares this outer chrome:
 - Unrealized P&L and % columns: green / red
 - Footer totals recalculate on every price update
 - `o` opens Order Entry pre-filled with current symbol + SELL
-- `s` opens Order Entry pre-filled with current symbol + SELL SHORT
+- `s` cycles the sort column; `S` toggles sort direction (Asc/Desc)
 
 ---
 
@@ -213,7 +213,7 @@ Triggered by `?` from any context.
 ║  1/2/3 (Orders tab)  Switch sub-tabs     ║
 ║  4 or Tab            Switch panels       ║
 ║  j / k  or ↑/↓    Move cursor           ║
-║  g / G             Top / Bottom          ║
+║  gg / G            Top / Bottom          ║
 ║  Enter             Open detail           ║
 ║  Esc               Close / Cancel        ║
 ║                                          ║
@@ -223,10 +223,18 @@ Triggered by `?` from any context.
 ║  a    Add symbol to watchlist            ║
 ║  d    Remove symbol from watchlist       ║
 ║  r    Force refresh                      ║
-║  /    Search / filter                    ║
+║  s/S  Cycle / toggle sort column/dir     ║
+║  f    Filter orders by symbol            ║
+║  p    Toggle equity range (1D/1W/1M/YTD) ║
+║  Ctrl-F / /  Global symbol search        ║
+║                                          ║
+║  ACCOUNT CHART                           ║
+║  ←/h / →/l  Move crosshair              ║
+║  Esc         Clear crosshair             ║
 ║                                          ║
 ║  GLOBAL                                  ║
 ║  q / Ctrl-C   Quit                       ║
+║  T            Cycle theme                ║
 ║  ?            This help screen           ║
 ║  A            About this app             ║
 ║                                          ║
@@ -301,8 +309,10 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `Tab` / `Shift-Tab` | Cycle tabs forward / backward |
 | `q` / `Ctrl-C` | Quit |
 | `r` | Force REST re-poll |
+| `T` | Cycle theme (default → dark → high-contrast) |
 | `?` | Toggle help overlay |
 | `A` | Open About modal |
+| `Ctrl-F` / `/` (non-Watchlist) | Open global symbol search modal |
 | `Esc` | Close any open modal |
 
 ### List Navigation (Watchlist, Positions, Orders)
@@ -328,7 +338,18 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | Key | Action |
 |-----|--------|
 | `o` | Open Order Entry pre-filled: selected symbol + SELL |
-| `s` | Open Order Entry pre-filled: selected symbol + SELL SHORT |
+| `s` | Cycle sort column (Symbol → Qty → Avg Cost → Cur Price → Mkt Value → P&L → None) |
+| `S` | Toggle sort direction (Asc ↔ Desc) |
+| `Enter` | Open Position Detail modal for selected row |
+
+### Account Panel
+
+| Key | Action |
+|-----|--------|
+| `p` | Cycle equity-chart range (1D → 1W → 1M → YTD) |
+| `←` / `h` | Move equity-chart crosshair left one data point |
+| `→` / `l` | Move equity-chart crosshair right one data point |
+| `Esc` | Clear equity-chart crosshair |
 
 ### Orders Panel
 
@@ -337,6 +358,10 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `o` | Open Order Entry (blank) |
 | `c` | Cancel selected order (confirmation prompt) |
 | `1` / `2` / `3` | Switch sub-tabs: Open / Filled / Cancelled |
+| `f` | Enter symbol-filter mode; type to filter orders by ticker |
+| `F` | Clear active symbol filter |
+| `s` | Cycle sort column (Symbol → Side → Type → Status → Submitted → None) |
+| `S` | Toggle sort direction (Asc ↔ Desc) |
 
 ### Order Entry Modal
 
@@ -351,16 +376,17 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 
 ## Mouse Interaction Model
 
-| Element | Left Click | Scroll |
-|---------|-----------|--------|
-| Tab bar | Switch to that panel | — |
-| List row | Select (move cursor) | Scroll list up/down |
-| Sub-tabs (Orders) | Switch sub-tab | — |
-| Modal: text input | Focus field | — |
-| Modal: radio button | Select option | — |
-| Modal: dropdown | Open dropdown | — |
-| Modal: dropdown option | Select and close | — |
-| Modal: Submit / Cancel | Activate button | — |
+| Element | Left Click | Double Click | Scroll |
+|---------|-----------|--------------|--------|
+| Tab bar | Switch to that panel | — | — |
+| List row | Select (move cursor) | Open Symbol/Position Detail modal | Scroll list up/down |
+| Sub-tabs (Orders) | Switch sub-tab | — | — |
+| Modal: text input | Focus field | — | — |
+| Modal: radio button | Select option | — | — |
+| Modal: dropdown | Open dropdown | — | — |
+| Modal: dropdown option | Select and close | — | — |
+| Modal: Submit / Cancel | Activate button | — | — |
+| Outside modal | Dismiss modal | — | — |
 
 Mouse support requires `crossterm` with the `event-stream` feature and `crossterm::execute!(stdout, EnableMouseCapture)` at startup. Hit positions for all interactive elements are calculated from the rendered `Rect` areas and stored in `App` state each frame.
 


### PR DESCRIPTION
Cleans up and brings README.md in sync with current implementation.

- **Key Bindings**: reorganised into groups (Global, Sorting, Orders, Account/chart, Mouse); removed stale SELL SHORT entry (s now sorts); added Ctrl-F/global search, s/S sort, f orders filter, p range toggle, crosshair keys, mouse actions
- **Features table**: added account metrics (short mkt value, day-trade count, PDT flag), position detail modal, global search, column sorting, orders filter, crosshair, mouse support, equity range toggle
- **Test count**: 540 -> 800