### PR TITLE
feat(prefs): configurable chart marker style (braille/dot/block/bar/half-block)

### DIFF
--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -542,10 +542,7 @@ fill_notifications_enabled = false
     #[test]
     fn chart_marker_to_ratatui_maps_all_variants() {
         use ratatui::symbols;
-        assert_eq!(
-            ChartMarker::Braille.to_ratatui(),
-            symbols::Marker::Braille
-        );
+        assert_eq!(ChartMarker::Braille.to_ratatui(), symbols::Marker::Braille);
         assert_eq!(ChartMarker::Dot.to_ratatui(), symbols::Marker::Dot);
         assert_eq!(ChartMarker::Block.to_ratatui(), symbols::Marker::Block);
         assert_eq!(ChartMarker::Bar.to_ratatui(), symbols::Marker::Bar);
@@ -591,7 +588,11 @@ chart_marker = "dot"
     fn chart_marker_invalid_value_falls_back_to_defaults() {
         let f = write_toml("[ui]\nchart_marker = \"invalid_value\"\n");
         let p = AppPrefs::load_from(f.path());
-        assert_eq!(p, AppPrefs::default(), "invalid chart_marker should fall back to defaults");
+        assert_eq!(
+            p,
+            AppPrefs::default(),
+            "invalid chart_marker should fall back to defaults"
+        );
     }
 
     #[test]

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -14,7 +14,54 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use ratatui::symbols;
 use serde::{Deserialize, Serialize};
+
+// ── Chart marker ──────────────────────────────────────────────────────────────
+
+/// Chart dataset marker style.
+///
+/// Controls the glyph used to draw line and scatter chart datasets.
+/// Corresponds 1:1 to [`ratatui::symbols::Marker`].
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChartMarker {
+    /// High-resolution braille dots (requires UTF-8 + braille font).
+    #[default]
+    Braille,
+    /// Simple dot (`·`); works on all terminals.
+    Dot,
+    /// Solid block (`█`).
+    Block,
+    /// Vertical bar (`|`).
+    Bar,
+    /// Half-block (`▄`); medium resolution, wide support.
+    HalfBlock,
+}
+
+impl ChartMarker {
+    /// Converts to the corresponding [`ratatui::symbols::Marker`] variant.
+    pub fn to_ratatui(self) -> symbols::Marker {
+        match self {
+            Self::Braille => symbols::Marker::Braille,
+            Self::Dot => symbols::Marker::Dot,
+            Self::Block => symbols::Marker::Block,
+            Self::Bar => symbols::Marker::Bar,
+            Self::HalfBlock => symbols::Marker::HalfBlock,
+        }
+    }
+
+    /// Returns the snake_case TOML string representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Braille => "braille",
+            Self::Dot => "dot",
+            Self::Block => "block",
+            Self::Bar => "bar",
+            Self::HalfBlock => "half_block",
+        }
+    }
+}
 
 // ── Sub-sections ──────────────────────────────────────────────────────────────
 
@@ -57,6 +104,9 @@ pub struct UiSection {
     /// `"1D"` | `"1W"` | `"1M"` | `"YTD"`.  Range-picker UI is tracked in
     /// issue #77.
     pub default_equity_range: String,
+    /// Marker style used for all chart datasets.  Accepted values:
+    /// `"braille"` | `"dot"` | `"block"` | `"bar"` | `"half_block"`.
+    pub chart_marker: ChartMarker,
 }
 
 impl Default for UiSection {
@@ -68,6 +118,7 @@ impl Default for UiSection {
             show_positions: true,
             show_orders: true,
             default_equity_range: "1D".into(),
+            chart_marker: ChartMarker::default(),
         }
     }
 }
@@ -264,6 +315,8 @@ show_positions     = {show_positions}
 show_orders        = {show_orders}
 # Default equity chart range. Accepted values: "1D" | "1W" | "1M" | "YTD"
 default_equity_range = "{equity_range}"
+# Chart marker style. Accepted values: "braille" | "dot" | "block" | "bar" | "half_block"
+chart_marker = "{chart_marker}"
 
 [stream]
 # Max reconnect attempts (0 = unlimited)
@@ -294,6 +347,7 @@ confirm_watchlist_remove = {confirm_remove}
             show_positions = self.ui.show_positions,
             show_orders = self.ui.show_orders,
             equity_range = self.ui.default_equity_range,
+            chart_marker = self.ui.chart_marker.as_str(),
             reconnect_max = self.stream.reconnect_max_attempts,
             reconnect_base = self.stream.reconnect_backoff_base_ms,
             fill_enabled = self.notifications.fill_notifications_enabled,
@@ -463,6 +517,97 @@ fill_notifications_enabled = false
             AppPrefs::default(),
             "unreadable file should yield defaults"
         );
+    }
+
+    #[test]
+    fn default_chart_marker_is_braille() {
+        let p = AppPrefs::default();
+        assert_eq!(p.ui.chart_marker, ChartMarker::Braille);
+    }
+
+    #[test]
+    fn chart_marker_as_str_round_trips() {
+        let cases = [
+            (ChartMarker::Braille, "braille"),
+            (ChartMarker::Dot, "dot"),
+            (ChartMarker::Block, "block"),
+            (ChartMarker::Bar, "bar"),
+            (ChartMarker::HalfBlock, "half_block"),
+        ];
+        for (variant, expected) in cases {
+            assert_eq!(variant.as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn chart_marker_to_ratatui_maps_all_variants() {
+        use ratatui::symbols;
+        assert_eq!(
+            ChartMarker::Braille.to_ratatui(),
+            symbols::Marker::Braille
+        );
+        assert_eq!(ChartMarker::Dot.to_ratatui(), symbols::Marker::Dot);
+        assert_eq!(ChartMarker::Block.to_ratatui(), symbols::Marker::Block);
+        assert_eq!(ChartMarker::Bar.to_ratatui(), symbols::Marker::Bar);
+        assert_eq!(
+            ChartMarker::HalfBlock.to_ratatui(),
+            symbols::Marker::HalfBlock
+        );
+    }
+
+    #[test]
+    fn chart_marker_parses_from_toml() {
+        let f = write_toml(
+            r#"
+[ui]
+chart_marker = "dot"
+"#,
+        );
+        let p = AppPrefs::load_from(f.path());
+        assert_eq!(p.ui.chart_marker, ChartMarker::Dot);
+    }
+
+    #[test]
+    fn chart_marker_all_variants_parse_from_toml() {
+        let cases = [
+            ("braille", ChartMarker::Braille),
+            ("dot", ChartMarker::Dot),
+            ("block", ChartMarker::Block),
+            ("bar", ChartMarker::Bar),
+            ("half_block", ChartMarker::HalfBlock),
+        ];
+        for (toml_val, expected) in cases {
+            let content = format!("[ui]\nchart_marker = \"{toml_val}\"\n");
+            let f = write_toml(&content);
+            let p = AppPrefs::load_from(f.path());
+            assert_eq!(
+                p.ui.chart_marker, expected,
+                "chart_marker = {toml_val:?} should parse to {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn chart_marker_invalid_value_falls_back_to_defaults() {
+        let f = write_toml("[ui]\nchart_marker = \"invalid_value\"\n");
+        let p = AppPrefs::load_from(f.path());
+        assert_eq!(p, AppPrefs::default(), "invalid chart_marker should fall back to defaults");
+    }
+
+    #[test]
+    fn chart_marker_missing_falls_back_to_braille() {
+        let f = write_toml("[ui]\ntheme = \"dark\"\n");
+        let p = AppPrefs::load_from(f.path());
+        assert_eq!(p.ui.chart_marker, ChartMarker::Braille);
+    }
+
+    #[test]
+    fn chart_marker_round_trips_through_toml_string() {
+        let mut p = AppPrefs::default();
+        p.ui.chart_marker = ChartMarker::HalfBlock;
+        let toml_str = p.to_toml_string();
+        let p2: AppPrefs = toml::from_str(&toml_str).unwrap();
+        assert_eq!(p2.ui.chart_marker, ChartMarker::HalfBlock);
     }
 
     #[test]

--- a/src/ui/account.rs
+++ b/src/ui/account.rs
@@ -1,7 +1,6 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout, Position as TermPos, Rect},
     style::Style,
-    symbols,
     text::{Line, Span},
     widgets::{Axis, Block, Borders, Chart, Clear, Dataset, GraphType, Paragraph},
     Frame,
@@ -143,7 +142,7 @@ fn render_equity_chart(frame: &mut Frame, area: Rect, app: &App) {
     let line_color = charts::trend_color(&data_points, &c);
 
     let dataset = Dataset::default()
-        .marker(symbols::Marker::Braille)
+        .marker(app.prefs.ui.chart_marker.to_ratatui())
         .graph_type(GraphType::Line)
         .style(Style::default().fg(line_color))
         .data(&data_points);

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1,7 +1,6 @@
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
-    symbols,
     text::{Line, Span},
     widgets::{
         Axis, Block, BorderType, Borders, Cell, Chart, Clear, Dataset, GraphType, Paragraph, Row,
@@ -833,8 +832,9 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
             let [y_min, y_max] = charts::y_bounds(&data_points);
             let line_color = charts::trend_color(&data_points, &c);
 
+            let marker = app.prefs.ui.chart_marker.to_ratatui();
             let dataset = Dataset::default()
-                .marker(symbols::Marker::Braille)
+                .marker(marker)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(line_color))
                 .data(&data_points);
@@ -853,7 +853,7 @@ fn render_symbol_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App) 
                         .collect();
                     datasets.push(
                         Dataset::default()
-                            .marker(symbols::Marker::Braille)
+                            .marker(marker)
                             .graph_type(GraphType::Scatter)
                             .style(Style::default().fg(c.accent))
                             .data(&crosshair_pts),
@@ -1342,7 +1342,7 @@ fn render_position_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App
             let line_color = charts::trend_color(&data_points, &c);
 
             let dataset = Dataset::default()
-                .marker(symbols::Marker::Braille)
+                .marker(app.prefs.ui.chart_marker.to_ratatui())
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(line_color))
                 .data(&data_points);


### PR DESCRIPTION
## Summary

- Adds a `ChartMarker` enum (`braille`, `dot`, `block`, `bar`, `half_block`) to `src/prefs.rs` with `braille` as the default
- Introduces a `chart_marker` key in the `[ui]` section of `config.toml`, persisted via `AppPrefs` save/load
- Replaces all four hardcoded `Marker::Braille` dataset calls in `src/ui/account.rs` and `src/ui/modals.rs` with `app.prefs.ui.chart_marker.to_ratatui()`

## Test plan

- [x] `chart_marker_default_is_braille` — default value is `ChartMarker::Braille`
- [x] `chart_marker_as_str_round_trips` — `as_str()` returns correct snake_case for all 5 variants
- [x] `chart_marker_to_ratatui_maps_all_variants` — each variant maps to the correct `ratatui::symbols::Marker`
- [x] `chart_marker_parses_from_toml` — TOML key parses correctly
- [x] `chart_marker_all_variants_parse_from_toml` — all 5 values parse from TOML
- [x] `chart_marker_invalid_value_falls_back_to_defaults` — bad value falls back to defaults without panic
- [x] `chart_marker_missing_falls_back_to_braille` — missing key defaults to `Braille`
- [x] `chart_marker_round_trips_through_toml_string` — `to_toml_string()` serializes and re-parses correctly
- [x] All 1077 existing tests continue to pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)