### PR TITLE
Implement price alerts, bulk-clear, Windows TUI fixes, and closed-maket fallbacks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -605,8 +605,7 @@ impl PrefsState {
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     CancelOrder(String),
-    /// User pressed Esc on dirty preferences; stashes the draft so 'n' can restore it.
-    DiscardPrefs(Box<PrefsState>),
+    ClearAllAlerts,
 }
 
 /// Focusable input field in the [`Modal::SetAlert`] dialog.
@@ -1200,8 +1199,8 @@ impl App {
                 let price = self
                     .quotes
                     .get(&p.symbol)
-                    .and_then(|q| q.ap.or(q.bp))
-                    .or_else(|| p.current_price.parse::<f64>().ok())?;
+                    .and_then(|q| q.ap.or(q.bp).filter(|&v| v > 0.0))
+                    .or_else(|| p.current_price.parse::<f64>().ok().filter(|&v| v > 0.0))?;
                 Some(qty * price)
             })
             .sum();
@@ -2301,5 +2300,53 @@ mod tests {
         );
         let c = StatusMessage::persistent("other");
         assert!(a != c);
+    }
+
+    #[test]
+    fn test_push_equity_from_quotes_filters_zero_prices() {
+        use crate::types::Quote;
+        let mut app = make_test_app();
+        app.equity_range = EquityRange::OneDay;
+
+        // Set up cash
+        app.account = Some(crate::types::AccountInfo {
+            cash: "1000.00".to_string(),
+            ..Default::default()
+        });
+
+        // Set up positions
+        app.positions = vec![
+            make_position_with_price("AAPL", "10", "150.00"),
+            make_position_with_price("TSLA", "5", "250.00"),
+        ];
+
+        // 1. Zero/invalid quotes injected
+        app.quotes.insert(
+            "AAPL".to_string(),
+            Quote {
+                symbol: "AAPL".to_string(),
+                ap: Some(0.0),
+                bp: Some(0.0),
+                ..Default::default()
+            },
+        );
+        app.quotes.insert(
+            "TSLA".to_string(),
+            Quote {
+                symbol: "TSLA".to_string(),
+                ap: Some(300.0),
+                bp: None,
+                ..Default::default()
+            },
+        );
+
+        app.push_equity_from_quotes();
+
+        // Cash: 1000.0
+        // AAPL: filters out quote price (0.0) -> falls back to current_price (150.0) * 10 = 1500.0
+        // TSLA: quote price is valid (300.0) * 5 = 1500.0
+        // Total equity = 1000.0 + 1500.0 + 1500.0 = 4000.0
+        // Expected value in cents: 400000
+        assert_eq!(app.equity_history.last(), Some(&400000));
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1014,6 +1014,7 @@ impl App {
         symbol_tx: watch::Sender<Vec<String>>,
     ) -> Self {
         let current_theme = Theme::from_str(&prefs.ui.theme);
+        let price_alerts = prefs.price_alerts.clone();
         Self {
             config,
             prefs,
@@ -1063,7 +1064,7 @@ impl App {
             orders_sort: SortState::default(),
             orders_symbol_filter: String::new(),
             orders_filter_active: false,
-            price_alerts: HashMap::new(),
+            price_alerts,
         }
     }
 
@@ -1192,6 +1193,10 @@ impl App {
             .filter_map(|p| {
                 let qty = p.qty.parse::<f64>().ok()?;
                 // Prefer live quote (ask then bid), fall back to last REST price.
+                // Note: If the market is closed, live quotes can return 0.0. To prevent zero-equity calculation bugs,
+                // we can filter out non-positive values, e.g.:
+                //     .and_then(|q| q.ap.or(q.bp).filter(|&v| v > 0.0))
+                //     .or_else(|| p.current_price.parse::<f64>().ok().filter(|&v| v > 0.0))
                 let price = self
                     .quotes
                     .get(&p.symbol)

--- a/src/app.rs
+++ b/src/app.rs
@@ -606,6 +606,7 @@ impl PrefsState {
 pub enum ConfirmAction {
     CancelOrder(String),
     ClearAllAlerts,
+    DiscardPrefs(Box<PrefsState>),
 }
 
 /// Focusable input field in the [`Modal::SetAlert`] dialog.

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -304,18 +304,10 @@ fn load_one_entry(user: &str) -> Result<Option<String>, KeychainStatus> {
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn offer_keychain_save(prefix: &str, key: &str, secret: &str) {
     eprint!("Store credentials in OS keychain for future logins? [Y/n]: ");
-    #[cfg(target_os = "windows")]
     let answer = match rpassword::read_password() {
         Ok(ans) => ans,
         Err(_) => return,
     };
-
-    #[cfg(not(target_os = "windows"))]
-    let mut answer = String::new();
-    #[cfg(not(target_os = "windows"))]
-    if io::stdin().read_line(&mut answer).is_err() {
-        return;
-    }
     if !(answer.trim().is_empty() || answer.trim().eq_ignore_ascii_case("y")) {
         return;
     }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -14,7 +14,7 @@
 //! Call [`resolve`] **before** `enable_raw_mode()` — it may print to stderr
 //! and read from stdin.
 
-use std::io::{self, BufRead as _, IsTerminal as _};
+use std::io::{self, IsTerminal as _};
 
 use anyhow::{bail, Result};
 
@@ -304,8 +304,16 @@ fn load_one_entry(user: &str) -> Result<Option<String>, KeychainStatus> {
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn offer_keychain_save(prefix: &str, key: &str, secret: &str) {
     eprint!("Store credentials in OS keychain for future logins? [Y/n]: ");
+    #[cfg(target_os = "windows")]
+    let answer = match rpassword::read_password() {
+        Ok(ans) => ans,
+        Err(_) => return,
+    };
+
+    #[cfg(not(target_os = "windows"))]
     let mut answer = String::new();
-    if io::stdin().lock().read_line(&mut answer).is_err() {
+    #[cfg(not(target_os = "windows"))]
+    if io::stdin().read_line(&mut answer).is_err() {
         return;
     }
     if !(answer.trim().is_empty() || answer.trim().eq_ignore_ascii_case("y")) {

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{Event as CEvent, EventStream};
+use crossterm::event::{Event as CEvent, EventStream, KeyEventKind};
 use futures::StreamExt;
 use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
@@ -11,7 +11,7 @@ pub async fn run(tx: Sender<AppEvent>, cancel: CancellationToken) {
         tokio::select! {
             Some(Ok(evt)) = stream.next() => {
                 let event: Option<AppEvent> = match evt {
-                    CEvent::Key(k) => Some(AppEvent::Input(k)),
+                    CEvent::Key(k) if k.kind != KeyEventKind::Release => Some(AppEvent::Input(k)),
                     CEvent::Mouse(m) => Some(AppEvent::Mouse(m)),
                     CEvent::Resize(w, h) => Some(AppEvent::Resize(w, h)),
                     _ => None,

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -418,6 +418,9 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                                 "Cleared all price alerts ({count})"
                             ));
                         }
+                        ConfirmAction::DiscardPrefs(_) => {
+                            app.push_transient_status("Preferences discarded");
+                        }
                     }
                     app.modal = None;
                     return;
@@ -432,6 +435,7 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                 if confirmed {
                     match &action {
                         ConfirmAction::CancelOrder(_) => {}
+                        ConfirmAction::ClearAllAlerts => {}
                         ConfirmAction::DiscardPrefs(_) => {
                             app.push_transient_status("Preferences discarded");
                         }
@@ -1041,10 +1045,8 @@ fn activate_prefs_field(state: &mut PrefsState) {
 /// Apply a confirmed dropdown selection to the draft prefs.
 fn apply_dropdown_selection(state: &mut PrefsState, selected: &str) {
     match state.section {
-        PrefsSection::App => {
-            if state.field_index == 0 {
-                state.draft.app.default_env = selected.to_string();
-            }
+        PrefsSection::App if state.field_index == 0 => {
+            state.draft.app.default_env = selected.to_string();
         }
         PrefsSection::Ui => match state.field_index {
             0 => state.draft.ui.theme = selected.to_string(),
@@ -1067,12 +1069,10 @@ fn apply_dropdown_selection(state: &mut PrefsState, selected: &str) {
 /// Apply a confirmed text-edit buffer to the draft prefs.
 fn apply_text_edit(state: &mut PrefsState, buf: &str) {
     match state.section {
-        PrefsSection::App => {
-            if state.field_index == 1 {
-                if let Ok(v) = buf.parse::<u64>() {
-                    // Floor at 100 ms; 0 would cause infinite-loop polling.
-                    state.draft.app.refresh_interval_ms = v.max(100);
-                }
+        PrefsSection::App if state.field_index == 1 => {
+            if let Ok(v) = buf.parse::<u64>() {
+                // Floor at 100 ms; 0 would cause infinite-loop polling.
+                state.draft.app.refresh_interval_ms = v.max(100);
             }
         }
         PrefsSection::Stream => match state.field_index {

--- a/src/input/modal.rs
+++ b/src/input/modal.rs
@@ -411,8 +411,12 @@ pub(crate) fn handle_modal_key(app: &mut App, key: crossterm::event::KeyEvent) {
                                 format!("Cancelling {}…", &id[..id.len().min(8)]),
                             );
                         }
-                        ConfirmAction::DiscardPrefs(_) => {
-                            app.push_transient_status("Preferences discarded");
+                        ConfirmAction::ClearAllAlerts => {
+                            let count = app.price_alerts.len();
+                            app.price_alerts.clear();
+                            app.push_transient_status(format!(
+                                "Cleared all price alerts ({count})"
+                            ));
                         }
                     }
                     app.modal = None;

--- a/src/input/watchlist.rs
+++ b/src/input/watchlist.rs
@@ -57,9 +57,17 @@ pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEven
         }
         // 'C' (uppercase) — clear all price alerts.
         KeyCode::Char('C') => {
-            let count = app.price_alerts.len();
-            app.price_alerts.clear();
-            app.push_transient_status(format!("Cleared all price alerts ({count})"));
+            if app.prefs.safety.confirm_watchlist_remove {
+                app.modal = Some(Modal::Confirm {
+                    message: format!("Clear all {} price alerts?", app.price_alerts.len()),
+                    action: crate::app::ConfirmAction::ClearAllAlerts,
+                    confirmed: false,
+                });
+            } else {
+                let count = app.price_alerts.len();
+                app.price_alerts.clear();
+                app.push_transient_status(format!("Cleared all price alerts ({count})"));
+            }
         }
         KeyCode::Char('d') => {
             if let (Some(symbol), Some(wl)) =

--- a/src/input/watchlist.rs
+++ b/src/input/watchlist.rs
@@ -55,6 +55,12 @@ pub(crate) fn handle_watchlist_key(app: &mut App, key: crossterm::event::KeyEven
                 });
             }
         }
+        // 'C' (uppercase) — clear all price alerts.
+        KeyCode::Char('C') => {
+            let count = app.price_alerts.len();
+            app.price_alerts.clear();
+            app.push_transient_status(format!("Cleared all price alerts ({count})"));
+        }
         KeyCode::Char('d') => {
             if let (Some(symbol), Some(wl)) =
                 (app.selected_watchlist_symbol(), app.watchlist.as_ref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,13 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Cleanup ────────────────────────────────────────────────────────────────
     tracing::info!("shutting down");
+    if let Some(path) = AppPrefs::default_path() {
+        app.prefs.price_alerts = app.price_alerts.clone();
+        if let Err(e) = app.prefs.write_to(&path) {
+            tracing::error!(error = %e, "failed to save price alerts on exit");
+        }
+    }
+
     cancel.cancel();
     disable_raw_mode()?;
     execute!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,9 +263,11 @@ async fn main() -> anyhow::Result<()> {
     // ── Cleanup ────────────────────────────────────────────────────────────────
     tracing::info!("shutting down");
     if let Some(path) = AppPrefs::default_path() {
-        app.prefs.price_alerts = app.price_alerts.clone();
-        if let Err(e) = app.prefs.write_to(&path) {
-            tracing::error!(error = %e, "failed to save price alerts on exit");
+        if app.price_alerts != app.prefs.price_alerts {
+            app.prefs.price_alerts = app.price_alerts.clone();
+            if let Err(e) = app.prefs.write_to(&path) {
+                tracing::error!(error = %e, "failed to save price alerts on exit");
+            }
         }
     }
 

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -662,16 +662,22 @@ chart_marker = "dot"
     fn price_alerts_round_trip() {
         let mut p = AppPrefs::default();
         let mut alerts = HashMap::new();
-        alerts.insert("AAPL".to_string(), crate::types::PriceAlert {
-            above: Some(185.0),
-            below: Some(170.0),
-            ..Default::default()
-        });
-        alerts.insert("TSLA".to_string(), crate::types::PriceAlert {
-            above: Some(250.5),
-            below: None,
-            ..Default::default()
-        });
+        alerts.insert(
+            "AAPL".to_string(),
+            crate::types::PriceAlert {
+                above: Some(185.0),
+                below: Some(170.0),
+                ..Default::default()
+            },
+        );
+        alerts.insert(
+            "TSLA".to_string(),
+            crate::types::PriceAlert {
+                above: Some(250.5),
+                below: None,
+                ..Default::default()
+            },
+        );
         p.price_alerts = alerts;
         let toml_str = p.to_toml_string();
         let p2: AppPrefs = toml::from_str(&toml_str).unwrap();

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -401,6 +401,12 @@ confirm_watchlist_remove = {confirm_remove}
                         if let Some(below) = alert.below {
                             parts.push(format!("below = {below}"));
                         }
+                        if alert.above_triggered {
+                            parts.push("above_triggered = true".to_string());
+                        }
+                        if alert.below_triggered {
+                            parts.push("below_triggered = true".to_string());
+                        }
                         toml_str.push_str(&format!("\"{key}\" = {{ {} }}\n", parts.join(", ")));
                     }
                 }
@@ -691,7 +697,8 @@ chart_marker = "dot"
             crate::types::PriceAlert {
                 above: Some(185.0),
                 below: Some(170.0),
-                ..Default::default()
+                above_triggered: true,
+                below_triggered: false,
             },
         );
         alerts.insert(
@@ -699,7 +706,8 @@ chart_marker = "dot"
             crate::types::PriceAlert {
                 above: Some(250.5),
                 below: None,
-                ..Default::default()
+                above_triggered: false,
+                below_triggered: true,
             },
         );
         alerts.insert(
@@ -707,7 +715,8 @@ chart_marker = "dot"
             crate::types::PriceAlert {
                 above: Some(350.0),
                 below: Some(340.0),
-                ..Default::default()
+                above_triggered: true,
+                below_triggered: true,
             },
         );
         p.price_alerts = alerts;

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -298,6 +298,25 @@ impl AppPrefs {
     /// Serialises to a TOML string with descriptive comments for each
     /// section.
     pub fn to_toml_string(&self) -> String {
+        let proxy_http = self
+            .proxy
+            .http
+            .as_deref()
+            .map(|v| format!("http   = \"{v}\""))
+            .unwrap_or_else(|| "# http   = \"http://proxy.corp.com:8080\"".into());
+        let proxy_socks5 = self
+            .proxy
+            .socks5
+            .as_deref()
+            .map(|v| format!("socks5 = \"{v}\""))
+            .unwrap_or_else(|| "# socks5 = \"socks5://proxy.corp.com:1080\"".into());
+        let proxy_no_proxy = self
+            .proxy
+            .no_proxy
+            .as_deref()
+            .map(|v| format!("no_proxy = \"{v}\""))
+            .unwrap_or_else(|| "# no_proxy = \"localhost,127.0.0.1\"".into());
+
         let mut toml_str = format!(
             r#"# alpaca-trader configuration
 # Generated automatically on first launch. Edit and restart to apply changes.
@@ -344,7 +363,9 @@ confirm_watchlist_remove = {confirm_remove}
 
 [proxy]
 # Leave commented to use HTTP_PROXY / HTTPS_PROXY environment variables
-# http   = "http://proxy.corp.com:8080"
+{proxy_http}
+{proxy_socks5}
+{proxy_no_proxy}
 "#,
             default_env = self.app.default_env,
             refresh_ms = self.app.refresh_interval_ms,
@@ -361,6 +382,9 @@ confirm_watchlist_remove = {confirm_remove}
             fill_ttl = self.notifications.fill_notification_ttl_ms,
             status_ttl = self.notifications.status_message_ttl_ms,
             confirm_remove = self.safety.confirm_watchlist_remove,
+            proxy_http = proxy_http,
+            proxy_socks5 = proxy_socks5,
+            proxy_no_proxy = proxy_no_proxy,
         );
 
         if !self.price_alerts.is_empty() {
@@ -377,7 +401,7 @@ confirm_watchlist_remove = {confirm_remove}
                         if let Some(below) = alert.below {
                             parts.push(format!("below = {below}"));
                         }
-                        toml_str.push_str(&format!("{key} = {{ {} }}\n", parts.join(", ")));
+                        toml_str.push_str(&format!("\"{key}\" = {{ {} }}\n", parts.join(", ")));
                     }
                 }
             }
@@ -678,9 +702,29 @@ chart_marker = "dot"
                 ..Default::default()
             },
         );
+        alerts.insert(
+            "BRK.B".to_string(),
+            crate::types::PriceAlert {
+                above: Some(350.0),
+                below: Some(340.0),
+                ..Default::default()
+            },
+        );
         p.price_alerts = alerts;
         let toml_str = p.to_toml_string();
         let p2: AppPrefs = toml::from_str(&toml_str).unwrap();
         assert_eq!(p.price_alerts, p2.price_alerts);
+    }
+
+    #[test]
+    fn proxy_round_trip() {
+        let mut p = AppPrefs::default();
+        p.proxy.http = Some("http://proxy.corp.com:8080".to_string());
+        p.proxy.socks5 = Some("socks5://proxy.corp.com:1080".to_string());
+        p.proxy.no_proxy = Some("localhost,127.0.0.1".to_string());
+
+        let toml_str = p.to_toml_string();
+        let p2: AppPrefs = toml::from_str(&toml_str).unwrap();
+        assert_eq!(p.proxy, p2.proxy);
     }
 }

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -11,6 +11,7 @@
 //! 2. Environment variables (`PAPER_ALPACA_*`, `LIVE_ALPACA_*`)
 //! 3. `config.toml` preferences (this module)
 //! 4. Compiled defaults (defined via `Default` impls below)
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -220,6 +221,9 @@ pub struct AppPrefs {
     pub safety: SafetySection,
     /// Proxy settings (`[proxy]` section).
     pub proxy: ProxySection,
+    /// Price alerts per symbol (`[price_alerts]` section).
+    #[serde(default)]
+    pub price_alerts: HashMap<String, crate::types::PriceAlert>,
 }
 
 impl AppPrefs {
@@ -294,7 +298,7 @@ impl AppPrefs {
     /// Serialises to a TOML string with descriptive comments for each
     /// section.
     pub fn to_toml_string(&self) -> String {
-        format!(
+        let mut toml_str = format!(
             r#"# alpaca-trader configuration
 # Generated automatically on first launch. Edit and restart to apply changes.
 # Credentials (API keys) are stored separately in the OS keychain, never here.
@@ -309,35 +313,38 @@ refresh_interval_ms = {refresh_ms}
 [ui]
 # Colour theme. Accepted values: "default" | "dark" | "high-contrast"
 theme = "{theme}"
+# Toggle dashboard panels. All default to true.
 show_account_panel = {show_account}
 show_watchlist     = {show_watchlist}
 show_positions     = {show_positions}
 show_orders        = {show_orders}
-# Default equity chart range. Accepted values: "1D" | "1W" | "1M" | "YTD"
+# Default historical date range for the equity chart.
+# Accepted values: "1D" | "5D" | "1M" | "3M" | "1Y" | "ALL"
 default_equity_range = "{equity_range}"
-# Chart marker style. Accepted values: "braille" | "dot" | "block" | "bar" | "half_block"
+# Visual marker style for chart data points.
+# Accepted values: "dot" | "block" | "braille"
 chart_marker = "{chart_marker}"
 
 [stream]
-# Max reconnect attempts (0 = unlimited)
-reconnect_max_attempts = {reconnect_max}
-# Base backoff between reconnects in milliseconds (doubles each attempt, capped at 30 s)
+# WebSocket reconnection tuning.
+reconnect_max_attempts    = {reconnect_max}
 reconnect_backoff_base_ms = {reconnect_base}
 
 [notifications]
+# Toggle desktop notification popups for order execution fills.
 fill_notifications_enabled = {fill_enabled}
+# Notification display duration in milliseconds.
 fill_notification_ttl_ms   = {fill_ttl}
+# TUI status bar message duration in milliseconds.
 status_message_ttl_ms      = {status_ttl}
 
 [safety]
-# Prompt for confirmation before removing a watchlist symbol
+# Require user confirmation before removing a symbol from the watchlist.
 confirm_watchlist_remove = {confirm_remove}
 
 [proxy]
 # Leave commented to use HTTP_PROXY / HTTPS_PROXY environment variables
 # http   = "http://proxy.corp.com:8080"
-# socks5 = "socks5://proxy.corp.com:1080"
-# no_proxy = "localhost,127.0.0.1"
 "#,
             default_env = self.app.default_env,
             refresh_ms = self.app.refresh_interval_ms,
@@ -354,7 +361,29 @@ confirm_watchlist_remove = {confirm_remove}
             fill_ttl = self.notifications.fill_notification_ttl_ms,
             status_ttl = self.notifications.status_message_ttl_ms,
             confirm_remove = self.safety.confirm_watchlist_remove,
-        )
+        );
+
+        if !self.price_alerts.is_empty() {
+            toml_str.push_str("\n[price_alerts]\n");
+            let mut sorted_keys: Vec<&String> = self.price_alerts.keys().collect();
+            sorted_keys.sort();
+            for key in sorted_keys {
+                if let Some(alert) = self.price_alerts.get(key) {
+                    if alert.above.is_some() || alert.below.is_some() {
+                        let mut parts = Vec::new();
+                        if let Some(above) = alert.above {
+                            parts.push(format!("above = {above}"));
+                        }
+                        if let Some(below) = alert.below {
+                            parts.push(format!("below = {below}"));
+                        }
+                        toml_str.push_str(&format!("{key} = {{ {} }}\n", parts.join(", ")));
+                    }
+                }
+            }
+        }
+
+        toml_str
     }
 
     /// Returns the configured status-message TTL as a [`Duration`].
@@ -627,5 +656,25 @@ chart_marker = "dot"
             AppPrefs::default(),
             "write failure path should still return defaults"
         );
+    }
+
+    #[test]
+    fn price_alerts_round_trip() {
+        let mut p = AppPrefs::default();
+        let mut alerts = HashMap::new();
+        alerts.insert("AAPL".to_string(), crate::types::PriceAlert {
+            above: Some(185.0),
+            below: Some(170.0),
+            ..Default::default()
+        });
+        alerts.insert("TSLA".to_string(), crate::types::PriceAlert {
+            above: Some(250.5),
+            below: None,
+            ..Default::default()
+        });
+        p.price_alerts = alerts;
+        let toml_str = p.to_toml_string();
+        let p2: AppPrefs = toml::from_str(&toml_str).unwrap();
+        assert_eq!(p.price_alerts, p2.price_alerts);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -826,15 +826,19 @@ pub struct PortfolioHistory {
 ///
 /// The alert fires when a real-time quote crosses the threshold: the status bar
 /// flashes a message and the terminal bell (`\x07`) is written to stdout.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct PriceAlert {
     /// Trigger when the ask or mid price rises **above** this threshold.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub above: Option<f64>,
     /// Trigger when the ask or mid price falls **below** this threshold.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub below: Option<f64>,
     /// Tracks whether the "above" alert has already fired this session,
     /// so it doesn't re-trigger on every subsequent tick above the threshold.
+    #[serde(skip, default)]
     pub above_triggered: bool,
     /// Tracks whether the "below" alert has already fired this session.
+    #[serde(skip, default)]
     pub below_triggered: bool,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -821,8 +821,9 @@ pub struct PortfolioHistory {
 /// An in-memory price alert for a single watchlist symbol.
 ///
 /// Both bounds are optional; a symbol can have an upper bound, a lower bound,
-/// or both simultaneously.  Alerts are session-only by default — they are not
-/// persisted to disk.
+/// or both simultaneously.  Alerts and their triggered state are persisted
+/// to disk so a restart doesn't re-fire a bell for a breach that was already
+/// acknowledged.
 ///
 /// The alert fires when a real-time quote crosses the threshold: the status bar
 /// flashes a message and the terminal bell (`\x07`) is written to stdout.
@@ -834,11 +835,13 @@ pub struct PriceAlert {
     /// Trigger when the ask or mid price falls **below** this threshold.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub below: Option<f64>,
-    /// Tracks whether the "above" alert has already fired this session,
-    /// so it doesn't re-trigger on every subsequent tick above the threshold.
-    #[serde(skip, default)]
+    /// Tracks whether the "above" alert has already fired, so it doesn't
+    /// re-trigger on every subsequent tick above the threshold (including
+    /// across restarts). Resets when the price retreats below the threshold.
+    #[serde(default)]
     pub above_triggered: bool,
-    /// Tracks whether the "below" alert has already fired this session.
-    #[serde(skip, default)]
+    /// Tracks whether the "below" alert has already fired. Resets when the
+    /// price retreats above the threshold.
+    #[serde(default)]
     pub below_triggered: bool,
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -672,14 +672,15 @@ fn render_ohlcv_section(
     let daily = snapshot.and_then(|s| s.daily_bar.as_ref());
     let prev = snapshot.and_then(|s| s.prev_daily_bar.as_ref());
 
+    let clean = |p: Option<f64>| p.filter(|&v| v > 0.0);
     let price: Option<f64> = quote
-        .and_then(|q| match (q.ap, q.bp) {
+        .and_then(|q| match (clean(q.ap), clean(q.bp)) {
             (Some(a), Some(b)) => Some((a + b) / 2.0),
             (Some(a), None) => Some(a),
             (None, Some(b)) => Some(b),
             _ => None,
         })
-        .or_else(|| daily.map(|b| b.c));
+        .or_else(|| daily.map(|b| b.c).filter(|&v| v > 0.0));
 
     let change_pct: Option<f64> = price.zip(prev.map(|b| b.c)).map(|(p, pc)| {
         if pc != 0.0 {

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -680,7 +680,7 @@ fn render_ohlcv_section(
             (None, Some(b)) => Some(b),
             _ => None,
         })
-        .or_else(|| daily.map(|b| b.c).filter(|&v| v > 0.0));
+        .or_else(|| clean(daily.map(|b| b.c)));
 
     let change_pct: Option<f64> = price.zip(prev.map(|b| b.c)).map(|(p, pc)| {
         if pc != 0.0 {

--- a/src/ui/positions.rs
+++ b/src/ui/positions.rs
@@ -91,11 +91,11 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     let mut rows: Vec<Row> = sorted
         .iter()
         .map(|p| {
-            let clean = |v: f64| if v > 0.0 { Some(v) } else { None };
+            let clean = |p: Option<f64>| p.filter(|&v| v > 0.0);
             let cur_price = app
                 .quotes
                 .get(&p.symbol)
-                .and_then(|q| q.ap.or(q.bp).and_then(clean))
+                .and_then(|q| clean(q.ap).or_else(|| clean(q.bp)))
                 .map(|v| format!("${:.2}", v))
                 .unwrap_or_else(|| format_price(&p.current_price));
 
@@ -700,6 +700,26 @@ mod tests {
             "MSFT".into(),
             Quote {
                 ap: None,
+                bp: Some(299.50),
+                ..Default::default()
+            },
+        );
+        let output = render_positions_to_string(&mut app);
+        assert!(
+            output.contains("299.50"),
+            "expected live bid price in cur-price column, got: {output}"
+        );
+    }
+
+    #[test]
+    fn positions_live_quote_bid_used_when_ask_is_zero() {
+        use crate::types::Quote;
+        let mut app = make_test_app();
+        app.positions.push(make_position("MSFT", "50.00"));
+        app.quotes.insert(
+            "MSFT".into(),
+            Quote {
+                ap: Some(0.0),
                 bp: Some(299.50),
                 ..Default::default()
             },

--- a/src/ui/positions.rs
+++ b/src/ui/positions.rs
@@ -91,10 +91,11 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     let mut rows: Vec<Row> = sorted
         .iter()
         .map(|p| {
+            let clean = |v: f64| if v > 0.0 { Some(v) } else { None };
             let cur_price = app
                 .quotes
                 .get(&p.symbol)
-                .and_then(|q| q.ap.or(q.bp))
+                .and_then(|q| q.ap.or(q.bp).and_then(clean))
                 .map(|v| format!("${:.2}", v))
                 .unwrap_or_else(|| format_price(&p.current_price));
 

--- a/src/ui/watchlist.rs
+++ b/src/ui/watchlist.rs
@@ -98,16 +98,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             let quote = app.quotes.get(&asset.symbol);
             let snapshot = app.snapshots.get(&asset.symbol);
 
-            // Current price: prefer real-time ask/bid quote, fall back to
-            // snapshot latest quote, then latest trade (works when market closed).
-            let current_price = quote.and_then(|q| q.ap.or(q.bp)).or_else(|| {
-                snapshot.and_then(|s| {
-                    s.latest_quote
-                        .as_ref()
-                        .and_then(|lq| lq.ap.or(lq.bp))
-                        .or_else(|| s.latest_trade.as_ref().map(|lt| lt.p))
-                })
-            });
+            let clean = |p: Option<f64>| p.filter(|&v| v > 0.0);
+            let current_price = quote
+                .and_then(|q| clean(q.ap).or_else(|| clean(q.bp)))
+                .or_else(|| {
+                    snapshot.and_then(|s| {
+                        s.latest_quote
+                            .as_ref()
+                            .and_then(|lq| clean(lq.ap).or_else(|| clean(lq.bp)))
+                            .or_else(|| s.latest_trade.as_ref().and_then(|lt| clean(Some(lt.p))))
+                    })
+                });
 
             let price_text = current_price
                 .map(|p| format!("${:.2}", p))
@@ -423,5 +424,52 @@ mod tests {
             output.contains("-10.00%"),
             "expected negative pct change, got: {output}"
         );
+    }
+
+    #[test]
+    fn test_e2e_set_price_alert_renders_bell() {
+        use crate::update::update;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let key = |code: KeyCode| {
+            crate::events::Event::Input(KeyEvent::new(code, KeyModifiers::NONE))
+        };
+        let shift_key = |code: KeyCode| {
+            crate::events::Event::Input(KeyEvent::new(code, KeyModifiers::SHIFT))
+        };
+
+        // 1. App starts with watchlist AAPL
+        let mut app = make_test_app();
+        app.active_tab = crate::app::Tab::Watchlist;
+        app.watchlist = Some(make_watchlist(&["AAPL"]));
+        app.watchlist_state.select(Some(0));
+
+        // 2. Render watchlist - verify NO bell icon initially
+        let output = render_watchlist_to_string(&mut app);
+        assert!(!output.contains("AAPL 🔔"));
+
+        // 3. Press Shift-A (uppercase A) to open SetAlert modal
+        update(&mut app, shift_key(KeyCode::Char('A')));
+        assert!(matches!(app.modal, Some(crate::app::Modal::SetAlert { .. })));
+
+        // 4. Input "185.00" into the active "above" field
+        update(&mut app, key(KeyCode::Char('1')));
+        update(&mut app, key(KeyCode::Char('8')));
+        update(&mut app, key(KeyCode::Char('5')));
+        update(&mut app, key(KeyCode::Char('.')));
+        update(&mut app, key(KeyCode::Char('0')));
+        update(&mut app, key(KeyCode::Char('0')));
+
+        // 5. Press Enter to save the alert
+        update(&mut app, key(KeyCode::Enter));
+
+        // 6. Verify modal is closed and alert is stored in app.price_alerts
+        assert!(app.modal.is_none());
+        let alert = app.price_alerts.get("AAPL").expect("alert should be set");
+        assert_eq!(alert.above, Some(185.0));
+
+        // 7. Render watchlist - verify AAPL 🔔 is now rendered
+        let output2 = render_watchlist_to_string(&mut app);
+        assert!(output2.contains("AAPL 🔔"), "expected AAPL 🔔 in output, got:\n{}", output2);
     }
 }

--- a/src/ui/watchlist.rs
+++ b/src/ui/watchlist.rs
@@ -431,12 +431,10 @@ mod tests {
         use crate::update::update;
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-        let key = |code: KeyCode| {
-            crate::events::Event::Input(KeyEvent::new(code, KeyModifiers::NONE))
-        };
-        let shift_key = |code: KeyCode| {
-            crate::events::Event::Input(KeyEvent::new(code, KeyModifiers::SHIFT))
-        };
+        let key =
+            |code: KeyCode| crate::events::Event::Input(KeyEvent::new(code, KeyModifiers::NONE));
+        let shift_key =
+            |code: KeyCode| crate::events::Event::Input(KeyEvent::new(code, KeyModifiers::SHIFT));
 
         // 1. App starts with watchlist AAPL
         let mut app = make_test_app();
@@ -450,7 +448,10 @@ mod tests {
 
         // 3. Press Shift-A (uppercase A) to open SetAlert modal
         update(&mut app, shift_key(KeyCode::Char('A')));
-        assert!(matches!(app.modal, Some(crate::app::Modal::SetAlert { .. })));
+        assert!(matches!(
+            app.modal,
+            Some(crate::app::Modal::SetAlert { .. })
+        ));
 
         // 4. Input "185.00" into the active "above" field
         update(&mut app, key(KeyCode::Char('1')));
@@ -470,6 +471,10 @@ mod tests {
 
         // 7. Render watchlist - verify AAPL 🔔 is now rendered
         let output2 = render_watchlist_to_string(&mut app);
-        assert!(output2.contains("AAPL 🔔"), "expected AAPL 🔔 in output, got:\n{}", output2);
+        assert!(
+            output2.contains("AAPL 🔔"),
+            "expected AAPL 🔔 in output, got:\n{}",
+            output2
+        );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -381,8 +381,9 @@ fn fill_notification_text(order: &crate::types::Order, event_type: &str) -> Opti
 /// the boundary (i.e. the condition is no longer met), allowing the alert to
 /// fire again if the price subsequently crosses the threshold once more.
 fn evaluate_price_alert(app: &mut App, q: &crate::types::Quote) {
+    let clean = |p: Option<f64>| p.filter(|&v| v > 0.0);
     // Derive mid-price from ask / bid; skip if no price is available.
-    let price = match (q.ap, q.bp) {
+    let price = match (clean(q.ap), clean(q.bp)) {
         (Some(a), Some(b)) => (a + b) / 2.0,
         (Some(a), None) => a,
         (None, Some(b)) => b,
@@ -1279,6 +1280,29 @@ mod tests {
             }
             other => panic!("expected SetAlert modal, got: {:?}", other),
         }
+    }
+
+    #[test]
+    fn watchlist_uppercase_c_clears_all_alerts() {
+        let mut app = watchlist_app();
+        app.price_alerts.insert(
+            "AAPL".into(),
+            crate::types::PriceAlert {
+                above: Some(200.0),
+                ..Default::default()
+            },
+        );
+        app.price_alerts.insert(
+            "MSFT".into(),
+            crate::types::PriceAlert {
+                below: Some(300.0),
+                ..Default::default()
+            },
+        );
+        assert_eq!(app.price_alerts.len(), 2);
+        update(&mut app, key(KeyCode::Char('C')));
+        assert!(app.price_alerts.is_empty());
+        assert!(app.current_status_text().contains("Cleared all price alerts (2)"));
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -392,6 +392,28 @@ fn evaluate_price_alert(app: &mut App, q: &crate::types::Quote) {
 
     let symbol = q.symbol.clone();
 
+    // Derive the previous price from the previous quote (if any) or snapshot (if any).
+    let prev_price = app
+        .quotes
+        .get(&symbol)
+        .map(|prev_q| match (clean(prev_q.ap), clean(prev_q.bp)) {
+            (Some(a), Some(b)) => (a + b) / 2.0,
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            _ => 0.0,
+        })
+        .filter(|&p| p > 0.0)
+        .or_else(|| {
+            app.snapshots.get(&symbol).and_then(|s| {
+                let clean_f64 = |val: f64| if val > 0.0 { Some(val) } else { None };
+                s.latest_trade
+                    .as_ref()
+                    .and_then(|t| clean_f64(t.p))
+                    .or_else(|| s.daily_bar.as_ref().and_then(|b| clean_f64(b.c)))
+                    .or_else(|| s.prev_daily_bar.as_ref().and_then(|b| clean_f64(b.c)))
+            })
+        });
+
     // Collect threshold values and current trigger states up front so we
     // don't hold a mutable borrow on `app.price_alerts` while calling the
     // status-push helpers (which also borrow `app` mutably).
@@ -412,15 +434,18 @@ fn evaluate_price_alert(app: &mut App, q: &crate::types::Quote) {
     if let Some(threshold) = above {
         if price >= threshold {
             if !above_triggered {
-                // Mark triggered.
+                let is_crossing = prev_price.is_some_and(|prev| prev < threshold);
+                if is_crossing {
+                    let msg = format!(
+                        "🔔 {symbol} above ${threshold:.2} — alert triggered! (${price:.2})"
+                    );
+                    app.push_transient_status(msg);
+                    // Ring the terminal bell.
+                    let _ = std::io::Write::write_all(&mut std::io::stdout(), b"\x07");
+                }
                 if let Some(a) = app.price_alerts.get_mut(&symbol) {
                     a.above_triggered = true;
                 }
-                let msg =
-                    format!("🔔 {symbol} above ${threshold:.2} — alert triggered! (${price:.2})");
-                app.push_transient_status(msg);
-                // Ring the terminal bell.
-                let _ = std::io::Write::write_all(&mut std::io::stdout(), b"\x07");
             }
         } else if above_triggered {
             // Price retreated below the threshold — reset so it can fire again.
@@ -434,13 +459,17 @@ fn evaluate_price_alert(app: &mut App, q: &crate::types::Quote) {
     if let Some(threshold) = below {
         if price <= threshold {
             if !below_triggered {
+                let is_crossing = prev_price.is_some_and(|prev| prev > threshold);
+                if is_crossing {
+                    let msg = format!(
+                        "🔔 {symbol} below ${threshold:.2} — alert triggered! (${price:.2})"
+                    );
+                    app.push_transient_status(msg);
+                    let _ = std::io::Write::write_all(&mut std::io::stdout(), b"\x07");
+                }
                 if let Some(a) = app.price_alerts.get_mut(&symbol) {
                     a.below_triggered = true;
                 }
-                let msg =
-                    format!("🔔 {symbol} below ${threshold:.2} — alert triggered! (${price:.2})");
-                app.push_transient_status(msg);
-                let _ = std::io::Write::write_all(&mut std::io::stdout(), b"\x07");
             }
         } else if below_triggered {
             // Price risen back above the threshold — reset.
@@ -1285,6 +1314,7 @@ mod tests {
     #[test]
     fn watchlist_uppercase_c_clears_all_alerts() {
         let mut app = watchlist_app();
+        app.prefs.safety.confirm_watchlist_remove = false;
         app.price_alerts.insert(
             "AAPL".into(),
             crate::types::PriceAlert {
@@ -1302,6 +1332,40 @@ mod tests {
         assert_eq!(app.price_alerts.len(), 2);
         update(&mut app, key(KeyCode::Char('C')));
         assert!(app.price_alerts.is_empty());
+        assert!(app
+            .current_status_text()
+            .contains("Cleared all price alerts (2)"));
+    }
+
+    #[test]
+    fn watchlist_uppercase_c_with_confirmation_clears_all_alerts() {
+        let mut app = watchlist_app();
+        app.prefs.safety.confirm_watchlist_remove = true;
+        app.price_alerts.insert(
+            "AAPL".into(),
+            crate::types::PriceAlert {
+                above: Some(200.0),
+                ..Default::default()
+            },
+        );
+        app.price_alerts.insert(
+            "MSFT".into(),
+            crate::types::PriceAlert {
+                below: Some(300.0),
+                ..Default::default()
+            },
+        );
+        assert_eq!(app.price_alerts.len(), 2);
+
+        // 1. Press Shift-C -> opens Modal::Confirm
+        update(&mut app, key(KeyCode::Char('C')));
+        assert_eq!(app.price_alerts.len(), 2); // not cleared yet
+        assert!(matches!(app.modal, Some(Modal::Confirm { .. })));
+
+        // 2. Press 'y' inside the modal to confirm -> clears alerts
+        update(&mut app, key(KeyCode::Char('y')));
+        assert!(app.price_alerts.is_empty());
+        assert!(app.modal.is_none());
         assert!(app
             .current_status_text()
             .contains("Cleared all price alerts (2)"));
@@ -1340,6 +1404,8 @@ mod tests {
                 ..Default::default()
             },
         );
+        update(&mut app, Event::MarketQuote(make_quote("AAPL", 199.0)));
+        app.status_queue.clear();
         update(&mut app, Event::MarketQuote(make_quote("AAPL", 201.0)));
         assert!(
             app.current_status_text().contains("above"),
@@ -1384,6 +1450,8 @@ mod tests {
                 ..Default::default()
             },
         );
+        update(&mut app, Event::MarketQuote(make_quote("AAPL", 199.0)));
+        app.status_queue.clear();
         update(&mut app, Event::MarketQuote(make_quote("AAPL", 201.0)));
         let first_status = app.current_status_text().to_string();
         // Second tick still above threshold — should NOT fire again.
@@ -1432,6 +1500,8 @@ mod tests {
                 ..Default::default()
             },
         );
+        update(&mut app, Event::MarketQuote(make_quote("AAPL", 151.0)));
+        app.status_queue.clear();
         update(&mut app, Event::MarketQuote(make_quote("AAPL", 149.0)));
         assert!(
             app.current_status_text().contains("below"),
@@ -1459,6 +1529,8 @@ mod tests {
                 ..Default::default()
             },
         );
+        update(&mut app, Event::MarketQuote(make_quote("AAPL", 199.0)));
+        app.status_queue.clear();
         // Ask=201, bid=199 → mid = 200.0; exactly at threshold → fires.
         let q = crate::types::Quote {
             symbol: "AAPL".into(),
@@ -1470,6 +1542,59 @@ mod tests {
         assert!(
             app.price_alerts["AAPL"].above_triggered,
             "mid-price at threshold should trigger alert"
+        );
+    }
+
+    #[test]
+    fn alert_uses_bid_price_when_only_bid_present() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.price_alerts.insert(
+            "AAPL".into(),
+            crate::types::PriceAlert {
+                above: Some(200.0),
+                ..Default::default()
+            },
+        );
+        update(&mut app, Event::MarketQuote(make_quote("AAPL", 199.0)));
+        app.status_queue.clear();
+        let q = crate::types::Quote {
+            symbol: "AAPL".into(),
+            ap: None,
+            bp: Some(205.0),
+            ..Default::default()
+        };
+        update(&mut app, Event::MarketQuote(q));
+        assert!(
+            app.price_alerts["AAPL"].above_triggered,
+            "bid price should trigger alert if ask is missing"
+        );
+    }
+
+    #[test]
+    fn alert_skipped_when_quote_has_zero_prices() {
+        let (mut app, _rx) = make_app_with_cmd();
+        app.price_alerts.insert(
+            "AAPL".into(),
+            crate::types::PriceAlert {
+                above: Some(200.0),
+                below: Some(100.0),
+                ..Default::default()
+            },
+        );
+        let q = crate::types::Quote {
+            symbol: "AAPL".into(),
+            ap: Some(0.0),
+            bp: Some(0.0),
+            ..Default::default()
+        };
+        update(&mut app, Event::MarketQuote(q));
+        assert!(
+            !app.price_alerts["AAPL"].above_triggered,
+            "0.0 price should be filtered out and not trigger above alert"
+        );
+        assert!(
+            !app.price_alerts["AAPL"].below_triggered,
+            "0.0 price should be filtered out and not trigger below alert"
         );
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -1302,7 +1302,9 @@ mod tests {
         assert_eq!(app.price_alerts.len(), 2);
         update(&mut app, key(KeyCode::Char('C')));
         assert!(app.price_alerts.is_empty());
-        assert!(app.current_status_text().contains("Cleared all price alerts (2)"));
+        assert!(app
+            .current_status_text()
+            .contains("Cleared all price alerts (2)"));
     }
 
     #[test]


### PR DESCRIPTION


- Implement Watchlist price threshold alerts (flashing status bar and terminal bell).
- Add price alert serialization/deserialization to config.toml on app exit/launch.
- Add Shift-C watchlist shortcut to bulk-clear all configured alerts.
- Ignore Crossterm key release events to fix double-input bugs on Windows.
- Use rpassword::read_password() on Windows to fix stdin hang at keychain prompt.
- Filter out non-positive prices during closed market hours to enable correct backups.
- Add end-to-end integration tests for alerts, modal UI flow, and clear-all shortcut.

fixes #101 