### PR TITLE
fix(deps): update quinn-proto and anyhow to address security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -2220,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

- **`quinn-proto` 0.11.14 → 0.11.15** — fixes [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185): remote memory exhaustion via unbounded out-of-order stream reassembly (CVSS 7.5 high). Comes in transitively via `reqwest → quinn → quinn-proto`.
- **`anyhow` 1.0.102 → 1.0.103** — fixes [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190): unsoundness (Stacked Borrows violation) in `Error::downcast_mut()`.

Closes dependabot PR #174 (anyhow-only bump) — this PR consolidates both fixes.

## Test plan

- [x] `cargo audit` passes with no vulnerabilities or warnings after update
- [x] Only `Cargo.lock` modified — no `Cargo.toml` changes required (both are transitive/patch updates)