### PR TITLE
feat(stream): add StreamReconnecting event and UI reconnect/offline indicators

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -571,6 +571,20 @@ pub struct App {
     pub market_stream_ok: bool,
     /// `true` while the account WebSocket is connected and authenticated.
     pub account_stream_ok: bool,
+    /// `true` while the market-data stream is in a reconnect back-off window.
+    pub market_stream_reconnecting: bool,
+    /// `true` while the account stream is in a reconnect back-off window.
+    pub account_stream_reconnecting: bool,
+    /// 1-based reconnect attempt counter for the market-data stream.
+    ///
+    /// Reset to `0` when the stream connects successfully. Non-zero when
+    /// `!market_stream_ok`; used to distinguish "initial loading" from
+    /// "permanently offline after exhausting max attempts".
+    pub market_reconnect_attempt: u32,
+    /// 1-based reconnect attempt counter for the account stream.
+    ///
+    /// See `market_reconnect_attempt` for semantics.
+    pub account_reconnect_attempt: u32,
 
     /// Interactive element positions from the last rendered frame.
     pub hit_areas: HitAreas,
@@ -676,6 +690,10 @@ impl App {
             spinner_tick: 0,
             market_stream_ok: false,
             account_stream_ok: false,
+            market_stream_reconnecting: false,
+            account_stream_reconnecting: false,
+            market_reconnect_attempt: 0,
+            account_reconnect_attempt: 0,
             hit_areas: HitAreas::default(),
             last_click: None,
             pending_g_at: None,

--- a/src/events.rs
+++ b/src/events.rs
@@ -50,7 +50,17 @@ pub enum Event {
     },
     /// A WebSocket stream successfully (re)connected.
     StreamConnected(StreamKind),
-    /// A WebSocket stream disconnected; reconnection will be attempted.
+    /// A WebSocket stream disconnected and is waiting to retry.
+    ///
+    /// `attempt` is the 1-based reconnect attempt number. The UI uses this to
+    /// display a "reconnecting… (N)" indicator while back-off is in progress.
+    StreamReconnecting {
+        /// Which stream is reconnecting.
+        kind: StreamKind,
+        /// 1-based attempt number (1 = first retry after the initial disconnect).
+        attempt: u32,
+    },
+    /// A WebSocket stream disconnected permanently (max reconnect attempts reached).
     StreamDisconnected(StreamKind),
     /// Portfolio equity history loaded at startup for the sparkline.
     PortfolioHistoryLoaded(Vec<f64>),

--- a/src/stream/account.rs
+++ b/src/stream/account.rs
@@ -79,9 +79,12 @@ async fn run_inner(
                         .await;
                     return;
                 }
-                warn!(error = %e, backoff_ms = backoff.as_millis(), "account stream disconnected, reconnecting");
+                warn!(error = %e, backoff_ms = backoff.as_millis(), attempt, "account stream disconnected, reconnecting");
                 let _ = tx
-                    .send(Event::StreamDisconnected(StreamKind::Account))
+                    .send(Event::StreamReconnecting {
+                        kind: StreamKind::Account,
+                        attempt,
+                    })
                     .await;
                 tokio::select! {
                     _ = cancel.cancelled() => return,
@@ -455,13 +458,16 @@ mod integration {
             run_inner(tx, cancel2, test_config(), &url2, AppPrefs::default()).await;
         });
 
-        let mut saw_disconnect = false;
+        let mut saw_reconnecting = false;
         let mut saw_trade = false;
         tokio::time::timeout(Duration::from_secs(5), async {
-            while !saw_disconnect || !saw_trade {
+            while !saw_reconnecting || !saw_trade {
                 match rx.recv().await {
-                    Some(Event::StreamDisconnected(StreamKind::Account)) => {
-                        saw_disconnect = true;
+                    Some(Event::StreamReconnecting {
+                        kind: StreamKind::Account,
+                        attempt: 1,
+                    }) => {
+                        saw_reconnecting = true;
                     }
                     Some(Event::TradeUpdate { order: o, .. }) if o.symbol == "AAPL" => {
                         saw_trade = true;
@@ -472,12 +478,12 @@ mod integration {
             }
         })
         .await
-        .expect("should see disconnect + reconnect trade update within 5s");
+        .expect("should see StreamReconnecting + reconnect trade update within 5s");
 
         cancel.cancel();
         assert!(
-            saw_disconnect,
-            "should emit StreamDisconnected on first close"
+            saw_reconnecting,
+            "should emit StreamReconnecting on first close"
         );
         assert!(saw_trade, "should emit TradeUpdate after reconnect");
     }

--- a/src/stream/market.rs
+++ b/src/stream/market.rs
@@ -84,8 +84,13 @@ async fn run_inner(
                     let _ = tx.send(Event::StreamDisconnected(StreamKind::Market)).await;
                     return;
                 }
-                warn!(error = %e, backoff_ms = backoff.as_millis(), "market stream disconnected, reconnecting");
-                let _ = tx.send(Event::StreamDisconnected(StreamKind::Market)).await;
+                warn!(error = %e, backoff_ms = backoff.as_millis(), attempt, "market stream disconnected, reconnecting");
+                let _ = tx
+                    .send(Event::StreamReconnecting {
+                        kind: StreamKind::Market,
+                        attempt,
+                    })
+                    .await;
                 tokio::select! {
                     _ = cancel.cancelled() => return,
                     _ = tokio::time::sleep(backoff) => {}
@@ -568,13 +573,16 @@ mod integration {
             .await;
         });
 
-        let mut saw_disconnect = false;
+        let mut saw_reconnecting = false;
         let mut saw_quote = false;
         tokio::time::timeout(Duration::from_secs(5), async {
-            while !saw_disconnect || !saw_quote {
+            while !saw_reconnecting || !saw_quote {
                 match rx.recv().await {
-                    Some(Event::StreamDisconnected(StreamKind::Market)) => {
-                        saw_disconnect = true;
+                    Some(Event::StreamReconnecting {
+                        kind: StreamKind::Market,
+                        attempt: 1,
+                    }) => {
+                        saw_reconnecting = true;
                     }
                     Some(Event::MarketQuote(q)) if q.symbol == "TSLA" => {
                         saw_quote = true;
@@ -585,12 +593,12 @@ mod integration {
             }
         })
         .await
-        .expect("should see disconnect + reconnect quote within 5s");
+        .expect("should see StreamReconnecting + reconnect quote within 5s");
 
         cancel.cancel();
         assert!(
-            saw_disconnect,
-            "should emit StreamDisconnected on first close"
+            saw_reconnecting,
+            "should emit StreamReconnecting on first close"
         );
         assert!(saw_quote, "should emit MarketQuote after reconnect");
     }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -77,16 +77,41 @@ pub fn render_header(frame: &mut Frame, area: Rect, app: &App) {
     }
 
     if !app.market_stream_ok || !app.account_stream_ok {
-        let which = match (app.market_stream_ok, app.account_stream_ok) {
-            (false, false) => " ⚠ STREAM",
-            (false, true) => " ⚠ MARKET",
-            (true, false) => " ⚠ ACCOUNT",
-            _ => unreachable!(),
-        };
-        spans.push(Span::styled(
-            which,
-            Style::default().fg(c.neutral).add_modifier(Modifier::BOLD),
-        ));
+        // Build separate indicators for each stream so per-stream state is clear.
+        for (ok, reconnecting, attempt, label) in [
+            (
+                app.market_stream_ok,
+                app.market_stream_reconnecting,
+                app.market_reconnect_attempt,
+                "MARKET",
+            ),
+            (
+                app.account_stream_ok,
+                app.account_stream_reconnecting,
+                app.account_reconnect_attempt,
+                "ACCOUNT",
+            ),
+        ] {
+            if ok {
+                continue;
+            }
+            let (text, color) = if reconnecting {
+                (
+                    format!(" ⟳ {} reconnecting… ({})", label, attempt),
+                    c.neutral,
+                )
+            } else if attempt > 0 {
+                // Max attempts exhausted — stream is permanently offline.
+                (format!(" ✗ {} OFFLINE", label), c.negative)
+            } else {
+                // Still on the initial connect attempt.
+                (format!(" ⚠ {}", label), c.neutral)
+            };
+            spans.push(Span::styled(
+                text,
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ));
+        }
     }
 
     let line = Line::from(spans);
@@ -336,6 +361,160 @@ mod tests {
         assert!(
             !output.contains("Updated"),
             "header must not show 'Updated' when last_updated is None"
+        );
+    }
+
+    // ── Stream status indicators ──────────────────────────────────────────────
+
+    #[test]
+    fn header_shows_no_stream_indicator_when_both_connected() {
+        let mut app = make_test_app();
+        app.market_stream_ok = true;
+        app.account_stream_ok = true;
+        let output = render_header_to_string(&app);
+        assert!(
+            !output.contains("MARKET") && !output.contains("ACCOUNT") && !output.contains("STREAM"),
+            "no stream indicator when both streams are connected; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_market_initial_loading_indicator() {
+        let mut app = make_test_app();
+        // Initial state: not ok, not reconnecting, attempt=0
+        app.market_stream_ok = false;
+        app.market_stream_reconnecting = false;
+        app.market_reconnect_attempt = 0;
+        app.account_stream_ok = true;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("MARKET"),
+            "header should show MARKET indicator during initial loading; got: {output:?}"
+        );
+        assert!(
+            !output.contains("reconnecting"),
+            "should not say reconnecting during initial load; got: {output:?}"
+        );
+        assert!(
+            !output.contains("OFFLINE"),
+            "should not say OFFLINE during initial load; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_market_reconnecting_indicator_with_attempt() {
+        let mut app = make_test_app();
+        app.market_stream_ok = false;
+        app.market_stream_reconnecting = true;
+        app.market_reconnect_attempt = 2;
+        app.account_stream_ok = true;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("reconnecting"),
+            "header should show reconnecting label; got: {output:?}"
+        );
+        assert!(
+            output.contains('2'),
+            "header should include attempt count; got: {output:?}"
+        );
+        assert!(
+            !output.contains("OFFLINE"),
+            "should not show OFFLINE while reconnecting; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_account_reconnecting_indicator_with_attempt() {
+        let mut app = make_test_app();
+        app.account_stream_ok = false;
+        app.account_stream_reconnecting = true;
+        app.account_reconnect_attempt = 3;
+        app.market_stream_ok = true;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("reconnecting"),
+            "header should show reconnecting label for account; got: {output:?}"
+        );
+        assert!(
+            output.contains('3'),
+            "header should include attempt count; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_market_offline_after_max_attempts() {
+        let mut app = make_test_app();
+        // Permanent offline: not ok, not reconnecting, but attempt > 0
+        app.market_stream_ok = false;
+        app.market_stream_reconnecting = false;
+        app.market_reconnect_attempt = 5;
+        app.account_stream_ok = true;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("OFFLINE"),
+            "header should show OFFLINE after exhausting reconnect attempts; got: {output:?}"
+        );
+        assert!(
+            !output.contains("reconnecting"),
+            "should not show reconnecting when permanently offline; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_account_offline_after_max_attempts() {
+        let mut app = make_test_app();
+        app.account_stream_ok = false;
+        app.account_stream_reconnecting = false;
+        app.account_reconnect_attempt = 3;
+        app.market_stream_ok = true;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("OFFLINE"),
+            "header should show OFFLINE for account stream; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_both_streams_reconnecting_independently() {
+        let mut app = make_test_app();
+        app.market_stream_ok = false;
+        app.market_stream_reconnecting = true;
+        app.market_reconnect_attempt = 1;
+        app.account_stream_ok = false;
+        app.account_stream_reconnecting = true;
+        app.account_reconnect_attempt = 2;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("MARKET"),
+            "should show MARKET indicator; got: {output:?}"
+        );
+        assert!(
+            output.contains("ACCOUNT"),
+            "should show ACCOUNT indicator; got: {output:?}"
+        );
+        assert!(
+            output.contains("reconnecting"),
+            "should show reconnecting label; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn header_shows_both_streams_offline() {
+        let mut app = make_test_app();
+        app.market_stream_ok = false;
+        app.market_stream_reconnecting = false;
+        app.market_reconnect_attempt = 3;
+        app.account_stream_ok = false;
+        app.account_stream_reconnecting = false;
+        app.account_reconnect_attempt = 3;
+        let output = render_header_to_string(&app);
+        assert!(
+            output.contains("MARKET"),
+            "should show MARKET OFFLINE; got: {output:?}"
+        );
+        assert!(
+            output.contains("ACCOUNT"),
+            "should show ACCOUNT OFFLINE; got: {output:?}"
         );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -77,12 +77,38 @@ pub fn update(app: &mut App, event: Event) {
         }
         Event::StatusMsg(msg) => app.push_status(StatusMessage::persistent(msg)),
         Event::StreamConnected(kind) => match kind {
-            StreamKind::Market => app.market_stream_ok = true,
-            StreamKind::Account => app.account_stream_ok = true,
+            StreamKind::Market => {
+                app.market_stream_ok = true;
+                app.market_stream_reconnecting = false;
+                app.market_reconnect_attempt = 0;
+            }
+            StreamKind::Account => {
+                app.account_stream_ok = true;
+                app.account_stream_reconnecting = false;
+                app.account_reconnect_attempt = 0;
+            }
+        },
+        Event::StreamReconnecting { kind, attempt } => match kind {
+            StreamKind::Market => {
+                app.market_stream_ok = false;
+                app.market_stream_reconnecting = true;
+                app.market_reconnect_attempt = attempt;
+            }
+            StreamKind::Account => {
+                app.account_stream_ok = false;
+                app.account_stream_reconnecting = true;
+                app.account_reconnect_attempt = attempt;
+            }
         },
         Event::StreamDisconnected(kind) => match kind {
-            StreamKind::Market => app.market_stream_ok = false,
-            StreamKind::Account => app.account_stream_ok = false,
+            StreamKind::Market => {
+                app.market_stream_ok = false;
+                app.market_stream_reconnecting = false;
+            }
+            StreamKind::Account => {
+                app.account_stream_ok = false;
+                app.account_stream_reconnecting = false;
+            }
         },
         Event::PortfolioHistoryLoaded(data) => {
             // Convert dollar values → cents (u64) to match equity_history format.
@@ -567,6 +593,121 @@ mod tests {
         update(&mut app, Event::StreamDisconnected(StreamKind::Market));
         assert!(!app.market_stream_ok);
         assert!(app.account_stream_ok);
+    }
+
+    // ── StreamReconnecting ────────────────────────────────────────────────────
+
+    #[test]
+    fn stream_reconnecting_market_sets_reconnecting_state() {
+        let mut app = make_test_app();
+        update(
+            &mut app,
+            Event::StreamReconnecting {
+                kind: StreamKind::Market,
+                attempt: 1,
+            },
+        );
+        assert!(
+            !app.market_stream_ok,
+            "stream should not be ok while reconnecting"
+        );
+        assert!(
+            app.market_stream_reconnecting,
+            "reconnecting flag should be set"
+        );
+        assert_eq!(app.market_reconnect_attempt, 1);
+        // account stream must remain unaffected
+        assert!(!app.account_stream_reconnecting);
+        assert_eq!(app.account_reconnect_attempt, 0);
+    }
+
+    #[test]
+    fn stream_reconnecting_account_sets_reconnecting_state() {
+        let mut app = make_test_app();
+        update(
+            &mut app,
+            Event::StreamReconnecting {
+                kind: StreamKind::Account,
+                attempt: 2,
+            },
+        );
+        assert!(!app.account_stream_ok);
+        assert!(app.account_stream_reconnecting);
+        assert_eq!(app.account_reconnect_attempt, 2);
+        // market stream must remain unaffected
+        assert!(!app.market_stream_reconnecting);
+        assert_eq!(app.market_reconnect_attempt, 0);
+    }
+
+    #[test]
+    fn stream_reconnecting_increments_attempt_counter() {
+        let mut app = make_test_app();
+        for attempt in 1..=3 {
+            update(
+                &mut app,
+                Event::StreamReconnecting {
+                    kind: StreamKind::Market,
+                    attempt,
+                },
+            );
+            assert_eq!(app.market_reconnect_attempt, attempt);
+        }
+    }
+
+    #[test]
+    fn stream_connected_clears_reconnecting_state_for_market() {
+        let mut app = make_test_app();
+        app.market_stream_reconnecting = true;
+        app.market_reconnect_attempt = 3;
+        update(&mut app, Event::StreamConnected(StreamKind::Market));
+        assert!(app.market_stream_ok);
+        assert!(
+            !app.market_stream_reconnecting,
+            "reconnecting flag should be cleared on connect"
+        );
+        assert_eq!(
+            app.market_reconnect_attempt, 0,
+            "attempt counter should reset on connect"
+        );
+    }
+
+    #[test]
+    fn stream_connected_clears_reconnecting_state_for_account() {
+        let mut app = make_test_app();
+        app.account_stream_reconnecting = true;
+        app.account_reconnect_attempt = 5;
+        update(&mut app, Event::StreamConnected(StreamKind::Account));
+        assert!(app.account_stream_ok);
+        assert!(!app.account_stream_reconnecting);
+        assert_eq!(app.account_reconnect_attempt, 0);
+    }
+
+    #[test]
+    fn stream_disconnected_clears_reconnecting_flag_for_market() {
+        let mut app = make_test_app();
+        app.market_stream_ok = true;
+        app.market_stream_reconnecting = true;
+        app.market_reconnect_attempt = 3;
+        update(&mut app, Event::StreamDisconnected(StreamKind::Market));
+        assert!(!app.market_stream_ok);
+        assert!(
+            !app.market_stream_reconnecting,
+            "permanent disconnect should clear reconnecting flag"
+        );
+        // attempt counter is intentionally kept so the UI can show "OFFLINE"
+        assert_eq!(app.market_reconnect_attempt, 3);
+    }
+
+    #[test]
+    fn stream_disconnected_clears_reconnecting_flag_for_account() {
+        let mut app = make_test_app();
+        app.account_stream_ok = true;
+        app.account_stream_reconnecting = true;
+        app.account_reconnect_attempt = 2;
+        update(&mut app, Event::StreamDisconnected(StreamKind::Account));
+        assert!(!app.account_stream_ok);
+        assert!(!app.account_stream_reconnecting);
+        assert_eq!(app.account_reconnect_attempt, 2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #76

## Summary

Differentiates three distinct WebSocket stream states in the dashboard header instead of a single ⚠ badge, so users can tell whether a stream is loading for the first time, actively reconnecting, or permanently offline.

## Changes

- **`src/events.rs`**: Add `StreamReconnecting { kind, attempt }` variant between `StreamConnected` and `StreamDisconnected`; `StreamDisconnected` is now reserved for permanent failure (max attempts exhausted)
- **`src/stream/market.rs`** & **`src/stream/account.rs`**: Emit `StreamReconnecting` during each back-off cycle; keep `StreamDisconnected` only for permanent give-up
- **`src/app.rs`**: Add `market_stream_reconnecting`, `account_stream_reconnecting` (bool) and `market_reconnect_attempt`, `account_reconnect_attempt` (u32) fields
- **`src/update.rs`**: Handle `StreamReconnecting` (set flag + attempt); clear reconnecting on `StreamConnected`; clear reconnecting flag on `StreamDisconnected`
- **`src/ui/dashboard.rs`**: Rework header to show per-stream 3-state indicator:
  - Initial loading → `⚠ MARKET` / `⚠ ACCOUNT` (neutral, attempt=0)
  - Reconnecting → `⟳ MARKET reconnecting… (N)` (neutral/yellow)
  - Permanently offline → `✗ MARKET OFFLINE` (negative/red, attempt>0)

## Testing

- Updated 2 stream integration tests (market + account) to assert `StreamReconnecting` on first server close
- Added 8 new `update.rs` unit tests covering all new event arms and state transitions
- Added 8 new `dashboard.rs` render tests covering all header label variants
- 715 tests total, all passing; `cargo clippy --all-targets -- -D warnings` clean