### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
+## [0.7.1] — 2026-05-22
+
+Patch release fixing TUI sluggishness during market hours. No new features or breaking changes.
+
+### Fixed
+
+- **Event queue drain before render** (`src/main.rs`) — the main loop previously called `terminal.draw()` on every single event, including every `MarketQuote` from the WebSocket stream. During market hours with many subscribed symbols, this caused continuous full re-renders that starved keyboard input. Added a non-blocking drain loop after processing the first event so all queued events are consumed in one pass before the next render. N quote events between frames now costs 1 render instead of N, keeping keyboard input responsive at high quote volumes. (Closes #143)
+
+[0.7.1]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.7.0...v0.7.1
+
+---
+
 ## [0.7.0] — 2026-05-21
 
 Adds interactive chart crosshairs, a keyboard shortcut help overlay, global symbol search, equity-range toggling, column sorting, an orders symbol filter, position detail modal, double-click support, and PDT/day-trade account metrics. Extensive documentation overhaul covering architecture, UI mockups, account management design, and library reference. Test count grows from **541 → 800**.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpaca-trader-rs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-trader-rs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,133 +1,57 @@
-# Release Notes — v0.7.0
+# Release Notes — v0.7.1
 
-**Release date:** 2026-05-21
+**Release date:** 2026-05-22
 **MSRV:** Rust 1.88+
-**Previous release:** [v0.6.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.6.0)
+**Previous release:** [v0.7.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.7.0)
 
 ---
 
 ## Overview
 
-v0.7.0 is a major feature release focused on interactivity and discoverability. The headline changes are:
-
-1. **Interactive Chart Crosshairs** — keyboard and mouse-driven crosshair tooltips on the equity chart and symbol detail intraday chart
-2. **Help Overlay** — `?` brings up a full-screen keyboard shortcut reference
-3. **Global Symbol Search** — `Ctrl-F` / `/` opens a floating symbol search from any panel
-4. **Position Detail Modal** — `Enter` on a position shows a dedicated modal with intraday chart and P&L
-5. **Double-Click Support** — double-clicking a row opens the same detail as `Enter`; outside-click dismisses
-6. **Orders Symbol Filter** — `f` activates an inline filter bar to narrow orders by ticker
-7. **Column Sorting** — `s`/`S` sorts and reverses both Orders and Positions tables
-8. **Equity Date-Range Toggle** — `p` cycles the equity chart between 1D / 1W / 1M / YTD
-9. **PDT & Day-Trade Metrics** — Pattern Day Trader flag and day-trade count shown in Account panel
-10. **Documentation Overhaul** — architecture, UI mockups, testing, library API, and account management design docs all updated or created
-
-Test count grows from **541 → 800 tests**.
-
----
-
-## What's New
-
-### Interactive Chart Crosshairs
-
-Both the Account equity chart and the Symbol Detail intraday chart now support interactive crosshairs.
-Use `←`/`h` and `→`/`l` to move the crosshair, or click a data point with the mouse.
-A tooltip shows the date and value at the selected point. `Esc` clears the crosshair.
-
-### Help Overlay (`?`)
-
-Press `?` from any panel to open a full-screen keyboard shortcut reference.
-Every key binding is listed by category — navigation, panels, modals, sorting, filtering, and charts.
-Any key press closes the overlay.
-
-### Global Symbol Search (`Ctrl-F` / `/`)
-
-From any non-Watchlist panel, press `Ctrl-F` or `/` to open a floating symbol search input.
-Type a ticker symbol and press `Enter` to open the Symbol Detail modal immediately.
-`Esc` cancels without navigating.
-
-### Position Detail Modal
-
-`Enter` on a Positions row opens a dedicated `PositionDetail` modal showing an intraday chart,
-current P&L (unrealized + realized), quantity, cost basis, and current price.
-Press `o` inside the modal to jump directly to Order Entry pre-filled with a SELL order for that symbol.
-
-### Double-Click & Outside-Click
-
-Double-clicking a row in any list panel opens the detail modal for that row, matching the `Enter` key behavior.
-Clicking outside an open modal (outside its bounding box) dismisses it.
-
-### Orders Symbol Filter
-
-Press `f` on the Orders panel to activate an inline filter bar at the bottom.
-Type a symbol to narrow visible rows in real time. `Enter` or `Esc` closes the filter bar. `F` clears the active filter.
-
-### Column Sorting
-
-`s` cycles the active sort column on both the Orders and Positions tables.
-`S` toggles the sort direction (Ascending ↔ Descending).
-The selected column header shows a `▲`/`▼` indicator.
-
-### Equity Date-Range Toggle
-
-Press `p` on the Account panel to cycle the equity chart between four ranges:
-**1D** (intraday), **1W** (one week), **1M** (one month), and **YTD** (year-to-date).
-The selected range is persisted in `~/.config/alpaca-trader-rs/prefs.toml` across restarts.
-
-### PDT Flag and Day-Trade Metrics
-
-The Account panel now shows `daytrade_count` and the Pattern Day Trader (`pdt`) flag.
-`short_market_value` is also fetched and displayed alongside `long_market_value`.
+v0.7.1 is a patch release fixing a responsiveness regression during market hours.
+No new features or breaking changes.
 
 ---
 
 ## Bug Fixes
 
-- **Orders Enter key** — `Enter` now only confirms the filter bar when active; previously the docs incorrectly described an Orders detail modal that never existed.
-- **Crosshair out-of-bounds** — fixed a panic when the crosshair index exceeded the chart data length after a data refresh.
+### TUI Sluggishness During Market Hours (Closes #143)
 
----
+**Problem:** The TUI became sluggish and unresponsive to keyboard input during market hours.
 
-## Documentation
+**Root cause:** The main loop called `terminal.draw()` on every event — including every
+`MarketQuote` arriving from the WebSocket stream. With many symbols subscribed, quote events
+arrive at high frequency, triggering continuous full re-renders that starved keyboard input.
 
-A complete documentation overhaul was performed in this release:
+**Fix:** Added a non-blocking drain loop after processing the first event. All queued events
+are consumed in a single pass before the next `terminal.draw()`, decoupling render rate from
+quote arrival rate.
 
-- **`docs/architecture.md`** — technology stack corrected; `apca` and `ratatui-textarea` removed (never used); 4 missing crates added; `AlpacaClient` method list corrected (13 real methods); REST endpoints table corrected; data-flow diagram updated.
-- **`docs/ui-mockups.md`** — Orders footer corrected; Position Detail modal section added; per-modal keyboard tables added.
-- **`docs/testing.md`** — test layout updated with `src/input/` directory; count updated 101 → 800.
-- **`docs/future-features.md`** — 7 issues marked ✅ Implemented with PR links.
-- **`docs/library.md`** — new: full library API reference with 6 usage examples.
-- **`docs/account-management.md`** — new: design spec for in-app credential entry, multi-profile support, and settings modal (Phases 1–3).
+```rust
+// Before: one render per event (N quotes = N renders per frame)
+// After: drain all queued events, then render once
+while let Ok(event) = rx.try_recv() {
+    update(&mut app, event);
+    if app.should_quit { break; }
+}
+```
 
----
-
-## Internal / Refactoring
-
-- **`src/input/`** — input handlers split into per-panel modules (`account.rs`, `modal.rs`, `orders.rs`, `positions.rs`, `watchlist.rs`, `mouse.rs`), each with full unit-test coverage.
-- **Test helpers** — `render_test_frame()` and similar helpers in `src/ui/test_helpers.rs` used consistently across all UI render tests.
-- **Coverage** — every `match` arm, `if let`, and modal variant is now covered by a dedicated test.
+N quote events between frames now costs **1 render** instead of N renders. Keyboard input
+remains responsive regardless of quote volume or number of subscribed symbols.
 
 ---
 
 ## Tests
 
-**800 tests total** (up from 541 in v0.6.0):
-
-| Scope | Count |
-|---|---|
-| Library (`src/types.rs`, `src/config.rs`, `src/prefs.rs`, `src/client.rs`) | ~120 |
-| Input handlers (`src/input/`) | ~180 |
-| UI render (`src/ui/`) | ~370 |
-| HTTP integration (`tests/client_tests.rs`) | ~100 |
-| Doc-tests | ~30 |
+**800 tests** (unchanged from v0.7.0) — this patch contains no new logic paths requiring
+additional test coverage.
 
 ---
 
 ## No Breaking Changes
 
-v0.7.0 is fully backwards-compatible with v0.6.0. All CLI flags,
-credential resolution, environment variables, and library API are unchanged.
-Existing `prefs.toml` files are read without modification; the new `equity_range` key
-defaults to `1D` if absent.
+v0.7.1 is fully backwards-compatible with v0.7.0. All CLI flags, credential resolution,
+environment variables, key bindings, and library API are unchanged.
 
 ---
 


### PR DESCRIPTION
Prepares the repository for the v0.7.1 patch release.

## Changes
- Bumped version in Cargo.toml: 0.7.0 → 0.7.1
- Updated CHANGELOG.md with v0.7.1 patch entry
- Replaced RELEASE_NOTES.md with v0.7.1 notes

## Fix included
- **Event queue drain before render** — eliminates TUI sluggishness during market hours by consuming all queued events in one pass before calling `terminal.draw()` (Closes #143)