### PR TITLE
fix(credentials): read .env in debug builds only, release uses OS keychain exclusively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
 serde             = { version = "1",    features = ["derive"] }
 serde_json        = "1"
 toml              = "1.1"
-dotenvy           = { version = "0.15", optional = true }
+dotenvy           = "0.15"
 anyhow            = "1"
 chrono            = { version = "0.4",  features = ["serde"] }
 futures           = "0.3"
@@ -68,10 +68,6 @@ keyring = { version = "3", features = ["linux-native"] }
 
 [target.'cfg(unix)'.dependencies]
 syslog = "7"
-
-[features]
-# Enable .env file loading via dotenvy (debug builds only; not for release).
-dev-env = ["dotenvy"]
 
 [dev-dependencies]
 wiremock   = "0.6"

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -170,8 +170,8 @@ pub fn reset(env: AlpacaEnv) {
     };
 
     // ── Report env var sources ────────────────────────────────────────────────
-    // When the dev-env feature is enabled, dotenvy::dotenv() is called before
-    // reset() in main, so vars from .env files are already in the environment.
+    // In debug builds, dotenvy::dotenv() is called before reset() in main, so
+    // vars from .env files are already in the environment at this point.
     let has_unified = std::env::var("ALPACA_API_KEY")
         .ok()
         .filter(|s| !s.is_empty())

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,8 @@ use update::update;
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    #[cfg(feature = "dev-env")]
+    // Load .env in debug builds only; release builds rely solely on the OS keychain.
+    #[cfg(debug_assertions)]
     dotenvy::dotenv().ok();
 
     // ── --reset: delete keychain credentials and exit ──────────────────────────


### PR DESCRIPTION
## Problem

The previous `chore(deps)` commit gated `dotenvy` behind an optional `dev-env` feature flag. This meant a plain `cargo build` (debug mode) **never** loaded `.env` files — you had to explicitly pass `--features dev-env`. That is the wrong behaviour: developers expect `.env` to work transparently in local builds without extra flags.

## Fix

Replace `#[cfg(feature = "dev-env")]` with `#[cfg(debug_assertions)]`, which Rust sets automatically based on the build profile:

| Command | `debug_assertions` | `.env` loaded? | Credential sources |
|---|---|---|---|
| `cargo build` | `true` | ✅ yes | `.env` → env vars → OS keychain → TTY prompt |
| `cargo build --release` | `false` | ❌ no | env vars → OS keychain → TTY prompt |

Also removes the now-unnecessary `[features]` table and promotes `dotenvy` back to a regular dependency — no explicit flag required for debug workflows.

## Changes

- `Cargo.toml` — `dotenvy` is a regular dependency again; `[features]` table and `dev-env` entry removed
- `src/main.rs` — `#[cfg(feature = "dev-env")]` → `#[cfg(debug_assertions)]`
- `src/credentials.rs` — comment updated to reflect debug-build behaviour

## Test plan

- [x] `cargo build` compiles and loads `.env` at runtime (debug)
- [x] `cargo build --release` compiles without loading `.env`
- [x] All 969 tests pass