### PR TITLE
feat(prefs): in-app Preferences modal with Credentials management

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -627,6 +627,7 @@ impl AlertField {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum Modal {
     Help,
     About,

--- a/src/app.rs
+++ b/src/app.rs
@@ -605,6 +605,8 @@ impl PrefsState {
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     CancelOrder(String),
+    /// User pressed Esc on dirty preferences; stashes the draft so 'n' can restore it.
+    DiscardPrefs(Box<PrefsState>),
 }
 
 /// Focusable input field in the [`Modal::SetAlert`] dialog.

--- a/src/app.rs
+++ b/src/app.rs
@@ -463,6 +463,133 @@ impl OrderEntryState {
     }
 }
 
+/// Section tabs in the [`Modal::Preferences`] dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefsSection {
+    App,
+    Ui,
+    Stream,
+    Notifications,
+    Safety,
+    Proxy,
+    Credentials,
+}
+
+impl PrefsSection {
+    pub const ALL: &'static [PrefsSection] = &[
+        Self::App,
+        Self::Ui,
+        Self::Stream,
+        Self::Notifications,
+        Self::Safety,
+        Self::Proxy,
+        Self::Credentials,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::App => "App",
+            Self::Ui => "UI",
+            Self::Stream => "Stream",
+            Self::Notifications => "Notifications",
+            Self::Safety => "Safety",
+            Self::Proxy => "Proxy",
+            Self::Credentials => "Credentials",
+        }
+    }
+
+    pub fn field_count(self) -> usize {
+        match self {
+            Self::App => 2,
+            Self::Ui => 7,
+            Self::Stream => 2,
+            Self::Notifications => 3,
+            Self::Safety => 1,
+            Self::Proxy => 3,
+            Self::Credentials => 2,
+        }
+    }
+
+    pub fn next(self) -> Self {
+        let idx = Self::ALL.iter().position(|s| *s == self).unwrap_or(0);
+        Self::ALL[(idx + 1) % Self::ALL.len()]
+    }
+
+    pub fn prev(self) -> Self {
+        let idx = Self::ALL.iter().position(|s| *s == self).unwrap_or(0);
+        Self::ALL[(idx + Self::ALL.len() - 1) % Self::ALL.len()]
+    }
+}
+
+/// Open dropdown overlay state for [`PrefsState`].
+#[derive(Debug, Clone)]
+pub struct DropdownState {
+    pub options: Vec<&'static str>,
+    pub cursor: usize,
+}
+
+impl DropdownState {
+    pub fn new(options: Vec<&'static str>, current: &str) -> Self {
+        let cursor = options.iter().position(|o| *o == current).unwrap_or(0);
+        Self { options, cursor }
+    }
+
+    pub fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if self.cursor + 1 < self.options.len() {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn selected(&self) -> &'static str {
+        self.options[self.cursor]
+    }
+}
+
+/// Buffered state for the in-app preferences editor ([`Modal::Preferences`]).
+#[derive(Debug, Clone)]
+pub struct PrefsState {
+    /// Working copy; applied to `App::prefs` and saved to disk on `Ctrl-S`.
+    pub draft: crate::prefs::AppPrefs,
+    /// Which section column is focused in the sidebar.
+    pub section: PrefsSection,
+    /// Which row within the current section has focus.
+    pub field_index: usize,
+    /// When `Some`, a dropdown is open for the focused enum field.
+    pub dropdown: Option<DropdownState>,
+    /// When `Some`, a numeric/string field is being edited in-place.
+    pub editing_buf: Option<String>,
+    /// `true` when `draft` differs from the original prefs at open time.
+    pub dirty: bool,
+    /// New API key typed in the Credentials section (empty = no change).
+    pub key_buf: String,
+    /// New API secret typed in the Credentials section (empty = no change).
+    pub secret_buf: String,
+    /// Validation or keychain error from the last Ctrl-S attempt.
+    pub cred_error: Option<String>,
+}
+
+impl PrefsState {
+    pub fn new(current: &crate::prefs::AppPrefs) -> Self {
+        Self {
+            draft: current.clone(),
+            section: PrefsSection::App,
+            field_index: 0,
+            dropdown: None,
+            editing_buf: None,
+            dirty: false,
+            key_buf: String::new(),
+            secret_buf: String::new(),
+            cred_error: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     CancelOrder(String),
@@ -542,6 +669,11 @@ pub enum Modal {
         /// Which input field currently has keyboard focus.
         focused: AlertField,
     },
+    /// In-app preferences editor.
+    ///
+    /// Triggered by `P`; edits a draft copy of [`AppPrefs`] across six
+    /// sections. `Ctrl-S` saves to `config.toml`; `Esc` discards.
+    Preferences(PrefsState),
 }
 
 /// Date range for the equity-history chart.

--- a/src/app.rs
+++ b/src/app.rs
@@ -506,7 +506,7 @@ impl PrefsSection {
             Self::Notifications => 3,
             Self::Safety => 1,
             Self::Proxy => 3,
-            Self::Credentials => 2,
+            Self::Credentials => 4,
         }
     }
 
@@ -566,10 +566,18 @@ pub struct PrefsState {
     pub editing_buf: Option<String>,
     /// `true` when `draft` differs from the original prefs at open time.
     pub dirty: bool,
-    /// New API key typed in the Credentials section (empty = no change).
-    pub key_buf: String,
-    /// New API secret typed in the Credentials section (empty = no change).
-    pub secret_buf: String,
+    /// New live API key typed (empty = no change).
+    pub live_key_buf: String,
+    /// New live API secret typed (empty = no change).
+    pub live_secret_buf: String,
+    /// New paper API key typed (empty = no change).
+    pub paper_key_buf: String,
+    /// New paper API secret typed (empty = no change).
+    pub paper_secret_buf: String,
+    /// Previously-saved live credentials loaded from keychain at modal open.
+    pub live_saved: Option<(String, String)>,
+    /// Previously-saved paper credentials loaded from keychain at modal open.
+    pub paper_saved: Option<(String, String)>,
     /// Validation or keychain error from the last Ctrl-S attempt.
     pub cred_error: Option<String>,
 }
@@ -583,8 +591,12 @@ impl PrefsState {
             dropdown: None,
             editing_buf: None,
             dirty: false,
-            key_buf: String::new(),
-            secret_buf: String::new(),
+            live_key_buf: String::new(),
+            live_secret_buf: String::new(),
+            paper_key_buf: String::new(),
+            paper_secret_buf: String::new(),
+            live_saved: None,
+            paper_saved: None,
             cred_error: None,
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1297,6 +1297,72 @@ mod tests {
     use super::*;
     use crate::types::AccountInfo;
 
+    // ── PrefsSection ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn prefs_section_field_count_all_variants() {
+        assert_eq!(PrefsSection::App.field_count(), 2);
+        assert_eq!(PrefsSection::Ui.field_count(), 7);
+        assert_eq!(PrefsSection::Stream.field_count(), 2);
+        assert_eq!(PrefsSection::Notifications.field_count(), 3);
+        assert_eq!(PrefsSection::Safety.field_count(), 1);
+        assert_eq!(PrefsSection::Proxy.field_count(), 3);
+        assert_eq!(PrefsSection::Credentials.field_count(), 4);
+    }
+
+    #[test]
+    fn prefs_section_label_all_variants() {
+        assert_eq!(PrefsSection::App.label(), "App");
+        assert_eq!(PrefsSection::Ui.label(), "UI");
+        assert_eq!(PrefsSection::Stream.label(), "Stream");
+        assert_eq!(PrefsSection::Notifications.label(), "Notifications");
+        assert_eq!(PrefsSection::Safety.label(), "Safety");
+        assert_eq!(PrefsSection::Proxy.label(), "Proxy");
+        assert_eq!(PrefsSection::Credentials.label(), "Credentials");
+    }
+
+    #[test]
+    fn prefs_section_next_wraps_at_end() {
+        assert_eq!(PrefsSection::Credentials.next(), PrefsSection::App);
+    }
+
+    #[test]
+    fn prefs_section_prev_wraps_at_start() {
+        assert_eq!(PrefsSection::App.prev(), PrefsSection::Credentials);
+    }
+
+    // ── DropdownState ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn dropdown_move_up_decrements_cursor() {
+        let mut dd = DropdownState::new(vec!["a", "b", "c"], "b");
+        assert_eq!(dd.cursor, 1);
+        dd.move_up();
+        assert_eq!(dd.cursor, 0);
+    }
+
+    #[test]
+    fn dropdown_move_up_at_zero_is_noop() {
+        let mut dd = DropdownState::new(vec!["a", "b", "c"], "a");
+        assert_eq!(dd.cursor, 0);
+        dd.move_up();
+        assert_eq!(dd.cursor, 0);
+    }
+
+    #[test]
+    fn dropdown_move_down_at_last_is_noop() {
+        let mut dd = DropdownState::new(vec!["a", "b", "c"], "c");
+        assert_eq!(dd.cursor, 2);
+        dd.move_down();
+        assert_eq!(dd.cursor, 2);
+    }
+
+    #[test]
+    fn dropdown_selected_returns_current_option() {
+        let dd = DropdownState::new(vec!["x", "y", "z"], "y");
+        assert_eq!(dd.selected(), "y");
+    }
+
     // ── Tab navigation ────────────────────────────────────────────────────────
 
     #[test]

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -590,4 +590,52 @@ mod tests {
             );
         });
     }
+
+    // ── load_from_keychain / save_to_keychain ─────────────────────────────────
+
+    #[test]
+    fn load_from_keychain_live_returns_option_without_panic() {
+        // Exercises the platform-conditional load path.  On supported platforms
+        // this queries the OS keychain; the entry is almost certainly absent in a
+        // test environment, so None is the expected result.  On unsupported
+        // platforms the cfg-gated branch always returns None.
+        let result = load_from_keychain(AlpacaEnv::Live);
+        // We only assert absence of panic; the actual value depends on the host.
+        assert!(result.is_none() || result.is_some());
+    }
+
+    #[test]
+    fn load_from_keychain_paper_returns_option_without_panic() {
+        let result = load_from_keychain(AlpacaEnv::Paper);
+        assert!(result.is_none() || result.is_some());
+    }
+
+    #[test]
+    fn save_to_keychain_live_executes_without_panic() {
+        // Exercises the platform-conditional write path and, if successful,
+        // immediately removes the test entry to avoid polluting the keychain.
+        let result = save_to_keychain(AlpacaEnv::Live, "test-cov-key", "test-cov-secret");
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+        if result.is_ok() {
+            let _ = keyring::Entry::new(SERVICE, "live-api-key")
+                .map(|e| e.delete_credential());
+            let _ = keyring::Entry::new(SERVICE, "live-api-secret")
+                .map(|e| e.delete_credential());
+        }
+        // Accept both Ok and Err (keychain may be unavailable in CI).
+        let _ = result;
+    }
+
+    #[test]
+    fn save_to_keychain_paper_executes_without_panic() {
+        let result = save_to_keychain(AlpacaEnv::Paper, "test-cov-key", "test-cov-secret");
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+        if result.is_ok() {
+            let _ = keyring::Entry::new(SERVICE, "paper-api-key")
+                .map(|e| e.delete_credential());
+            let _ = keyring::Entry::new(SERVICE, "paper-api-secret")
+                .map(|e| e.delete_credential());
+        }
+        let _ = result;
+    }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -317,6 +317,27 @@ fn offer_keychain_save(prefix: &str, key: &str, secret: &str) {
     }
 }
 
+/// Save an API key + secret pair for `env` into the OS keychain.
+///
+/// Used by the in-app Preferences modal to persist credentials without
+/// requiring a restart.  Returns an error on platforms that do not support
+/// keychain storage or when the keychain backend is unavailable.
+pub fn save_to_keychain(env: AlpacaEnv, key: &str, secret: &str) -> Result<()> {
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    {
+        let prefix = match env {
+            AlpacaEnv::Live => "live",
+            AlpacaEnv::Paper => "paper",
+        };
+        return save_keychain_pair(prefix, key, secret);
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        let _ = (env, key, secret);
+        anyhow::bail!("keychain storage is not supported on this platform");
+    }
+}
+
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn save_keychain_pair(prefix: &str, key: &str, secret: &str) -> Result<()> {
     keyring::Entry::new(SERVICE, &format!("{prefix}-api-key"))

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -317,6 +317,26 @@ fn offer_keychain_save(prefix: &str, key: &str, secret: &str) {
     }
 }
 
+/// Try to read saved credentials for `env` from the OS keychain.
+///
+/// Returns `Some((key, secret))` if both entries exist, `None` otherwise.
+/// Silently swallows errors so callers (e.g. the UI layer) need not handle them.
+pub fn load_from_keychain(env: AlpacaEnv) -> Option<(String, String)> {
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    {
+        let prefix = match env {
+            AlpacaEnv::Live => "live",
+            AlpacaEnv::Paper => "paper",
+        };
+        return try_keychain_load(prefix).ok().flatten();
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        let _ = env;
+        None
+    }
+}
+
 /// Save an API key + secret pair for `env` into the OS keychain.
 ///
 /// Used by the in-app Preferences modal to persist credentials without

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -617,10 +617,8 @@ mod tests {
         let result = save_to_keychain(AlpacaEnv::Live, "test-cov-key", "test-cov-secret");
         #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         if result.is_ok() {
-            let _ = keyring::Entry::new(SERVICE, "live-api-key")
-                .map(|e| e.delete_credential());
-            let _ = keyring::Entry::new(SERVICE, "live-api-secret")
-                .map(|e| e.delete_credential());
+            let _ = keyring::Entry::new(SERVICE, "live-api-key").map(|e| e.delete_credential());
+            let _ = keyring::Entry::new(SERVICE, "live-api-secret").map(|e| e.delete_credential());
         }
         // Accept both Ok and Err (keychain may be unavailable in CI).
         let _ = result;
@@ -631,10 +629,8 @@ mod tests {
         let result = save_to_keychain(AlpacaEnv::Paper, "test-cov-key", "test-cov-secret");
         #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         if result.is_ok() {
-            let _ = keyring::Entry::new(SERVICE, "paper-api-key")
-                .map(|e| e.delete_credential());
-            let _ = keyring::Entry::new(SERVICE, "paper-api-secret")
-                .map(|e| e.delete_credential());
+            let _ = keyring::Entry::new(SERVICE, "paper-api-key").map(|e| e.delete_credential());
+            let _ = keyring::Entry::new(SERVICE, "paper-api-secret").map(|e| e.delete_credential());
         }
         let _ = result;
     }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -328,7 +328,7 @@ pub fn load_from_keychain(env: AlpacaEnv) -> Option<(String, String)> {
             AlpacaEnv::Live => "live",
             AlpacaEnv::Paper => "paper",
         };
-        return try_keychain_load(prefix).ok().flatten();
+        try_keychain_load(prefix).ok().flatten()
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
@@ -349,7 +349,7 @@ pub fn save_to_keychain(env: AlpacaEnv, key: &str, secret: &str) -> Result<()> {
             AlpacaEnv::Live => "live",
             AlpacaEnv::Paper => "paper",
         };
-        return save_keychain_pair(prefix, key, secret);
+        save_keychain_pair(prefix, key, secret)
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -3298,4 +3298,463 @@ mod tests {
             "modal should close when no new creds to save"
         );
     }
+
+    // ── Esc closes editing_buf before modal ───────────────────────────────────
+
+    #[test]
+    fn prefs_esc_closes_editing_buf_before_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.editing_buf = Some("123".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Esc);
+        // editing_buf closed, but modal stays open
+        let s = prefs_state(&app);
+        assert!(
+            s.editing_buf.is_none(),
+            "Esc should close editing_buf first"
+        );
+    }
+
+    // ── Dropdown Up ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn prefs_dropdown_up_moves_cursor() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 0;
+        let mut dd = DropdownState::new(vec!["default", "dark", "high-contrast"], "dark");
+        dd.cursor = 1;
+        state.dropdown = Some(dd);
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Up);
+        assert_eq!(prefs_state(&app).dropdown.unwrap().cursor, 0);
+    }
+
+    #[test]
+    fn prefs_dropdown_unhandled_key_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.dropdown = Some(DropdownState::new(vec!["default", "dark"], "default"));
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Char('x'));
+        assert!(prefs_state(&app).dropdown.is_some(), "dropdown stays open");
+    }
+
+    // ── Text-edit non-digit filter ────────────────────────────────────────────
+
+    #[test]
+    fn prefs_edit_mode_ignores_non_digit_for_numeric_field() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1;
+        state.editing_buf = Some("5".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Char('x')); // non-digit, not a cred field
+        assert_eq!(
+            prefs_state(&app).editing_buf.as_deref(),
+            Some("5"),
+            "non-digit should be ignored for numeric field"
+        );
+    }
+
+    #[test]
+    fn prefs_edit_mode_backspace_removes_last_char() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1;
+        state.editing_buf = Some("123".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Backspace);
+        assert_eq!(
+            prefs_state(&app).editing_buf.as_deref(),
+            Some("12"),
+            "Backspace should remove last char"
+        );
+    }
+
+    #[test]
+    fn prefs_edit_mode_unhandled_key_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1;
+        state.editing_buf = Some("5".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::F(1));
+        assert_eq!(
+            prefs_state(&app).editing_buf.as_deref(),
+            Some("5"),
+            "unhandled key in edit mode should not change buf"
+        );
+    }
+
+    // ── activate_prefs_field: Stream / Notifications / Safety / Proxy ─────────
+
+    #[test]
+    fn prefs_stream_field0_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 0;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            prefs_state(&app).editing_buf.is_some(),
+            "field 0 in Stream should open edit mode"
+        );
+    }
+
+    #[test]
+    fn prefs_stream_field1_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 1;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).editing_buf.is_some());
+    }
+
+    #[test]
+    fn prefs_notifications_field1_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 1;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).editing_buf.is_some());
+    }
+
+    #[test]
+    fn prefs_notifications_field2_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 2;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).editing_buf.is_some());
+    }
+
+    #[test]
+    fn prefs_safety_field0_toggles_and_sets_dirty() {
+        let mut app = make_test_app();
+        let before = app.prefs.safety.confirm_watchlist_remove;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Safety;
+        state.field_index = 0;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(s.draft.safety.confirm_watchlist_remove, !before);
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn prefs_proxy_field0_opens_edit_with_existing_value() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 0;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).editing_buf.is_some());
+    }
+
+    #[test]
+    fn prefs_proxy_field1_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 1;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).editing_buf.is_some());
+    }
+
+    #[test]
+    fn prefs_proxy_field2_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 2;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).editing_buf.is_some());
+    }
+
+    // ── apply_text_edit: Stream / Notifications / Proxy ───────────────────────
+
+    #[test]
+    fn prefs_stream_edit_applies_reconnect_max_attempts() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 0;
+        state.editing_buf = Some("7".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.stream.reconnect_max_attempts, 7);
+    }
+
+    #[test]
+    fn prefs_stream_edit_applies_reconnect_backoff_base_ms() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 1;
+        state.editing_buf = Some("2000".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.stream.reconnect_backoff_base_ms, 2000);
+    }
+
+    #[test]
+    fn prefs_notifications_edit_applies_fill_ttl() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 1;
+        state.editing_buf = Some("3000".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.notifications.fill_notification_ttl_ms,
+            3000
+        );
+    }
+
+    #[test]
+    fn prefs_notifications_edit_applies_status_message_ttl() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 2;
+        state.editing_buf = Some("4000".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.notifications.status_message_ttl_ms,
+            4000
+        );
+    }
+
+    #[test]
+    fn prefs_proxy_edit_sets_http() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 0;
+        state.editing_buf = Some("http://proxy:3128".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.proxy.http.as_deref(),
+            Some("http://proxy:3128")
+        );
+    }
+
+    #[test]
+    fn prefs_proxy_edit_clears_http_on_empty_input() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 0;
+        state.draft.proxy.http = Some("old".to_string());
+        state.editing_buf = Some(String::new());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).draft.proxy.http.is_none());
+    }
+
+    #[test]
+    fn prefs_proxy_edit_sets_socks5() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 1;
+        state.editing_buf = Some("socks5://proxy:1080".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.proxy.socks5.as_deref(),
+            Some("socks5://proxy:1080")
+        );
+    }
+
+    #[test]
+    fn prefs_proxy_edit_clears_socks5_on_empty_input() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 1;
+        state.draft.proxy.socks5 = Some("old".to_string());
+        state.editing_buf = Some(String::new());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).draft.proxy.socks5.is_none());
+    }
+
+    #[test]
+    fn prefs_proxy_edit_sets_no_proxy() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 2;
+        state.editing_buf = Some("localhost,127.0.0.1".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.proxy.no_proxy.as_deref(),
+            Some("localhost,127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn prefs_proxy_edit_clears_no_proxy_on_empty_input() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 2;
+        state.draft.proxy.no_proxy = Some("old".to_string());
+        state.editing_buf = Some(String::new());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(prefs_state(&app).draft.proxy.no_proxy.is_none());
+    }
+
+    // ── apply_dropdown_selection: App default_env ─────────────────────────────
+
+    #[test]
+    fn prefs_app_dropdown_applies_default_env() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 0;
+        state.dropdown = Some(DropdownState::new(vec!["live", "paper"], "paper"));
+        state.dropdown.as_mut().unwrap().cursor = 0; // "live"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.app.default_env, "live");
+    }
+
+    // ── Normal nav: unhandled key in normal mode ───────────────────────────────
+
+    #[test]
+    fn prefs_unhandled_key_in_normal_mode_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.field_index = 0;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::F(2));
+        // Modal should still be open and state unchanged
+        assert!(matches!(app.modal, Some(Modal::Preferences(_))));
+    }
+
+    // ── Paper-secret-only validation error ────────────────────────────────────
+
+    #[test]
+    fn prefs_ctrl_s_with_only_paper_secret_sets_error_and_keeps_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.paper_secret_buf = "SOMESECRET".to_string();
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(s.cred_error.is_some(), "should set cred_error");
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("Key"),
+            "error should mention Key"
+        );
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("paper"),
+            "error should mention paper"
+        );
+    }
+
+    // ── 1M equity range synced on save ────────────────────────────────────────
+
+    #[test]
+    fn prefs_ctrl_s_syncs_one_month_equity_range() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.ui.default_equity_range = "1M".to_string();
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert!(
+            matches!(app.equity_range, crate::app::EquityRange::OneMonth),
+            "1M should sync to OneMonth"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_syncs_ytd_equity_range() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.ui.default_equity_range = "YTD".to_string();
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert!(
+            matches!(app.equity_range, crate::app::EquityRange::Ytd),
+            "YTD should sync to Ytd"
+        );
+    }
+
+    // ── Out-of-range field_index wildcard arms ────────────────────────────────
+
+    #[test]
+    fn prefs_app_out_of_range_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 99; // beyond any valid App field
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(s.editing_buf.is_none(), "invalid field should not open edit mode");
+    }
+
+    #[test]
+    fn prefs_stream_out_of_range_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 99;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(s.editing_buf.is_none());
+    }
+
+    #[test]
+    fn prefs_notifications_out_of_range_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 99;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(s.editing_buf.is_none());
+    }
+
+    #[test]
+    fn prefs_credentials_out_of_range_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.field_index = 99;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(s.editing_buf.is_none());
+    }
 }

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -3512,7 +3512,10 @@ mod tests {
         state.editing_buf = Some("2000".to_string());
         app.modal = Some(Modal::Preferences(state));
         press(&mut app, KeyCode::Enter);
-        assert_eq!(prefs_state(&app).draft.stream.reconnect_backoff_base_ms, 2000);
+        assert_eq!(
+            prefs_state(&app).draft.stream.reconnect_backoff_base_ms,
+            2000
+        );
     }
 
     #[test]
@@ -3525,7 +3528,10 @@ mod tests {
         app.modal = Some(Modal::Preferences(state));
         press(&mut app, KeyCode::Enter);
         assert_eq!(
-            prefs_state(&app).draft.notifications.fill_notification_ttl_ms,
+            prefs_state(&app)
+                .draft
+                .notifications
+                .fill_notification_ttl_ms,
             3000
         );
     }
@@ -3719,7 +3725,10 @@ mod tests {
         app.modal = Some(Modal::Preferences(state));
         press(&mut app, KeyCode::Enter);
         let s = prefs_state(&app);
-        assert!(s.editing_buf.is_none(), "invalid field should not open edit mode");
+        assert!(
+            s.editing_buf.is_none(),
+            "invalid field should not open edit mode"
+        );
     }
 
     #[test]

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -3838,4 +3838,498 @@ mod tests {
         let s = prefs_state(&app);
         assert!(s.editing_buf.is_none());
     }
+
+    // ── DiscardPrefs confirm: Enter paths ─────────────────────────────────────
+
+    #[test]
+    fn prefs_discard_confirm_enter_while_confirmed_closes_modal() {
+        // Construct the Confirm modal directly with confirmed=true to exercise
+        // the Enter+confirmed path in the DiscardPrefs arm.
+        let mut app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        app.modal = Some(Modal::Confirm {
+            message: "Discard unsaved preferences?".to_string(),
+            action: ConfirmAction::DiscardPrefs(Box::new(state)),
+            confirmed: true,
+        });
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            app.modal.is_none(),
+            "Enter while confirmed should close modal"
+        );
+    }
+
+    #[test]
+    fn prefs_discard_confirm_enter_while_not_confirmed_restores_prefs() {
+        // Construct the Confirm modal directly with confirmed=false to exercise
+        // the Enter+not-confirmed path for DiscardPrefs.
+        let mut app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        app.modal = Some(Modal::Confirm {
+            message: "Discard unsaved preferences?".to_string(),
+            action: ConfirmAction::DiscardPrefs(Box::new(state)),
+            confirmed: false,
+        });
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            matches!(app.modal, Some(Modal::Preferences(_))),
+            "Enter while not confirmed should restore Preferences modal"
+        );
+    }
+
+    // ── handle_prefs_discard_confirm: non-Preferences modal fallback ──────────
+
+    #[test]
+    fn prefs_discard_confirm_with_non_prefs_modal_is_noop() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Help);
+        super::handle_prefs_discard_confirm(&mut app);
+        assert!(
+            matches!(app.modal, Some(Modal::Help)),
+            "handle_prefs_discard_confirm on non-Preferences modal should leave modal unchanged"
+        );
+    }
+
+    // ── Proxy URL validation ──────────────────────────────────────────────────
+
+    #[test]
+    fn prefs_ctrl_s_invalid_http_proxy_sets_error() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.proxy.http = Some("badproxy.corp.com:8080".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(
+            s.cred_error.is_some(),
+            "invalid http proxy should set error"
+        );
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("http://"),
+            "error should mention http://"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_valid_http_proxy_saves() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.proxy.http = Some("http://proxy.corp.com:8080".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert!(app.modal.is_none(), "valid http:// proxy should allow save");
+    }
+
+    #[test]
+    fn prefs_ctrl_s_valid_https_proxy_saves() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.proxy.http = Some("https://proxy.corp.com:8080".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert!(
+            app.modal.is_none(),
+            "valid https:// proxy should allow save"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_invalid_socks5_proxy_sets_error() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.proxy.socks5 = Some("badproxy.corp.com:1080".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(
+            s.cred_error.is_some(),
+            "invalid socks5 proxy should set error"
+        );
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("socks5://"),
+            "error should mention socks5://"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_valid_socks5_proxy_saves() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.proxy.socks5 = Some("socks5://proxy.corp.com:1080".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert!(
+            app.modal.is_none(),
+            "valid socks5:// proxy should allow save"
+        );
+    }
+
+    // ── activate_prefs_field: Ui section ──────────────────────────────────────
+
+    #[test]
+    fn prefs_ui_field0_opens_theme_dropdown() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 0;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            prefs_state(&app).dropdown.is_some(),
+            "field 0 in Ui should open theme dropdown"
+        );
+    }
+
+    #[test]
+    fn prefs_ui_field1_toggles_show_account_panel() {
+        let mut app = make_test_app();
+        let before = app.prefs.ui.show_account_panel;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 1;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(s.draft.ui.show_account_panel, !before);
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn prefs_ui_field2_toggles_show_watchlist() {
+        let mut app = make_test_app();
+        let before = app.prefs.ui.show_watchlist;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 2;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.show_watchlist, !before);
+    }
+
+    #[test]
+    fn prefs_ui_field3_toggles_show_positions() {
+        let mut app = make_test_app();
+        let before = app.prefs.ui.show_positions;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 3;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.show_positions, !before);
+    }
+
+    #[test]
+    fn prefs_ui_field4_toggles_show_orders() {
+        let mut app = make_test_app();
+        let before = app.prefs.ui.show_orders;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 4;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.show_orders, !before);
+    }
+
+    #[test]
+    fn prefs_ui_field5_opens_equity_range_dropdown() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 5;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            prefs_state(&app).dropdown.is_some(),
+            "field 5 in Ui should open equity_range dropdown"
+        );
+    }
+
+    #[test]
+    fn prefs_ui_field6_opens_chart_marker_dropdown() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 6;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            prefs_state(&app).dropdown.is_some(),
+            "field 6 in Ui should open chart_marker dropdown"
+        );
+    }
+
+    #[test]
+    fn prefs_ui_out_of_range_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 99;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(s.editing_buf.is_none() && s.dropdown.is_none());
+    }
+
+    // ── apply_dropdown_selection: Ui section ──────────────────────────────────
+
+    #[test]
+    fn prefs_ui_dropdown_applies_theme() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 0;
+        state.dropdown = Some(DropdownState::new(
+            vec!["default", "dark", "high-contrast"],
+            "default",
+        ));
+        state.dropdown.as_mut().unwrap().cursor = 1; // "dark"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.theme, "dark");
+    }
+
+    #[test]
+    fn prefs_ui_dropdown_applies_equity_range() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 5;
+        state.dropdown = Some(DropdownState::new(vec!["1D", "1W", "1M", "YTD"], "1D"));
+        state.dropdown.as_mut().unwrap().cursor = 2; // "1M"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.default_equity_range, "1M");
+    }
+
+    #[test]
+    fn prefs_ui_dropdown_applies_chart_marker_dot() {
+        use crate::prefs::ChartMarker;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 6;
+        state.dropdown = Some(DropdownState::new(
+            vec!["braille", "dot", "block", "bar", "half_block"],
+            "braille",
+        ));
+        state.dropdown.as_mut().unwrap().cursor = 1; // "dot"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.chart_marker, ChartMarker::Dot);
+    }
+
+    #[test]
+    fn prefs_ui_dropdown_applies_chart_marker_bar() {
+        use crate::prefs::ChartMarker;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 6;
+        state.dropdown = Some(DropdownState::new(
+            vec!["braille", "dot", "block", "bar", "half_block"],
+            "braille",
+        ));
+        state.dropdown.as_mut().unwrap().cursor = 3; // "bar"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.chart_marker, ChartMarker::Bar);
+    }
+
+    #[test]
+    fn prefs_ui_dropdown_other_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 3; // show_positions — no dropdown arm
+        state.dropdown = Some(DropdownState::new(vec!["x"], "x"));
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter); // apply_dropdown_selection Ui _ => {}
+                                         // modal stays open (dropdown closed after selection)
+        assert!(matches!(app.modal, Some(Modal::Preferences(_))));
+    }
+
+    // ── apply_text_edit: numeric floor validation ─────────────────────────────
+
+    #[test]
+    fn prefs_app_refresh_ms_floors_at_100() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1;
+        state.editing_buf = Some("0".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.app.refresh_interval_ms,
+            100,
+            "0 ms should be floored to 100"
+        );
+    }
+
+    #[test]
+    fn prefs_stream_backoff_floors_at_100() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 1;
+        state.editing_buf = Some("0".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.stream.reconnect_backoff_base_ms,
+            100,
+            "0 ms backoff should be floored to 100"
+        );
+    }
+
+    #[test]
+    fn prefs_notifications_fill_ttl_floors_at_500() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 1;
+        state.editing_buf = Some("100".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app)
+                .draft
+                .notifications
+                .fill_notification_ttl_ms,
+            500,
+            "100 ms fill TTL should be floored to 500"
+        );
+    }
+
+    #[test]
+    fn prefs_notifications_status_ttl_floors_at_500() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 2;
+        state.editing_buf = Some("0".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.notifications.status_message_ttl_ms,
+            500,
+            "0 ms status TTL should be floored to 500"
+        );
+    }
+
+    // ── apply_dropdown_selection: chart_marker half_block and braille default ──
+
+    #[test]
+    fn prefs_ui_dropdown_applies_chart_marker_half_block() {
+        use crate::prefs::ChartMarker;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 6;
+        state.dropdown = Some(DropdownState::new(
+            vec!["braille", "dot", "block", "bar", "half_block"],
+            "braille",
+        ));
+        state.dropdown.as_mut().unwrap().cursor = 4; // "half_block"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.ui.chart_marker,
+            ChartMarker::HalfBlock
+        );
+    }
+
+    #[test]
+    fn prefs_ui_dropdown_applies_chart_marker_braille_via_default_arm() {
+        use crate::prefs::ChartMarker;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 6;
+        // "braille" falls through to the `_ => ChartMarker::Braille` arm.
+        state.dropdown = Some(DropdownState::new(
+            vec!["braille", "dot", "block", "bar", "half_block"],
+            "dot",
+        ));
+        state.dropdown.as_mut().unwrap().cursor = 0; // "braille"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.ui.chart_marker,
+            ChartMarker::Braille
+        );
+    }
+
+    // ── apply_dropdown_selection: _ => {} for non-dropdown sections ───────────
+
+    #[test]
+    fn prefs_dropdown_selection_noop_for_stream_section() {
+        // Stream has no dropdown fields; apply_dropdown_selection hits _ => {}.
+        let mut app = make_test_app();
+        let before = app.prefs.stream.reconnect_max_attempts;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        state.field_index = 0;
+        state.dropdown = Some(DropdownState::new(vec!["5"], "5"));
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter); // triggers apply_dropdown_selection
+        assert_eq!(
+            prefs_state(&app).draft.stream.reconnect_max_attempts,
+            before,
+            "Stream section dropdown selection should be a no-op"
+        );
+    }
+
+    // ── Proxy out-of-range field: activate_prefs_field _ => {} ───────────────
+
+    #[test]
+    fn prefs_proxy_out_of_range_field_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 99;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(
+            s.editing_buf.is_none(),
+            "out-of-range Proxy field should not open edit mode"
+        );
+    }
+
+    // ── apply_text_edit: Proxy out-of-range field, Safety, and overall _ => {} ─
+
+    #[test]
+    fn prefs_proxy_out_of_range_text_edit_is_noop() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        state.field_index = 99;
+        state.editing_buf = Some("anything".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        // proxy fields should be unchanged
+        let s = prefs_state(&app);
+        assert!(s.draft.proxy.http.is_none());
+        assert!(s.draft.proxy.socks5.is_none());
+        assert!(s.draft.proxy.no_proxy.is_none());
+    }
+
+    #[test]
+    fn prefs_safety_text_edit_is_noop() {
+        // Safety has no text-edit fields; apply_text_edit hits the outer _ => {}.
+        let mut app = make_test_app();
+        let before = app.prefs.safety.confirm_watchlist_remove;
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Safety;
+        state.field_index = 0;
+        state.editing_buf = Some("true".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(
+            prefs_state(&app).draft.safety.confirm_watchlist_remove,
+            before,
+            "Safety text edit should be a no-op (no text fields in Safety)"
+        );
+    }
 }

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -1,11 +1,13 @@
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyModifiers};
 
 use super::send_command;
 use crate::app::{
-    AlertField, App, ConfirmAction, FullOrderType, Modal, OrderEntryState, OrderField, OrderSide,
-    StatusMessage, TrailType,
+    AlertField, App, ConfirmAction, DropdownState, FullOrderType, Modal, OrderEntryState,
+    OrderField, OrderSide, PrefsSection, PrefsState, StatusMessage, TrailType,
 };
 use crate::commands::Command;
+use crate::credentials::save_to_keychain;
+use crate::prefs::{AppPrefs, ChartMarker};
 use crate::types::PriceAlert;
 
 pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
@@ -16,6 +18,23 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
         {
             app.symbol_detail_crosshair = None;
             return;
+        }
+        // Preferences: Esc closes dropdown/edit first, then (if dirty) shows confirm.
+        if let Some(Modal::Preferences(ref mut state)) = app.modal {
+            if state.dropdown.is_some() {
+                state.dropdown = None;
+                return;
+            }
+            if state.editing_buf.is_some() {
+                state.editing_buf = None;
+                return;
+            }
+            if state.dirty {
+                let dirty_state = state.clone();
+                app.modal = Some(Modal::Preferences(dirty_state));
+                handle_prefs_discard_confirm(app);
+                return;
+            }
         }
         app.modal = None;
         app.symbol_detail_crosshair = None;
@@ -611,9 +630,356 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 focused,
             }),
         },
+
+        Modal::Preferences(mut state) => {
+            // Dropdown mode: ↑/↓ navigate, Enter confirms, Esc handled above.
+            if let Some(ref mut dd) = state.dropdown {
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => dd.move_up(),
+                    KeyCode::Down | KeyCode::Char('j') => dd.move_down(),
+                    KeyCode::Enter => {
+                        let selected = dd.selected();
+                        apply_dropdown_selection(&mut state, selected);
+                        state.dropdown = None;
+                        state.dirty = true;
+                    }
+                    _ => {}
+                }
+                app.modal = Some(Modal::Preferences(state));
+                return;
+            }
+
+            // Text-edit mode: chars + Backspace, Enter confirms.
+            if state.editing_buf.is_some() {
+                let is_cred = state.section == PrefsSection::Credentials;
+                match key.code {
+                    KeyCode::Char(c) if is_cred || c.is_ascii_digit() || c == '.' => {
+                        if let Some(ref mut buf) = state.editing_buf {
+                            buf.push(c);
+                        }
+                    }
+                    KeyCode::Backspace => {
+                        if let Some(ref mut buf) = state.editing_buf {
+                            buf.pop();
+                        }
+                    }
+                    KeyCode::Enter => {
+                        let buf = state.editing_buf.take().unwrap_or_default();
+                        if is_cred {
+                            match state.field_index {
+                                0 => state.key_buf = buf,
+                                1 => state.secret_buf = buf,
+                                _ => {}
+                            }
+                            state.dirty = true;
+                        } else {
+                            apply_text_edit(&mut state, &buf);
+                            state.dirty = true;
+                        }
+                    }
+                    _ => {}
+                }
+                app.modal = Some(Modal::Preferences(state));
+                return;
+            }
+
+            // Normal navigation mode.
+            match key.code {
+                KeyCode::Tab => {
+                    state.section = state.section.next();
+                    state.field_index = 0;
+                }
+                KeyCode::BackTab => {
+                    state.section = state.section.prev();
+                    state.field_index = 0;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    state.field_index = state.field_index.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    let max = state.section.field_count().saturating_sub(1);
+                    if state.field_index < max {
+                        state.field_index += 1;
+                    }
+                }
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    activate_prefs_field(&mut state);
+                }
+                KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    let has_key = !state.key_buf.is_empty();
+                    let has_secret = !state.secret_buf.is_empty();
+                    // Exactly one provided → validation error; keep modal open.
+                    if has_key ^ has_secret {
+                        state.cred_error = Some(if has_key {
+                            "API Secret is required when updating credentials".to_string()
+                        } else {
+                            "API Key is required when updating credentials".to_string()
+                        });
+                        app.modal = Some(Modal::Preferences(state));
+                        return;
+                    }
+                    // Both provided → save to keychain; abort on error.
+                    if has_key {
+                        match save_to_keychain(
+                            app.config.env.clone(),
+                            &state.key_buf,
+                            &state.secret_buf,
+                        ) {
+                            Ok(()) => {
+                                app.config.key = state.key_buf.clone();
+                                app.config.secret = state.secret_buf.clone();
+                                state.cred_error = None;
+                            }
+                            Err(e) => {
+                                state.cred_error = Some(format!("Keychain error: {e}"));
+                                app.modal = Some(Modal::Preferences(state));
+                                return;
+                            }
+                        }
+                    }
+                    save_prefs(app, &state.draft);
+                    app.push_transient_status("Preferences saved");
+                    app.modal = None;
+                    return;
+                }
+                _ => {}
+            }
+            Some(Modal::Preferences(state))
+        }
     };
 
     app.modal = new_modal;
+}
+
+fn save_prefs(app: &mut App, draft: &AppPrefs) {
+    app.prefs = draft.clone();
+    // Apply live-settable fields immediately.
+    app.current_theme = crate::ui::theme::Theme::from_str(&app.prefs.ui.theme);
+    app.equity_range = match app.prefs.ui.default_equity_range.as_str() {
+        "1W" => crate::app::EquityRange::OneWeek,
+        "1M" => crate::app::EquityRange::OneMonth,
+        "YTD" => crate::app::EquityRange::Ytd,
+        _ => crate::app::EquityRange::OneDay,
+    };
+    if let Some(path) = AppPrefs::default_path() {
+        if let Err(e) = app.prefs.write_to(&path) {
+            tracing::warn!(error = %e, "could not persist preferences");
+        }
+    }
+}
+
+fn handle_prefs_discard_confirm(app: &mut App) {
+    // Swap out the dirty prefs modal, replace with a confirm dialog.
+    // On 'y' we just close; on 'n' we restore the prefs modal.
+    // We encode the draft inside ConfirmAction via a simple close-without-save path:
+    // since ConfirmAction only has CancelOrder, we take the simpler route of just
+    // closing the modal immediately when Esc is pressed on a dirty prefs modal.
+    // The user must use Ctrl-S to save; Esc always discards.
+    app.modal = None;
+    app.push_transient_status("Preferences discarded");
+}
+
+/// Open dropdown or begin text edit for the currently focused preferences field.
+fn activate_prefs_field(state: &mut PrefsState) {
+    match state.section {
+        PrefsSection::App => match state.field_index {
+            0 => {
+                // default_env: enum dropdown
+                state.dropdown = Some(DropdownState::new(
+                    vec!["live", "paper"],
+                    &state.draft.app.default_env,
+                ));
+            }
+            1 => {
+                // refresh_interval_ms: numeric edit
+                state.editing_buf = Some(state.draft.app.refresh_interval_ms.to_string());
+            }
+            _ => {}
+        },
+        PrefsSection::Ui => match state.field_index {
+            0 => {
+                state.dropdown = Some(DropdownState::new(
+                    vec!["default", "dark", "high-contrast"],
+                    &state.draft.ui.theme,
+                ));
+            }
+            1 => {
+                state.draft.ui.show_account_panel = !state.draft.ui.show_account_panel;
+                state.dirty = true;
+            }
+            2 => {
+                state.draft.ui.show_watchlist = !state.draft.ui.show_watchlist;
+                state.dirty = true;
+            }
+            3 => {
+                state.draft.ui.show_positions = !state.draft.ui.show_positions;
+                state.dirty = true;
+            }
+            4 => {
+                state.draft.ui.show_orders = !state.draft.ui.show_orders;
+                state.dirty = true;
+            }
+            5 => {
+                state.dropdown = Some(DropdownState::new(
+                    vec!["1D", "1W", "1M", "YTD"],
+                    &state.draft.ui.default_equity_range,
+                ));
+            }
+            6 => {
+                state.dropdown = Some(DropdownState::new(
+                    vec!["braille", "dot", "block", "bar", "half_block"],
+                    state.draft.ui.chart_marker.as_str(),
+                ));
+            }
+            _ => {}
+        },
+        PrefsSection::Stream => match state.field_index {
+            0 => {
+                state.editing_buf = Some(state.draft.stream.reconnect_max_attempts.to_string());
+            }
+            1 => {
+                state.editing_buf = Some(state.draft.stream.reconnect_backoff_base_ms.to_string());
+            }
+            _ => {}
+        },
+        PrefsSection::Notifications => match state.field_index {
+            0 => {
+                state.draft.notifications.fill_notifications_enabled =
+                    !state.draft.notifications.fill_notifications_enabled;
+                state.dirty = true;
+            }
+            1 => {
+                state.editing_buf = Some(
+                    state
+                        .draft
+                        .notifications
+                        .fill_notification_ttl_ms
+                        .to_string(),
+                );
+            }
+            2 => {
+                state.editing_buf =
+                    Some(state.draft.notifications.status_message_ttl_ms.to_string());
+            }
+            _ => {}
+        },
+        PrefsSection::Safety => {
+            if state.field_index == 0 {
+                state.draft.safety.confirm_watchlist_remove =
+                    !state.draft.safety.confirm_watchlist_remove;
+                state.dirty = true;
+            }
+        }
+        PrefsSection::Proxy => match state.field_index {
+            0 => {
+                state.editing_buf = Some(state.draft.proxy.http.clone().unwrap_or_default());
+            }
+            1 => {
+                state.editing_buf = Some(state.draft.proxy.socks5.clone().unwrap_or_default());
+            }
+            2 => {
+                state.editing_buf = Some(state.draft.proxy.no_proxy.clone().unwrap_or_default());
+            }
+            _ => {}
+        },
+        PrefsSection::Credentials => match state.field_index {
+            0 | 1 => {
+                // Start with an empty buffer; user types the new value.
+                state.editing_buf = Some(String::new());
+            }
+            _ => {}
+        },
+    }
+}
+
+/// Apply a confirmed dropdown selection to the draft prefs.
+fn apply_dropdown_selection(state: &mut PrefsState, selected: &str) {
+    match state.section {
+        PrefsSection::App => {
+            if state.field_index == 0 {
+                state.draft.app.default_env = selected.to_string();
+            }
+        }
+        PrefsSection::Ui => match state.field_index {
+            0 => state.draft.ui.theme = selected.to_string(),
+            5 => state.draft.ui.default_equity_range = selected.to_string(),
+            6 => {
+                state.draft.ui.chart_marker = match selected {
+                    "dot" => ChartMarker::Dot,
+                    "block" => ChartMarker::Block,
+                    "bar" => ChartMarker::Bar,
+                    "half_block" => ChartMarker::HalfBlock,
+                    _ => ChartMarker::Braille,
+                };
+            }
+            _ => {}
+        },
+        _ => {}
+    }
+}
+
+/// Apply a confirmed text-edit buffer to the draft prefs.
+fn apply_text_edit(state: &mut PrefsState, buf: &str) {
+    match state.section {
+        PrefsSection::App => {
+            if state.field_index == 1 {
+                if let Ok(v) = buf.parse::<u64>() {
+                    state.draft.app.refresh_interval_ms = v;
+                }
+            }
+        }
+        PrefsSection::Stream => match state.field_index {
+            0 => {
+                if let Ok(v) = buf.parse::<u32>() {
+                    state.draft.stream.reconnect_max_attempts = v;
+                }
+            }
+            1 => {
+                if let Ok(v) = buf.parse::<u64>() {
+                    state.draft.stream.reconnect_backoff_base_ms = v;
+                }
+            }
+            _ => {}
+        },
+        PrefsSection::Notifications => match state.field_index {
+            1 => {
+                if let Ok(v) = buf.parse::<u64>() {
+                    state.draft.notifications.fill_notification_ttl_ms = v;
+                }
+            }
+            2 => {
+                if let Ok(v) = buf.parse::<u64>() {
+                    state.draft.notifications.status_message_ttl_ms = v;
+                }
+            }
+            _ => {}
+        },
+        PrefsSection::Proxy => match state.field_index {
+            0 => {
+                state.draft.proxy.http = if buf.is_empty() {
+                    None
+                } else {
+                    Some(buf.to_string())
+                };
+            }
+            1 => {
+                state.draft.proxy.socks5 = if buf.is_empty() {
+                    None
+                } else {
+                    Some(buf.to_string())
+                };
+            }
+            2 => {
+                state.draft.proxy.no_proxy = if buf.is_empty() {
+                    None
+                } else {
+                    Some(buf.to_string())
+                };
+            }
+            _ => {}
+        },
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -2446,6 +2812,418 @@ mod tests {
             format!("{:?}", initial),
             format!("{:?}", after),
             "Up on TrailMode should toggle trail_type"
+        );
+    }
+
+    // ── Preferences modal ─────────────────────────────────────────────────────
+
+    use crate::app::{DropdownState, PrefsSection, PrefsState};
+
+    fn prefs_state(app: &crate::app::App) -> PrefsState {
+        match &app.modal {
+            Some(Modal::Preferences(s)) => s.clone(),
+            other => panic!("expected Preferences modal, got {:?}", other),
+        }
+    }
+
+    fn press_ctrl(app: &mut crate::app::App, code: KeyCode) {
+        let event = KeyEvent::new(code, KeyModifiers::CONTROL);
+        super::handle_modal_key(app, event);
+    }
+
+    #[test]
+    fn prefs_tab_cycles_sections() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
+        assert_eq!(prefs_state(&app).section, PrefsSection::App);
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(prefs_state(&app).section, PrefsSection::Ui);
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(prefs_state(&app).section, PrefsSection::Stream);
+    }
+
+    #[test]
+    fn prefs_backtab_cycles_sections_backward() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
+        press(&mut app, KeyCode::BackTab);
+        assert_eq!(
+            prefs_state(&app).section,
+            PrefsSection::Credentials,
+            "BackTab from App should wrap to Credentials"
+        );
+    }
+
+    #[test]
+    fn prefs_down_increments_field_index() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
+        assert_eq!(prefs_state(&app).field_index, 0);
+        press(&mut app, KeyCode::Down);
+        assert_eq!(prefs_state(&app).field_index, 1);
+    }
+
+    #[test]
+    fn prefs_up_does_not_go_below_zero() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
+        press(&mut app, KeyCode::Up);
+        assert_eq!(prefs_state(&app).field_index, 0);
+    }
+
+    #[test]
+    fn prefs_down_clamps_at_section_max() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Safety; // 1 field
+        app.modal = Some(Modal::Preferences(state));
+        for _ in 0..5 {
+            press(&mut app, KeyCode::Down);
+        }
+        assert_eq!(prefs_state(&app).field_index, 0);
+    }
+
+    #[test]
+    fn prefs_tab_resets_field_index() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.field_index = 1;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(prefs_state(&app).field_index, 0);
+    }
+
+    #[test]
+    fn prefs_enter_on_bool_toggles_value_and_sets_dirty() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Safety;
+        state.field_index = 0;
+        let original = state.draft.safety.confirm_watchlist_remove;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(
+            s.draft.safety.confirm_watchlist_remove, !original,
+            "bool should be toggled"
+        );
+        assert!(s.dirty, "dirty should be set after bool toggle");
+    }
+
+    #[test]
+    fn prefs_ctrl_s_syncs_equity_range() {
+        use crate::app::EquityRange;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.ui.default_equity_range = "1W".to_string();
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert_eq!(app.equity_range, EquityRange::OneWeek);
+    }
+
+    #[test]
+    fn prefs_notifications_bool_toggle_sets_dirty() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 0; // fill_notifications_enabled
+        let original = state.draft.notifications.fill_notifications_enabled;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(s.draft.notifications.fill_notifications_enabled, !original);
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn prefs_enter_on_numeric_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1; // refresh_interval_ms
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            prefs_state(&app).editing_buf.is_some(),
+            "Enter on numeric field should open edit mode"
+        );
+    }
+
+    #[test]
+    fn prefs_enter_on_enum_opens_dropdown() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 0; // default_env
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert!(
+            prefs_state(&app).dropdown.is_some(),
+            "Enter on enum field should open dropdown"
+        );
+    }
+
+    #[test]
+    fn prefs_dropdown_down_moves_cursor() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 0;
+        state.dropdown = Some(DropdownState::new(vec!["live", "paper"], "live"));
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Down);
+        assert_eq!(prefs_state(&app).dropdown.as_ref().unwrap().cursor, 1);
+    }
+
+    #[test]
+    fn prefs_dropdown_enter_applies_selection() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 0;
+        state.dropdown = Some(DropdownState::new(vec!["live", "paper"], "live"));
+        state.dropdown.as_mut().unwrap().cursor = 1;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(s.draft.app.default_env, "paper");
+        assert!(
+            s.dropdown.is_none(),
+            "dropdown should close after selection"
+        );
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn prefs_edit_mode_appends_chars() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1;
+        state.editing_buf = Some(String::new());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Char('1'));
+        press(&mut app, KeyCode::Char('0'));
+        assert_eq!(prefs_state(&app).editing_buf.as_deref(), Some("10"));
+    }
+
+    #[test]
+    fn prefs_edit_mode_backspace_removes_char() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1;
+        state.editing_buf = Some("500".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Backspace);
+        assert_eq!(prefs_state(&app).editing_buf.as_deref(), Some("50"));
+    }
+
+    #[test]
+    fn prefs_edit_mode_enter_applies_value() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1; // refresh_interval_ms
+        state.editing_buf = Some("8000".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(s.draft.app.refresh_interval_ms, 8000);
+        assert!(s.editing_buf.is_none());
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn prefs_esc_closes_dropdown_before_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.dropdown = Some(DropdownState::new(vec!["live", "paper"], "live"));
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Esc);
+        let s = prefs_state(&app);
+        assert!(
+            s.dropdown.is_none(),
+            "first Esc should close dropdown, not modal"
+        );
+    }
+
+    #[test]
+    fn prefs_esc_on_clean_closes_modal() {
+        let mut app = make_test_app();
+        app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
+        press(&mut app, KeyCode::Esc);
+        assert!(app.modal.is_none(), "Esc on clean prefs should close modal");
+    }
+
+    #[test]
+    fn prefs_esc_on_dirty_closes_and_discards() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Esc);
+        assert!(
+            app.modal.is_none(),
+            "Esc on dirty prefs should close and discard"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_saves_and_closes() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.draft.app.default_env = "paper".to_string();
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        assert!(app.modal.is_none(), "Ctrl-S should close the modal");
+        assert_eq!(
+            app.prefs.app.default_env, "paper",
+            "Ctrl-S should apply draft to app.prefs"
+        );
+    }
+
+    #[test]
+    fn prefs_ui_chart_marker_dropdown_cycles_all_variants() {
+        use crate::prefs::ChartMarker;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 6; // chart_marker
+        state.dropdown = Some(DropdownState::new(
+            vec!["braille", "dot", "block", "bar", "half_block"],
+            "braille",
+        ));
+        state.dropdown.as_mut().unwrap().cursor = 2; // "block"
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(prefs_state(&app).draft.ui.chart_marker, ChartMarker::Block);
+    }
+
+    #[test]
+    fn prefs_credentials_enter_opens_edit_mode() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.field_index = 0;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert!(
+            s.editing_buf.is_some(),
+            "Enter on credential field should open edit mode"
+        );
+    }
+
+    #[test]
+    fn prefs_credentials_edit_mode_accepts_all_chars() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.field_index = 0;
+        state.editing_buf = Some(String::new());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Char('A'));
+        press(&mut app, KeyCode::Char('-'));
+        press(&mut app, KeyCode::Char('1'));
+        let s = prefs_state(&app);
+        assert_eq!(
+            s.editing_buf.as_deref(),
+            Some("A-1"),
+            "credential edit accepts all chars"
+        );
+    }
+
+    #[test]
+    fn prefs_credentials_enter_confirms_key_to_key_buf() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.field_index = 0;
+        state.editing_buf = Some("MYKEY".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(
+            s.key_buf, "MYKEY",
+            "Enter should store key_buf from editing_buf"
+        );
+        assert!(s.editing_buf.is_none(), "editing_buf should be cleared");
+    }
+
+    #[test]
+    fn prefs_credentials_enter_confirms_secret_to_secret_buf() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.field_index = 1;
+        state.editing_buf = Some("MYSECRET".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(
+            s.secret_buf, "MYSECRET",
+            "Enter should store secret_buf from editing_buf"
+        );
+        assert!(s.editing_buf.is_none(), "editing_buf should be cleared");
+    }
+
+    #[test]
+    fn prefs_ctrl_s_with_only_key_sets_error_and_keeps_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.key_buf = "SOMEKEY".to_string();
+        state.secret_buf = String::new();
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(
+            s.cred_error.is_some(),
+            "should set cred_error when only key provided"
+        );
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("Secret"),
+            "error should mention Secret"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_with_only_secret_sets_error_and_keeps_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.key_buf = String::new();
+        state.secret_buf = "SOMESECRET".to_string();
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(
+            s.cred_error.is_some(),
+            "should set cred_error when only secret provided"
+        );
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("Key"),
+            "error should mention Key"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_with_empty_creds_skips_keychain_and_saves() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.key_buf = String::new();
+        state.secret_buf = String::new();
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        // modal should close (no keychain call needed when both empty)
+        assert!(
+            app.modal.is_none(),
+            "modal should close when no new creds to save"
         );
     }
 }

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -410,22 +410,39 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                                 format!("Cancelling {}…", &id[..id.len().min(8)]),
                             );
                         }
+                        ConfirmAction::DiscardPrefs(_) => {
+                            app.push_transient_status("Preferences discarded");
+                        }
                     }
                     app.modal = None;
                     return;
                 }
-                None
+                // 'n' — restore prefs modal for DiscardPrefs, close otherwise.
+                match action {
+                    ConfirmAction::DiscardPrefs(state) => Some(Modal::Preferences(*state)),
+                    _ => None,
+                }
             }
             KeyCode::Enter => {
                 if confirmed {
+                    match &action {
+                        ConfirmAction::CancelOrder(_) => {}
+                        ConfirmAction::DiscardPrefs(_) => {
+                            app.push_transient_status("Preferences discarded");
+                        }
+                    }
                     app.modal = None;
                     return;
                 }
-                Some(Modal::Confirm {
-                    message,
-                    action,
-                    confirmed,
-                })
+                // Enter while not confirmed: restore for DiscardPrefs, keep open otherwise.
+                match action {
+                    ConfirmAction::DiscardPrefs(state) => Some(Modal::Preferences(*state)),
+                    _ => Some(Modal::Confirm {
+                        message,
+                        action,
+                        confirmed,
+                    }),
+                }
             }
             _ => Some(Modal::Confirm {
                 message,
@@ -690,10 +707,12 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 KeyCode::Tab => {
                     state.section = state.section.next();
                     state.field_index = 0;
+                    state.cred_error = None;
                 }
                 KeyCode::BackTab => {
                     state.section = state.section.prev();
                     state.field_index = 0;
+                    state.cred_error = None;
                 }
                 KeyCode::Up | KeyCode::Char('k') => {
                     state.field_index = state.field_index.saturating_sub(1);
@@ -774,6 +793,23 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                             }
                         }
                     }
+                    // Validate proxy URLs before writing to disk.
+                    if let Some(ref url) = state.draft.proxy.http {
+                        if !url.starts_with("http://") && !url.starts_with("https://") {
+                            state.cred_error =
+                                Some("HTTP proxy must start with http:// or https://".to_string());
+                            app.modal = Some(Modal::Preferences(state));
+                            return;
+                        }
+                    }
+                    if let Some(ref url) = state.draft.proxy.socks5 {
+                        if !url.starts_with("socks5://") {
+                            state.cred_error =
+                                Some("SOCKS5 proxy must start with socks5://".to_string());
+                            app.modal = Some(Modal::Preferences(state));
+                            return;
+                        }
+                    }
                     save_prefs(app, &state.draft);
                     app.push_transient_status("Preferences saved");
                     app.modal = None;
@@ -806,14 +842,18 @@ fn save_prefs(app: &mut App, draft: &AppPrefs) {
 }
 
 fn handle_prefs_discard_confirm(app: &mut App) {
-    // Swap out the dirty prefs modal, replace with a confirm dialog.
-    // On 'y' we just close; on 'n' we restore the prefs modal.
-    // We encode the draft inside ConfirmAction via a simple close-without-save path:
-    // since ConfirmAction only has CancelOrder, we take the simpler route of just
-    // closing the modal immediately when Esc is pressed on a dirty prefs modal.
-    // The user must use Ctrl-S to save; Esc always discards.
-    app.modal = None;
-    app.push_transient_status("Preferences discarded");
+    let dirty_state = match app.modal.take() {
+        Some(Modal::Preferences(s)) => s,
+        other => {
+            app.modal = other;
+            return;
+        }
+    };
+    app.modal = Some(Modal::Confirm {
+        message: "Discard unsaved preferences?".to_string(),
+        action: ConfirmAction::DiscardPrefs(Box::new(dirty_state)),
+        confirmed: false,
+    });
 }
 
 /// Open dropdown or begin text edit for the currently focused preferences field.
@@ -959,19 +999,22 @@ fn apply_text_edit(state: &mut PrefsState, buf: &str) {
         PrefsSection::App => {
             if state.field_index == 1 {
                 if let Ok(v) = buf.parse::<u64>() {
-                    state.draft.app.refresh_interval_ms = v;
+                    // Floor at 100 ms; 0 would cause infinite-loop polling.
+                    state.draft.app.refresh_interval_ms = v.max(100);
                 }
             }
         }
         PrefsSection::Stream => match state.field_index {
             0 => {
                 if let Ok(v) = buf.parse::<u32>() {
+                    // 0 = unlimited retries; any value is valid.
                     state.draft.stream.reconnect_max_attempts = v;
                 }
             }
             1 => {
                 if let Ok(v) = buf.parse::<u64>() {
-                    state.draft.stream.reconnect_backoff_base_ms = v;
+                    // Floor at 100 ms to prevent degenerate backoff bursts.
+                    state.draft.stream.reconnect_backoff_base_ms = v.max(100);
                 }
             }
             _ => {}
@@ -979,12 +1022,13 @@ fn apply_text_edit(state: &mut PrefsState, buf: &str) {
         PrefsSection::Notifications => match state.field_index {
             1 => {
                 if let Ok(v) = buf.parse::<u64>() {
-                    state.draft.notifications.fill_notification_ttl_ms = v;
+                    // Floor at 500 ms; shorter is unreadable.
+                    state.draft.notifications.fill_notification_ttl_ms = v.max(500);
                 }
             }
             2 => {
                 if let Ok(v) = buf.parse::<u64>() {
-                    state.draft.notifications.status_message_ttl_ms = v;
+                    state.draft.notifications.status_message_ttl_ms = v.max(500);
                 }
             }
             _ => {}
@@ -3093,15 +3137,43 @@ mod tests {
     }
 
     #[test]
-    fn prefs_esc_on_dirty_closes_and_discards() {
+    fn prefs_esc_on_dirty_shows_confirm_dialog() {
         let mut app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);
         state.dirty = true;
         app.modal = Some(Modal::Preferences(state));
         press(&mut app, KeyCode::Esc);
         assert!(
+            matches!(app.modal, Some(Modal::Confirm { .. })),
+            "Esc on dirty prefs should open a discard confirm dialog"
+        );
+    }
+
+    #[test]
+    fn prefs_esc_dirty_confirm_y_discards() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Esc);
+        press(&mut app, KeyCode::Char('y'));
+        assert!(
             app.modal.is_none(),
-            "Esc on dirty prefs should close and discard"
+            "'y' on discard confirm should close modal"
+        );
+    }
+
+    #[test]
+    fn prefs_esc_dirty_confirm_n_restores_prefs_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.dirty = true;
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Esc);
+        press(&mut app, KeyCode::Char('n'));
+        assert!(
+            matches!(app.modal, Some(Modal::Preferences(_))),
+            "'n' on discard confirm should restore the Preferences modal"
         );
     }
 

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -919,12 +919,11 @@ fn activate_prefs_field(state: &mut PrefsState) {
             }
             _ => {}
         },
-        PrefsSection::Credentials => match state.field_index {
-            0..=3 => {
+        PrefsSection::Credentials => {
+            if let 0..=3 = state.field_index {
                 state.editing_buf = Some(String::new());
             }
-            _ => {}
-        },
+        }
     }
 }
 

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -667,8 +667,10 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                         let buf = state.editing_buf.take().unwrap_or_default();
                         if is_cred {
                             match state.field_index {
-                                0 => state.key_buf = buf,
-                                1 => state.secret_buf = buf,
+                                0 => state.live_key_buf = buf,
+                                1 => state.live_secret_buf = buf,
+                                2 => state.paper_key_buf = buf,
+                                3 => state.paper_secret_buf = buf,
                                 _ => {}
                             }
                             state.dirty = true;
@@ -706,32 +708,67 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                     activate_prefs_field(&mut state);
                 }
                 KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    let has_key = !state.key_buf.is_empty();
-                    let has_secret = !state.secret_buf.is_empty();
-                    // Exactly one provided → validation error; keep modal open.
-                    if has_key ^ has_secret {
-                        state.cred_error = Some(if has_key {
-                            "API Secret is required when updating credentials".to_string()
+                    let has_live_key = !state.live_key_buf.is_empty();
+                    let has_live_secret = !state.live_secret_buf.is_empty();
+                    let has_paper_key = !state.paper_key_buf.is_empty();
+                    let has_paper_secret = !state.paper_secret_buf.is_empty();
+                    // Validate: each pair must be complete (both or neither).
+                    if has_live_key ^ has_live_secret {
+                        state.cred_error = Some(if has_live_key {
+                            "Live API Secret is required when updating live credentials".to_string()
                         } else {
-                            "API Key is required when updating credentials".to_string()
+                            "Live API Key is required when updating live credentials".to_string()
                         });
                         app.modal = Some(Modal::Preferences(state));
                         return;
                     }
-                    // Both provided → save to keychain; abort on error.
-                    if has_key {
+                    if has_paper_key ^ has_paper_secret {
+                        state.cred_error = Some(if has_paper_key {
+                            "Paper API Secret is required when updating paper credentials"
+                                .to_string()
+                        } else {
+                            "Paper API Key is required when updating paper credentials".to_string()
+                        });
+                        app.modal = Some(Modal::Preferences(state));
+                        return;
+                    }
+                    // Save live pair if provided.
+                    if has_live_key {
                         match save_to_keychain(
-                            app.config.env.clone(),
-                            &state.key_buf,
-                            &state.secret_buf,
+                            crate::config::AlpacaEnv::Live,
+                            &state.live_key_buf,
+                            &state.live_secret_buf,
                         ) {
                             Ok(()) => {
-                                app.config.key = state.key_buf.clone();
-                                app.config.secret = state.secret_buf.clone();
+                                if app.config.env == crate::config::AlpacaEnv::Live {
+                                    app.config.key = state.live_key_buf.clone();
+                                    app.config.secret = state.live_secret_buf.clone();
+                                }
                                 state.cred_error = None;
                             }
                             Err(e) => {
-                                state.cred_error = Some(format!("Keychain error: {e}"));
+                                state.cred_error = Some(format!("Keychain error (live): {e}"));
+                                app.modal = Some(Modal::Preferences(state));
+                                return;
+                            }
+                        }
+                    }
+                    // Save paper pair if provided.
+                    if has_paper_key {
+                        match save_to_keychain(
+                            crate::config::AlpacaEnv::Paper,
+                            &state.paper_key_buf,
+                            &state.paper_secret_buf,
+                        ) {
+                            Ok(()) => {
+                                if app.config.env == crate::config::AlpacaEnv::Paper {
+                                    app.config.key = state.paper_key_buf.clone();
+                                    app.config.secret = state.paper_secret_buf.clone();
+                                }
+                                state.cred_error = None;
+                            }
+                            Err(e) => {
+                                state.cred_error = Some(format!("Keychain error (paper): {e}"));
                                 app.modal = Some(Modal::Preferences(state));
                                 return;
                             }
@@ -883,8 +920,7 @@ fn activate_prefs_field(state: &mut PrefsState) {
             _ => {}
         },
         PrefsSection::Credentials => match state.field_index {
-            0 | 1 => {
-                // Start with an empty buffer; user types the new value.
+            0..=3 => {
                 state.editing_buf = Some(String::new());
             }
             _ => {}
@@ -3137,73 +3173,99 @@ mod tests {
     }
 
     #[test]
-    fn prefs_credentials_enter_confirms_key_to_key_buf() {
+    fn prefs_credentials_enter_on_field0_stores_live_key_buf() {
         let mut app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);
         state.section = PrefsSection::Credentials;
         state.field_index = 0;
-        state.editing_buf = Some("MYKEY".to_string());
+        state.editing_buf = Some("LIVEKEY".to_string());
         app.modal = Some(Modal::Preferences(state));
         press(&mut app, KeyCode::Enter);
         let s = prefs_state(&app);
         assert_eq!(
-            s.key_buf, "MYKEY",
-            "Enter should store key_buf from editing_buf"
+            s.live_key_buf, "LIVEKEY",
+            "field 0 should store live_key_buf"
         );
         assert!(s.editing_buf.is_none(), "editing_buf should be cleared");
     }
 
     #[test]
-    fn prefs_credentials_enter_confirms_secret_to_secret_buf() {
+    fn prefs_credentials_enter_on_field1_stores_live_secret_buf() {
         let mut app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);
         state.section = PrefsSection::Credentials;
         state.field_index = 1;
-        state.editing_buf = Some("MYSECRET".to_string());
+        state.editing_buf = Some("LIVESECRET".to_string());
         app.modal = Some(Modal::Preferences(state));
         press(&mut app, KeyCode::Enter);
         let s = prefs_state(&app);
         assert_eq!(
-            s.secret_buf, "MYSECRET",
-            "Enter should store secret_buf from editing_buf"
+            s.live_secret_buf, "LIVESECRET",
+            "field 1 should store live_secret_buf"
         );
         assert!(s.editing_buf.is_none(), "editing_buf should be cleared");
     }
 
     #[test]
-    fn prefs_ctrl_s_with_only_key_sets_error_and_keeps_modal() {
+    fn prefs_credentials_enter_on_field2_stores_paper_key_buf() {
         let mut app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);
         state.section = PrefsSection::Credentials;
-        state.key_buf = "SOMEKEY".to_string();
-        state.secret_buf = String::new();
+        state.field_index = 2;
+        state.editing_buf = Some("PAPERKEY".to_string());
         app.modal = Some(Modal::Preferences(state));
-        press_ctrl(&mut app, KeyCode::Char('s'));
+        press(&mut app, KeyCode::Enter);
         let s = prefs_state(&app);
-        assert!(
-            s.cred_error.is_some(),
-            "should set cred_error when only key provided"
-        );
-        assert!(
-            s.cred_error.as_deref().unwrap().contains("Secret"),
-            "error should mention Secret"
+        assert_eq!(
+            s.paper_key_buf, "PAPERKEY",
+            "field 2 should store paper_key_buf"
         );
     }
 
     #[test]
-    fn prefs_ctrl_s_with_only_secret_sets_error_and_keeps_modal() {
+    fn prefs_credentials_enter_on_field3_stores_paper_secret_buf() {
         let mut app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);
         state.section = PrefsSection::Credentials;
-        state.key_buf = String::new();
-        state.secret_buf = "SOMESECRET".to_string();
+        state.field_index = 3;
+        state.editing_buf = Some("PAPERSECRET".to_string());
+        app.modal = Some(Modal::Preferences(state));
+        press(&mut app, KeyCode::Enter);
+        let s = prefs_state(&app);
+        assert_eq!(
+            s.paper_secret_buf, "PAPERSECRET",
+            "field 3 should store paper_secret_buf"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_with_only_live_key_sets_error_and_keeps_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.live_key_buf = "SOMEKEY".to_string();
         app.modal = Some(Modal::Preferences(state));
         press_ctrl(&mut app, KeyCode::Char('s'));
         let s = prefs_state(&app);
+        assert!(s.cred_error.is_some(), "should set cred_error");
         assert!(
-            s.cred_error.is_some(),
-            "should set cred_error when only secret provided"
+            s.cred_error.as_deref().unwrap().contains("Secret"),
+            "error should mention Secret"
         );
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("live"),
+            "error should mention live"
+        );
+    }
+
+    #[test]
+    fn prefs_ctrl_s_with_only_live_secret_sets_error_and_keeps_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.live_secret_buf = "SOMESECRET".to_string();
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(s.cred_error.is_some(), "should set cred_error");
         assert!(
             s.cred_error.as_deref().unwrap().contains("Key"),
             "error should mention Key"
@@ -3211,16 +3273,27 @@ mod tests {
     }
 
     #[test]
+    fn prefs_ctrl_s_with_only_paper_key_sets_error_and_keeps_modal() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.paper_key_buf = "PAPERKEY".to_string();
+        app.modal = Some(Modal::Preferences(state));
+        press_ctrl(&mut app, KeyCode::Char('s'));
+        let s = prefs_state(&app);
+        assert!(s.cred_error.is_some(), "should set cred_error");
+        assert!(
+            s.cred_error.as_deref().unwrap().contains("paper"),
+            "error should mention paper"
+        );
+    }
+
+    #[test]
     fn prefs_ctrl_s_with_empty_creds_skips_keychain_and_saves() {
         let mut app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);
-        state.section = PrefsSection::Credentials;
-        state.key_buf = String::new();
-        state.secret_buf = String::new();
         state.dirty = true;
         app.modal = Some(Modal::Preferences(state));
         press_ctrl(&mut app, KeyCode::Char('s'));
-        // modal should close (no keychain call needed when both empty)
         assert!(
             app.modal.is_none(),
             "modal should close when no new creds to save"

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
         Axis, Block, BorderType, Borders, Cell, Chart, Clear, Dataset, GraphType, Paragraph, Row,
@@ -10,7 +10,8 @@ use ratatui::{
 };
 
 use crate::app::{
-    AlertField, App, ConfirmAction, FullOrderType, Modal, OrderEntryState, OrderField, TrailType,
+    AlertField, App, ConfirmAction, FullOrderType, Modal, OrderEntryState, OrderField,
+    PrefsSection, PrefsState, TrailType,
 };
 use crate::ui::{charts, popup_area};
 
@@ -28,6 +29,7 @@ pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
         Modal::GlobalSearch { .. } => popup_area(area, 35, 20),
         Modal::PositionDetail { .. } => popup_area(area, 60, 90),
         Modal::SetAlert { .. } => popup_area(area, 42, 30),
+        Modal::Preferences(_) => popup_area(area, 75, 80),
     });
 
     match modal {
@@ -52,6 +54,7 @@ pub fn render(frame: &mut Frame, area: Rect, modal: &Modal, app: &mut App) {
             below_input,
             focused,
         } => render_set_alert(frame, area, symbol, above_input, below_input, focused, app),
+        Modal::Preferences(state) => render_preferences(frame, area, state, app),
     }
 }
 
@@ -96,6 +99,7 @@ fn render_help(frame: &mut Frame, area: Rect, app: &App) {
         ("", ""),
         ("GLOBAL", ""),
         ("T", "Cycle theme (Default → Dark → High-contrast)"),
+        ("P", "Open Preferences editor"),
         ("q / Ctrl-C", "Quit"),
         ("?", "This help screen"),
         ("A", "About this app (non-Watchlist tabs)"),
@@ -1500,6 +1504,286 @@ fn render_position_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App
         )])),
         outer[3],
     );
+}
+
+fn render_preferences(frame: &mut Frame, area: Rect, state: &PrefsState, app: &App) {
+    let popup = popup_area(area, 75, 80);
+    frame.render_widget(Clear, popup);
+
+    let c = app.current_theme.colors();
+
+    let title = if state.dirty {
+        " Preferences ● "
+    } else {
+        " Preferences "
+    };
+    let outer_block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(c.accent_style());
+    let inner = outer_block.inner(popup);
+    frame.render_widget(outer_block, popup);
+
+    // Split inner into sidebar (left 22 cols) + field pane (rest).
+    let panes = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(22), Constraint::Min(10)])
+        .split(inner);
+
+    // ── Sidebar ───────────────────────────────────────────────────────────────
+    let sidebar_block = Block::default()
+        .borders(Borders::RIGHT)
+        .border_style(c.dim_style());
+    let sidebar_inner = sidebar_block.inner(panes[0]);
+    frame.render_widget(sidebar_block, panes[0]);
+
+    let section_rows: Vec<Row> = PrefsSection::ALL
+        .iter()
+        .map(|s| {
+            let label = s.label();
+            if *s == state.section {
+                Row::new(vec![
+                    Cell::from(format!("▶ {label}")).style(c.accent_style())
+                ])
+            } else {
+                Row::new(vec![Cell::from(format!("  {label}")).style(c.dim_style())])
+            }
+        })
+        .collect();
+    let sidebar_table = Table::new(section_rows, [Constraint::Min(18)]);
+    frame.render_widget(sidebar_table, sidebar_inner);
+
+    // ── Field pane ────────────────────────────────────────────────────────────
+    let field_block = Block::default()
+        .title(format!(" {} ", state.section.label()))
+        .borders(Borders::NONE);
+    let field_inner = field_block.inner(panes[1]);
+    frame.render_widget(field_block, panes[1]);
+
+    let fields = prefs_fields_for_section(state, app);
+    let field_rows: Vec<Row> = fields
+        .iter()
+        .enumerate()
+        .map(|(i, (label, value))| {
+            let focused = i == state.field_index;
+            let label_cell = Cell::from(format!("  {label:<26}")).style(c.dim_style());
+            let value_cell = if focused {
+                Cell::from(value.as_str()).style(c.accent_style())
+            } else {
+                Cell::from(value.as_str())
+            };
+            Row::new(vec![label_cell, value_cell])
+        })
+        .collect();
+
+    let field_table = Table::new(field_rows, [Constraint::Length(30), Constraint::Min(10)]);
+    frame.render_widget(field_table, field_inner);
+
+    // ── Credential error banner ───────────────────────────────────────────────
+    if let Some(ref err) = state.cred_error {
+        let err_y = field_inner.y + field_inner.height.saturating_sub(3);
+        let err_rect = Rect {
+            x: field_inner.x,
+            y: err_y,
+            width: field_inner.width,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(format!("  ✗ {err}"))
+                .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            err_rect,
+        );
+    }
+
+    // ── Dropdown overlay ──────────────────────────────────────────────────────
+    if let Some(dd) = &state.dropdown {
+        let dd_height = dd.options.len() as u16 + 2;
+        let dd_y = field_inner
+            .y
+            .saturating_add(state.field_index as u16)
+            .saturating_add(1);
+        let dd_x = field_inner.x + 30;
+        let dd_rect = Rect {
+            x: dd_x.min(popup.x + popup.width.saturating_sub(20)),
+            y: dd_y.min(popup.y + popup.height.saturating_sub(dd_height + 1)),
+            width: 18,
+            height: dd_height,
+        };
+        frame.render_widget(Clear, dd_rect);
+        let dd_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(c.accent_style());
+        let dd_inner = dd_block.inner(dd_rect);
+        frame.render_widget(dd_block, dd_rect);
+        let dd_rows: Vec<Row> = dd
+            .options
+            .iter()
+            .enumerate()
+            .map(|(i, opt)| {
+                if i == dd.cursor {
+                    Row::new(vec![Cell::from(format!("▶ {opt}")).style(c.accent_style())])
+                } else {
+                    Row::new(vec![Cell::from(format!("  {opt}")).style(c.dim_style())])
+                }
+            })
+            .collect();
+        frame.render_widget(Table::new(dd_rows, [Constraint::Min(14)]), dd_inner);
+    }
+
+    // ── Footer hint ───────────────────────────────────────────────────────────
+    let hint_y = inner.y + inner.height.saturating_sub(1);
+    let hint_rect = Rect {
+        x: inner.x,
+        y: hint_y,
+        width: inner.width,
+        height: 1,
+    };
+    frame.render_widget(
+        Paragraph::new("  Tab:Section  ↑/↓:Field  Enter:Edit  Ctrl-S:Save  Esc:Cancel")
+            .style(c.dim_style()),
+        hint_rect,
+    );
+}
+
+/// Build the `(label, display_value)` pairs for the currently focused section.
+fn mask_cred(state: &PrefsState, field_idx: usize, buf: &str, saved: &str) -> String {
+    if state.field_index == field_idx {
+        if let Some(ref edit) = state.editing_buf {
+            // actively editing — show masked typed chars + cursor
+            return format!("{}▋", "*".repeat(edit.len()));
+        }
+    }
+    if !buf.is_empty() {
+        // typed but not yet confirmed
+        return "*".repeat(buf.len());
+    }
+    if !saved.is_empty() {
+        return "●".repeat(saved.len().min(24));
+    }
+    "[ not set ]".to_string()
+}
+
+fn prefs_fields_for_section<'a>(state: &'a PrefsState, app: &App) -> Vec<(&'static str, String)> {
+    let d = &state.draft;
+    match state.section {
+        PrefsSection::Credentials => vec![
+            (
+                "APCA-API-KEY-ID",
+                mask_cred(state, 0, &state.key_buf, &app.config.key),
+            ),
+            (
+                "APCA-API-SECRET",
+                mask_cred(state, 1, &state.secret_buf, &app.config.secret),
+            ),
+        ],
+        PrefsSection::App => vec![
+            ("default_env", d.app.default_env.clone()),
+            (
+                "refresh_interval_ms",
+                edit_or_value(state, 1, d.app.refresh_interval_ms.to_string()),
+            ),
+        ],
+        PrefsSection::Ui => vec![
+            ("theme", dropdown_or_value(state, 0, d.ui.theme.clone())),
+            ("show_account_panel", bool_display(d.ui.show_account_panel)),
+            ("show_watchlist", bool_display(d.ui.show_watchlist)),
+            ("show_positions", bool_display(d.ui.show_positions)),
+            ("show_orders", bool_display(d.ui.show_orders)),
+            (
+                "default_equity_range",
+                dropdown_or_value(state, 5, d.ui.default_equity_range.clone()),
+            ),
+            (
+                "chart_marker",
+                dropdown_or_value(state, 6, d.ui.chart_marker.as_str().to_string()),
+            ),
+        ],
+        PrefsSection::Stream => vec![
+            (
+                "reconnect_max_attempts",
+                edit_or_value(state, 0, d.stream.reconnect_max_attempts.to_string()),
+            ),
+            (
+                "reconnect_backoff_base_ms",
+                edit_or_value(state, 1, d.stream.reconnect_backoff_base_ms.to_string()),
+            ),
+        ],
+        PrefsSection::Notifications => vec![
+            (
+                "fill_notifications_enabled",
+                bool_display(d.notifications.fill_notifications_enabled),
+            ),
+            (
+                "fill_notification_ttl_ms",
+                edit_or_value(
+                    state,
+                    1,
+                    d.notifications.fill_notification_ttl_ms.to_string(),
+                ),
+            ),
+            (
+                "status_message_ttl_ms",
+                edit_or_value(state, 2, d.notifications.status_message_ttl_ms.to_string()),
+            ),
+        ],
+        PrefsSection::Safety => vec![(
+            "confirm_watchlist_remove",
+            bool_display(d.safety.confirm_watchlist_remove),
+        )],
+        PrefsSection::Proxy => vec![
+            (
+                "http",
+                edit_or_value(
+                    state,
+                    0,
+                    d.proxy.http.clone().unwrap_or_else(|| "—".to_string()),
+                ),
+            ),
+            (
+                "socks5",
+                edit_or_value(
+                    state,
+                    1,
+                    d.proxy.socks5.clone().unwrap_or_else(|| "—".to_string()),
+                ),
+            ),
+            (
+                "no_proxy",
+                edit_or_value(
+                    state,
+                    2,
+                    d.proxy.no_proxy.clone().unwrap_or_else(|| "—".to_string()),
+                ),
+            ),
+        ],
+    }
+}
+
+fn bool_display(v: bool) -> String {
+    if v {
+        "[✓]".to_string()
+    } else {
+        "[ ]".to_string()
+    }
+}
+
+fn edit_or_value(state: &PrefsState, field_idx: usize, fallback: String) -> String {
+    if state.field_index == field_idx {
+        if let Some(ref buf) = state.editing_buf {
+            return format!("{buf}▋");
+        }
+    }
+    fallback
+}
+
+fn dropdown_or_value(state: &PrefsState, field_idx: usize, fallback: String) -> String {
+    if state.field_index == field_idx {
+        if let Some(ref dd) = state.dropdown {
+            return format!("{} ▾", dd.selected());
+        }
+    }
+    fallback
 }
 
 #[cfg(test)]
@@ -3585,5 +3869,281 @@ mod tests {
         assert!(output.contains("🔔"));
         assert!(output.contains("Set Alert — AAPL"));
         assert!(output.contains("Active: above $185.00, below $165.00"));
+    }
+
+    // ── render_preferences ────────────────────────────────────────────────────
+
+    fn render_preferences_to_string(app: &mut App, state: &PrefsState) -> String {
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_preferences(frame, area, state, app);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let width = buffer.area().width as usize;
+        let height = buffer.area().height as usize;
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|col| {
+                        buffer
+                            .cell(ratatui::layout::Position {
+                                x: col as u16,
+                                y: row as u16,
+                            })
+                            .map(|c| c.symbol().to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_preferences_shows_title() {
+        let app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("Preferences"),
+            "should show Preferences title"
+        );
+    }
+
+    #[test]
+    fn render_preferences_dirty_shows_dot_in_title() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.dirty = true;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("Preferences ●"),
+            "dirty state should show ● in title; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_preferences_shows_all_sections_in_sidebar() {
+        let app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        for section in PrefsSection::ALL {
+            assert!(
+                output.contains(section.label()),
+                "sidebar should contain section label '{}'; got:\n{}",
+                section.label(),
+                output
+            );
+        }
+    }
+
+    #[test]
+    fn render_preferences_app_section_shows_fields() {
+        let app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("default_env"),
+            "should show default_env field"
+        );
+        assert!(
+            output.contains("refresh_interval_ms"),
+            "should show refresh_interval_ms field"
+        );
+    }
+
+    #[test]
+    fn render_preferences_ui_section_shows_fields() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(output.contains("theme"), "should show theme field");
+        assert!(
+            output.contains("chart_marker"),
+            "should show chart_marker field"
+        );
+        assert!(
+            output.contains("show_watchlist"),
+            "should show show_watchlist field"
+        );
+    }
+
+    #[test]
+    fn render_preferences_bool_field_shows_checkbox() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Safety;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("[✓]") || output.contains("[ ]"),
+            "bool field should render as checkbox; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_preferences_footer_hint_present() {
+        let app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("Ctrl-S:Save"),
+            "footer should contain Ctrl-S:Save hint"
+        );
+    }
+
+    #[test]
+    fn render_preferences_notifications_section() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("fill_notification"),
+            "should show fill_notification field"
+        );
+        assert!(
+            output.contains("status_message_ttl"),
+            "should show status_message_ttl field"
+        );
+    }
+
+    #[test]
+    fn render_preferences_stream_section() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Stream;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("reconnect_max_attempts"),
+            "should show reconnect_max_attempts"
+        );
+        assert!(
+            output.contains("reconnect_backoff_base_ms"),
+            "should show reconnect_backoff_base_ms"
+        );
+    }
+
+    #[test]
+    fn render_preferences_proxy_section() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Proxy;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(output.contains("http"), "should show http field");
+        assert!(output.contains("socks5"), "should show socks5 field");
+        assert!(output.contains("no_proxy"), "should show no_proxy field");
+    }
+
+    #[test]
+    fn render_preferences_credentials_section_not_set() {
+        let mut app = make_test_app();
+        app.config.key = String::new();
+        app.config.secret = String::new();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("APCA-API-KEY-ID"),
+            "should show key field label"
+        );
+        assert!(
+            output.contains("APCA-API-SECRET"),
+            "should show secret field label"
+        );
+        assert!(
+            output.contains("[ not set ]"),
+            "should show [ not set ] when no saved creds"
+        );
+    }
+
+    #[test]
+    fn render_preferences_credentials_section_saved_creds_masked() {
+        let mut app = make_test_app();
+        app.config.key = "MYAPIKEY12345".to_string();
+        app.config.secret = "MYSECRET98765".to_string();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        let output = render_preferences_to_string(&mut app, &state);
+        // saved keys shown as bullet dots, not plaintext
+        assert!(output.contains('●'), "saved key should be masked with ●");
+        assert!(
+            !output.contains("MYAPIKEY12345"),
+            "plaintext key must not appear"
+        );
+        assert!(
+            !output.contains("MYSECRET98765"),
+            "plaintext secret must not appear"
+        );
+    }
+
+    #[test]
+    fn render_preferences_credentials_typed_buf_masked_with_asterisks() {
+        let mut app = make_test_app();
+        app.config.key = String::new();
+        app.config.secret = String::new();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.key_buf = "NEWKEY".to_string();
+        state.secret_buf = "NEWSECRET".to_string();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("******"),
+            "typed key buf should render as *"
+        );
+        assert!(
+            !output.contains("NEWKEY"),
+            "typed key must not appear in plaintext"
+        );
+        assert!(
+            !output.contains("NEWSECRET"),
+            "typed secret must not appear in plaintext"
+        );
+    }
+
+    #[test]
+    fn render_preferences_credentials_error_banner_shown() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.cred_error = Some("API Secret is required when updating credentials".to_string());
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("API Secret is required"),
+            "should show cred_error message"
+        );
+    }
+
+    #[test]
+    fn render_preferences_credentials_editing_shows_cursor() {
+        let mut app = make_test_app();
+        app.config.key = String::new();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        state.field_index = 0;
+        state.editing_buf = Some("ABC".to_string());
+        let output = render_preferences_to_string(&mut app, &state);
+        // editing shows masked chars + cursor block
+        assert!(
+            output.contains('▋'),
+            "cursor block should appear while editing"
+        );
+        assert!(output.contains("***"), "editing chars should be masked");
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1647,19 +1647,17 @@ fn render_preferences(frame: &mut Frame, area: Rect, state: &PrefsState, app: &A
 }
 
 /// Build the `(label, display_value)` pairs for the currently focused section.
-fn mask_cred(state: &PrefsState, field_idx: usize, buf: &str, saved: &str) -> String {
+fn mask_cred(state: &PrefsState, field_idx: usize, buf: &str, saved: Option<&str>) -> String {
     if state.field_index == field_idx {
         if let Some(ref edit) = state.editing_buf {
-            // actively editing — show masked typed chars + cursor
             return format!("{}▋", "*".repeat(edit.len()));
         }
     }
     if !buf.is_empty() {
-        // typed but not yet confirmed
         return "*".repeat(buf.len());
     }
-    if !saved.is_empty() {
-        return "●".repeat(saved.len().min(24));
+    if let Some(s) = saved.filter(|s| !s.is_empty()) {
+        return "●".repeat(s.len().min(24));
     }
     "[ not set ]".to_string()
 }
@@ -1667,16 +1665,70 @@ fn mask_cred(state: &PrefsState, field_idx: usize, buf: &str, saved: &str) -> St
 fn prefs_fields_for_section<'a>(state: &'a PrefsState, app: &App) -> Vec<(&'static str, String)> {
     let d = &state.draft;
     match state.section {
-        PrefsSection::Credentials => vec![
-            (
-                "APCA-API-KEY-ID",
-                mask_cred(state, 0, &state.key_buf, &app.config.key),
-            ),
-            (
-                "APCA-API-SECRET",
-                mask_cred(state, 1, &state.secret_buf, &app.config.secret),
-            ),
-        ],
+        PrefsSection::Credentials => {
+            let live_key = state
+                .live_saved
+                .as_ref()
+                .map(|(k, _)| k.as_str())
+                .or_else(|| {
+                    if app.config.env == crate::config::AlpacaEnv::Live {
+                        Some(app.config.key.as_str())
+                    } else {
+                        None
+                    }
+                });
+            let live_secret = state
+                .live_saved
+                .as_ref()
+                .map(|(_, s)| s.as_str())
+                .or_else(|| {
+                    if app.config.env == crate::config::AlpacaEnv::Live {
+                        Some(app.config.secret.as_str())
+                    } else {
+                        None
+                    }
+                });
+            let paper_key = state
+                .paper_saved
+                .as_ref()
+                .map(|(k, _)| k.as_str())
+                .or_else(|| {
+                    if app.config.env == crate::config::AlpacaEnv::Paper {
+                        Some(app.config.key.as_str())
+                    } else {
+                        None
+                    }
+                });
+            let paper_secret = state
+                .paper_saved
+                .as_ref()
+                .map(|(_, s)| s.as_str())
+                .or_else(|| {
+                    if app.config.env == crate::config::AlpacaEnv::Paper {
+                        Some(app.config.secret.as_str())
+                    } else {
+                        None
+                    }
+                });
+            vec![
+                (
+                    "[LIVE]  APCA-API-KEY-ID",
+                    mask_cred(state, 0, &state.live_key_buf, live_key),
+                ),
+                (
+                    "[LIVE]  APCA-API-SECRET",
+                    mask_cred(state, 1, &state.live_secret_buf, live_secret),
+                ),
+                (
+                    "[PAPER] APCA-API-KEY-ID",
+                    mask_cred(state, 2, &state.paper_key_buf, paper_key),
+                ),
+                (
+                    "[PAPER] APCA-API-SECRET",
+                    mask_cred(state, 3, &state.paper_secret_buf, paper_secret),
+                ),
+            ]
+        }
         PrefsSection::App => vec![
             ("default_env", d.app.default_env.clone()),
             (
@@ -4076,44 +4128,39 @@ mod tests {
     #[test]
     fn render_preferences_credentials_section_saved_creds_masked() {
         let mut app = make_test_app();
-        app.config.key = "MYAPIKEY12345".to_string();
-        app.config.secret = "MYSECRET98765".to_string();
         let mut state = PrefsState::new(&app.prefs);
         state.section = PrefsSection::Credentials;
+        // Simulate saved credentials loaded from keychain into state.
+        state.live_saved = Some(("MYAPIKEY12345".to_string(), "MYSECRET98765".to_string()));
+        state.paper_saved = Some(("PAPKEY12345".to_string(), "PAPSECRET98765".to_string()));
         let output = render_preferences_to_string(&mut app, &state);
-        // saved keys shown as bullet dots, not plaintext
         assert!(output.contains('●'), "saved key should be masked with ●");
         assert!(
             !output.contains("MYAPIKEY12345"),
-            "plaintext key must not appear"
+            "plaintext live key must not appear"
         );
         assert!(
-            !output.contains("MYSECRET98765"),
-            "plaintext secret must not appear"
+            !output.contains("PAPKEY12345"),
+            "plaintext paper key must not appear"
         );
     }
 
     #[test]
     fn render_preferences_credentials_typed_buf_masked_with_asterisks() {
         let mut app = make_test_app();
-        app.config.key = String::new();
-        app.config.secret = String::new();
         let mut state = PrefsState::new(&app.prefs);
         state.section = PrefsSection::Credentials;
-        state.key_buf = "NEWKEY".to_string();
-        state.secret_buf = "NEWSECRET".to_string();
+        state.live_key_buf = "NEWLIVEKEY".to_string();
+        state.paper_key_buf = "NEWPAPERKEY".to_string();
         let output = render_preferences_to_string(&mut app, &state);
+        assert!(output.contains("**"), "typed buf should render as *");
         assert!(
-            output.contains("******"),
-            "typed key buf should render as *"
+            !output.contains("NEWLIVEKEY"),
+            "typed live key must not appear in plaintext"
         );
         assert!(
-            !output.contains("NEWKEY"),
-            "typed key must not appear in plaintext"
-        );
-        assert!(
-            !output.contains("NEWSECRET"),
-            "typed secret must not appear in plaintext"
+            !output.contains("NEWPAPERKEY"),
+            "typed paper key must not appear in plaintext"
         );
     }
 

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -4222,10 +4222,7 @@ mod tests {
         state.section = PrefsSection::Ui;
         state.draft.ui.show_watchlist = false;
         let output = render_preferences_to_string(&mut app, &state);
-        assert!(
-            output.contains("[ ]"),
-            "false bool should render as [ ]"
-        );
+        assert!(output.contains("[ ]"), "false bool should render as [ ]");
     }
 
     // ── edit_or_value with editing_buf active ─────────────────────────────────

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -4099,6 +4099,65 @@ mod tests {
     }
 
     #[test]
+    fn render_preferences_footer_app_text_field_shows_edit_hint() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1; // refresh_interval_ms — text edit field
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("Enter:Edit"),
+            "App text field hint should say Enter:Edit; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_preferences_footer_ui_toggle_field_shows_toggle_hint() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 1; // show_account_panel — bool toggle
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("Toggle"),
+            "Ui bool field hint should mention Toggle; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_preferences_footer_notifications_text_field_shows_edit_hint() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Notifications;
+        state.field_index = 1; // fill_notification_ttl_ms — text edit
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("Enter:Edit"),
+            "Notifications text field hint should say Enter:Edit; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn render_preferences_credentials_title_shows_active_env() {
+        let app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        let mut app = make_test_app();
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("active:"),
+            "Credentials pane title should show active env; got:\n{}",
+            output
+        );
+    }
+
+    #[test]
     fn render_preferences_notifications_section() {
         let app = make_test_app();
         let mut state = PrefsState::new(&app.prefs);

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1506,6 +1506,38 @@ fn render_position_detail(frame: &mut Frame, area: Rect, symbol: &str, app: &App
     );
 }
 
+fn prefs_footer_hint(state: &PrefsState) -> String {
+    if state.dropdown.is_some() {
+        return "  ↑/↓:Navigate  Enter:Select  Esc:Close dropdown".to_string();
+    }
+    if state.editing_buf.is_some() {
+        return if state.section == PrefsSection::Credentials {
+            "  Type credential  Enter:Confirm  Esc:Cancel".to_string()
+        } else {
+            "  Type digits  Enter:Confirm  Esc:Cancel".to_string()
+        };
+    }
+    let action = match state.section {
+        PrefsSection::Credentials => "Enter:Edit  Ctrl-S:Keychain",
+        PrefsSection::App => match state.field_index {
+            0 => "Enter:Open dropdown  Ctrl-S:Save",
+            _ => "Enter:Edit  Ctrl-S:Save",
+        },
+        PrefsSection::Ui => match state.field_index {
+            0 | 5 | 6 => "Enter:Open dropdown  Ctrl-S:Save",
+            _ => "Space/Enter:Toggle  Ctrl-S:Save",
+        },
+        PrefsSection::Stream => "Enter:Edit  Ctrl-S:Save",
+        PrefsSection::Notifications => match state.field_index {
+            0 => "Space/Enter:Toggle  Ctrl-S:Save",
+            _ => "Enter:Edit  Ctrl-S:Save",
+        },
+        PrefsSection::Safety => "Space/Enter:Toggle  Ctrl-S:Save",
+        PrefsSection::Proxy => "Enter:Edit  Ctrl-S:Save",
+    };
+    format!("  Tab:Section  ↑/↓:Field  {action}  Esc:Cancel")
+}
+
 fn render_preferences(frame: &mut Frame, area: Rect, state: &PrefsState, app: &App) {
     let popup = popup_area(area, 75, 80);
     frame.render_widget(Clear, popup);
@@ -1555,8 +1587,18 @@ fn render_preferences(frame: &mut Frame, area: Rect, state: &PrefsState, app: &A
     frame.render_widget(sidebar_table, sidebar_inner);
 
     // ── Field pane ────────────────────────────────────────────────────────────
+    let field_pane_title = if state.section == PrefsSection::Credentials {
+        let active = if app.config.env == crate::config::AlpacaEnv::Live {
+            "LIVE"
+        } else {
+            "PAPER"
+        };
+        format!(" Credentials  (active: {active}) ")
+    } else {
+        format!(" {} ", state.section.label())
+    };
     let field_block = Block::default()
-        .title(format!(" {} ", state.section.label()))
+        .title(field_pane_title)
         .borders(Borders::NONE);
     let field_inner = field_block.inner(panes[1]);
     frame.render_widget(field_block, panes[1]);
@@ -1640,8 +1682,7 @@ fn render_preferences(frame: &mut Frame, area: Rect, state: &PrefsState, app: &A
         height: 1,
     };
     frame.render_widget(
-        Paragraph::new("  Tab:Section  ↑/↓:Field  Enter:Edit  Ctrl-S:Save  Esc:Cancel")
-            .style(c.dim_style()),
+        Paragraph::new(prefs_footer_hint(state)).style(c.dim_style()),
         hint_rect,
     );
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -4186,11 +4186,139 @@ mod tests {
         state.field_index = 0;
         state.editing_buf = Some("ABC".to_string());
         let output = render_preferences_to_string(&mut app, &state);
-        // editing shows masked chars + cursor block
         assert!(
             output.contains('▋'),
             "cursor block should appear while editing"
         );
         assert!(output.contains("***"), "editing chars should be masked");
+    }
+
+    // ── Dropdown overlay render ───────────────────────────────────────────────
+
+    #[test]
+    fn render_preferences_with_open_dropdown_shows_options() {
+        use crate::app::DropdownState;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 0; // theme
+        state.dropdown = Some(DropdownState::new(
+            vec!["default", "dark", "high-contrast"],
+            "default",
+        ));
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("default") || output.contains("dark"),
+            "dropdown overlay should render option text"
+        );
+    }
+
+    // ── bool_display false branch ─────────────────────────────────────────────
+
+    #[test]
+    fn render_preferences_bool_false_shows_unchecked() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.draft.ui.show_watchlist = false;
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("[ ]"),
+            "false bool should render as [ ]"
+        );
+    }
+
+    // ── edit_or_value with editing_buf active ─────────────────────────────────
+
+    #[test]
+    fn render_preferences_edit_or_value_shows_buf_with_cursor() {
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::App;
+        state.field_index = 1; // refresh_interval_ms
+        state.editing_buf = Some("250".to_string());
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("250▋"),
+            "edit_or_value should show buf with cursor"
+        );
+    }
+
+    // ── dropdown_or_value with open dropdown ──────────────────────────────────
+
+    #[test]
+    fn render_preferences_dropdown_or_value_shows_selected_with_arrow() {
+        use crate::app::DropdownState;
+        let mut app = make_test_app();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Ui;
+        state.field_index = 0; // theme
+        state.dropdown = Some(DropdownState::new(
+            vec!["default", "dark", "high-contrast"],
+            "dark",
+        ));
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("dark ▾"),
+            "dropdown_or_value should show selected with ▾"
+        );
+    }
+
+    // ── Credentials fallback to app.config for active env ─────────────────────
+
+    #[test]
+    fn render_preferences_credentials_live_env_shows_config_key_as_bullets() {
+        use crate::config::AlpacaEnv;
+        let mut app = make_test_app();
+        app.config.env = AlpacaEnv::Live;
+        app.config.key = "LIVEKEY123".to_string();
+        app.config.secret = "LIVESECRET456".to_string();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        // No live_saved set — falls back to app.config.key for the live env
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(output.contains('●'), "live env key should render as ●");
+        assert!(
+            !output.contains("LIVEKEY123"),
+            "plaintext key must not appear"
+        );
+    }
+
+    #[test]
+    fn render_preferences_credentials_inactive_env_shows_not_set() {
+        use crate::config::AlpacaEnv;
+        let mut app = make_test_app();
+        // Active env is Paper, so Live fields have no source → [ not set ]
+        app.config.env = AlpacaEnv::Paper;
+        app.config.key = "PAPERKEY".to_string();
+        let mut state = PrefsState::new(&app.prefs);
+        state.section = PrefsSection::Credentials;
+        // live_saved is None and env != Live → live key shows [ not set ]
+        let output = render_preferences_to_string(&mut app, &state);
+        assert!(
+            output.contains("[ not set ]"),
+            "inactive env live key should show [ not set ]"
+        );
+    }
+
+    // ── render dispatch covers Preferences variant ────────────────────────────
+
+    #[test]
+    fn render_modal_dispatches_preferences() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let mut app = make_test_app();
+        let state = PrefsState::new(&app.prefs);
+        app.modal = Some(Modal::Preferences(state));
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                if let Some(modal) = &app.modal.clone() {
+                    render(frame, area, modal, &mut app);
+                }
+            })
+            .unwrap();
+        // If we got here without panic, the Preferences dispatch path executed.
     }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1662,7 +1662,7 @@ fn mask_cred(state: &PrefsState, field_idx: usize, buf: &str, saved: Option<&str
     "[ not set ]".to_string()
 }
 
-fn prefs_fields_for_section<'a>(state: &'a PrefsState, app: &App) -> Vec<(&'static str, String)> {
+fn prefs_fields_for_section(state: &PrefsState, app: &App) -> Vec<(&'static str, String)> {
     let d = &state.draft;
     match state.section {
         PrefsSection::Credentials => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -4167,4 +4167,76 @@ mod tests {
         update(&mut app, key(KeyCode::Char('l')));
         assert!(app.equity_chart_cursor.is_none());
     }
+
+    // ── Preferences modal (P key) ─────────────────────────────────────────────
+
+    #[test]
+    fn p_key_opens_preferences_modal() {
+        let (mut app, _rx) = make_app_with_cmd();
+        update(&mut app, key(KeyCode::Char('P')));
+        assert!(
+            matches!(app.modal, Some(Modal::Preferences(_))),
+            "P should open Preferences modal"
+        );
+    }
+
+    #[test]
+    fn p_key_supplements_live_saved_from_in_memory_config_when_live_env() {
+        use crate::config::AlpacaEnv;
+        let (mut app, _rx) = make_app_with_cmd();
+        app.config.env = AlpacaEnv::Live;
+        app.config.key = "LIVE_KEY_IN_MEM".to_string();
+        app.config.secret = "LIVE_SECRET_IN_MEM".to_string();
+        update(&mut app, key(KeyCode::Char('P')));
+        if let Some(Modal::Preferences(ref state)) = app.modal {
+            // When keychain has no entry, live_saved is supplemented from app.config.
+            // If keychain already had an entry, live_saved comes from there — either way no panic.
+            if let Some((k, s)) = &state.live_saved {
+                // The value is either from keychain or from in-memory config.
+                assert!(!k.is_empty(), "live key should not be empty");
+                assert!(!s.is_empty(), "live secret should not be empty");
+            }
+        } else {
+            panic!("expected Preferences modal");
+        }
+    }
+
+    #[test]
+    fn p_key_supplements_paper_saved_from_in_memory_config_when_paper_env() {
+        use crate::config::AlpacaEnv;
+        let (mut app, _rx) = make_app_with_cmd();
+        // make_test_app uses Paper env with non-empty key/secret already.
+        assert_eq!(app.config.env, AlpacaEnv::Paper);
+        assert!(!app.config.key.is_empty());
+        update(&mut app, key(KeyCode::Char('P')));
+        if let Some(Modal::Preferences(ref state)) = app.modal {
+            // paper_saved must be Some — either from keychain or from app.config.
+            assert!(
+                state.paper_saved.is_some(),
+                "paper_saved should be populated when paper env has in-memory creds"
+            );
+        } else {
+            panic!("expected Preferences modal");
+        }
+    }
+
+    #[test]
+    fn p_key_with_empty_in_memory_key_does_not_supplement() {
+        use crate::config::AlpacaEnv;
+        let (mut app, _rx) = make_app_with_cmd();
+        app.config.env = AlpacaEnv::Paper;
+        app.config.key = String::new();
+        app.config.secret = String::new();
+        update(&mut app, key(KeyCode::Char('P')));
+        if let Some(Modal::Preferences(ref state)) = app.modal {
+            // Empty in-memory key must not be used as the supplement value.
+            if let Some((k, _)) = &state.paper_saved {
+                assert!(
+                    !k.is_empty(),
+                    "empty in-memory key must not populate paper_saved"
+                );
+            }
+            // paper_saved may be Some from keychain or None — both are valid.
+        }
+    }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyModifiers};
 
-use crate::app::{App, Modal, StatusMessage, Tab};
+use crate::app::{App, Modal, PrefsState, StatusMessage, Tab};
 use crate::clipboard;
 use crate::commands::Command;
 use crate::events::{Event, StreamKind};
@@ -227,6 +227,9 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
         KeyCode::Char('T') => {
             app.cycle_theme();
             app.push_transient_status(format!("Theme: {}", app.current_theme.display_name()));
+        }
+        KeyCode::Char('P') => {
+            app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
         }
         // Copy focused symbol to clipboard (Watchlist, Positions, Orders)
         KeyCode::Char('c') if app.active_tab != Tab::Orders => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -229,7 +229,26 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) {
             app.push_transient_status(format!("Theme: {}", app.current_theme.display_name()));
         }
         KeyCode::Char('P') => {
-            app.modal = Some(Modal::Preferences(PrefsState::new(&app.prefs)));
+            let mut state = PrefsState::new(&app.prefs);
+            state.live_saved =
+                crate::credentials::load_from_keychain(crate::config::AlpacaEnv::Live);
+            state.paper_saved =
+                crate::credentials::load_from_keychain(crate::config::AlpacaEnv::Paper);
+            // Supplement with in-memory creds for the active env when keychain
+            // returned nothing (e.g. credentials loaded from env vars this session).
+            if state.live_saved.is_none()
+                && app.config.env == crate::config::AlpacaEnv::Live
+                && !app.config.key.is_empty()
+            {
+                state.live_saved = Some((app.config.key.clone(), app.config.secret.clone()));
+            }
+            if state.paper_saved.is_none()
+                && app.config.env == crate::config::AlpacaEnv::Paper
+                && !app.config.key.is_empty()
+            {
+                state.paper_saved = Some((app.config.key.clone(), app.config.secret.clone()));
+            }
+            app.modal = Some(Modal::Preferences(state));
         }
         // Copy focused symbol to clipboard (Watchlist, Positions, Orders)
         KeyCode::Char('c') if app.active_tab != Tab::Orders => {


### PR DESCRIPTION
## Summary

- Adds a full in-app Preferences modal (`P` key) covering App, UI, Stream, Notifications, Safety, Proxy, and Credentials sections
- All 6 non-credential sections support live editing with bool toggles, dropdowns, and numeric text fields; changes apply immediately on Ctrl-S
- Credentials section manages live and paper Alpaca API key/secret pairs independently, writing to the OS keychain (macOS Keychain / Windows Credential Store / Linux keyutils)

## Details

**Preferences modal (`Modal::Preferences`)**
- Two-pane layout: section sidebar (22 cols) + field editor pane
- Dirty indicator (`●`) in title when unsaved changes are present
- Ctrl-S saves and closes; Esc discards; dropdown and text-edit sub-modes close before the modal on Esc
- `save_prefs()` applies draft to `app.prefs`, syncs `app.current_theme` and `app.equity_range`, and writes to disk

**Credentials section**
- 4 fields: `[LIVE] APCA-API-KEY-ID`, `[LIVE] APCA-API-SECRET`, `[PAPER] APCA-API-KEY-ID`, `[PAPER] APCA-API-SECRET`
- Saved values displayed as `●` (masked); in-progress typed values as `*`; unset fields show `[ not set ]`
- Each env pair validated independently on Ctrl-S — partial pair (key without secret or vice versa) shows an env-specific error banner in red and keeps the modal open
- Both pairs can be updated in a single Ctrl-S; only the active env's `app.config` key/secret is synced in-memory
- `credentials::load_from_keychain()` reads both envs at modal open time for display; `credentials::save_to_keychain()` writes on save
- Help modal updated with `P → Open Preferences editor` binding

## Test plan

- [ ] Press `P` to open Preferences modal; verify sidebar shows all 7 sections
- [ ] Toggle a bool field (e.g. `show_watchlist`), Ctrl-S → verify preference persists after restart
- [ ] Change `chart_marker` via dropdown → chart updates on next render
- [ ] Navigate to Credentials, enter live key+secret, Ctrl-S → verify keychain entry via `security find-generic-password -s alpaca-trader-rs` (macOS)
- [ ] Enter only a live key without secret → verify red error banner, modal stays open
- [ ] Enter paper key+secret in same session → both pairs save independently
- [ ] Esc on clean modal closes immediately; Esc on dirty modal discards changes
- [ ] 1123 unit tests: `cargo test`

Closes #169