### PR TITLE
perf(main): drain event queue before each render to fix market-hours sluggishness

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,19 @@ async fn main() -> anyhow::Result<()> {
             Some(event) => update(&mut app, event),
         }
 
+        // Drain any additional events that queued up while we were rendering.
+        // During market hours the WebSocket stream delivers quote updates at
+        // high frequency; without this drain each quote would trigger its own
+        // full render, flooding the terminal and starving keyboard input.
+        // Processing them all in one pass before the next draw keeps the render
+        // rate independent of the quote rate.
+        while let Ok(event) = rx.try_recv() {
+            update(&mut app, event);
+            if app.should_quit {
+                break;
+            }
+        }
+
         // If the update requested an immediate redraw (e.g. terminal resize),
         // draw again before blocking for the next event so the layout adapts
         // right away instead of waiting for the next periodic tick.


### PR DESCRIPTION
## Summary

Fixes #143 (milestone v0.7.1)

The TUI was sluggish and unresponsive to keyboard input during market hours because the main loop called `terminal.draw()` on **every** event — including every `MarketQuote` from the WebSocket stream. With many symbols subscribed, quote events arrive at high frequency, causing continuous full re-renders that starved keyboard input.

## Root Cause

```rust
loop {
    terminal.draw(...)   // full render on EVERY iteration
    recv ONE event       // each quote = one re-render
    update state
}
```

## Fix

Added a non-blocking drain loop after the first event is processed. All queued events are consumed in one pass before the next `terminal.draw()`, decoupling the render rate from the quote rate.

```rust
while let Ok(event) = rx.try_recv() {
    update(&mut app, event);
    if app.should_quit { break; }
}
```

N quote events between frames → 1 render instead of N renders. Keyboard input remains responsive regardless of quote volume.

## Testing

- `cargo build` ✅
- `cargo test` — all 29 tests pass ✅  
- `cargo clippy` — clean ✅