### PR TITLE
docs: refresh documentation and release notes for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ This project does not use semantic versioning — releases are tagged by date.
 
 ---
 
+## [0.8.0] — 2026-07-12
+
+Adds bracket order support, extended order types (Stop / Stop-Limit / Trailing Stop / Extended Hours), watchlist price alerts with persistence, an in-app Preferences modal with keychain-backed Credentials management, a configurable chart marker style, and a three-state stream reconnect indicator. Fixes several zero-price display bugs during closed-market hours, switches to an MIT-only license, and changes `.env` loading to debug builds only. Test count grows from **800 → 1254**.
+
+### Added
+
+#### Orders
+- **Bracket order support** (`src/app.rs`, `src/handlers/commands.rs`, `src/input/modal.rs`, `src/ui/modals.rs`, `src/input/validation.rs`) — order entry modal gains a Bracket checkbox (Market/Limit orders only) that submits entry + take-profit + stop-loss legs atomically via `order_class=bracket`; full directional price validation. (#160, closes #102)
+- **Extended order types** (`src/app.rs`, `src/types.rs`, `src/commands.rs`) — Stop, Stop-Limit, and Trailing Stop (price or percent) order types, plus an Extended Hours flag, replacing the old binary Market/Limit toggle. (#155, closes #94)
+
+#### Watchlist & Alerts
+- **Price threshold alerts** (`src/app.rs`, `src/stream/`, `src/ui/watchlist.rs`, `src/input/watchlist.rs`) — set an above/below price threshold per watchlist symbol; a live quote crossing the threshold flashes the status bar and rings the terminal bell. (#156, #178, closes #101)
+- **Alert persistence** (`src/prefs.rs`, `src/types.rs`) — alerts (including triggered state, so a restart doesn't re-fire an already-acknowledged breach) round-trip through the `[price_alerts]` section of `config.toml`, including symbols with dotted tickers (e.g. `BRK.B`). (#178)
+- **`Shift-C` bulk-clear** (`src/input/watchlist.rs`) — clears all configured alerts at once, gated behind `confirm_watchlist_remove` with a confirmation modal. (#178)
+
+#### Preferences
+- **In-app Preferences modal** (`P` key) (`src/app.rs`, `src/ui/modals.rs`, `src/input/modal.rs`) — edit App, UI, Stream, Notifications, Safety, Proxy, and Credentials sections live; `Ctrl-S` saves and applies immediately. (#170, closes #169)
+- **Credentials section** (`src/credentials.rs`) — manage live and paper Alpaca API key/secret pairs independently from within the app, writing to the OS keychain (macOS Keychain / Windows Credential Store / Linux keyutils). (#170)
+- **Configurable chart marker style** (`src/prefs.rs`) — `chart_marker` preference (`braille` / `dot` / `block` / `bar` / `half_block`) applied to all chart widgets. (#168, closes #147)
+
+#### Charts
+- **Dynamic intraday chart labels** (`src/ui/account.rs`, `src/ui/modals.rs`) — the X-axis end label now reflects the time of the last received bar instead of a hardcoded `"16:00"`; Y-axis min/max price labels added so the price range is readable without the crosshair tooltip. (#161, closes #146)
+
+#### Connectivity
+- **Stream reconnect indicator** (`src/events.rs`, `src/stream/`, `src/ui/dashboard.rs`) — dashboard header differentiates initial loading, active reconnection (with attempt count), and permanent offline states per stream, instead of a single ambiguous warning badge. (#149, closes #76)
+
+#### Library
+- **`AlpacaClient::get_historical_bars`** (`src/client.rs`) — paginated multi-day historical OHLCV bars. (#176, closes #172)
+- **`AlpacaClient::get_order`** (`src/client.rs`) — fetch a single order by ID for efficient fill polling. (#177, closes #173)
+- **`AlpacaClient::get_asset`, `replace_watchlist`, `get_watchlist_by_name`** (`src/client.rs`) — additional REST client coverage. (#150)
+
+### Changed
+- **License: MIT-only** — dropped the Apache-2.0 dual-license option; `Cargo.toml`, `LICENSE.md`, `README.md`, `CONTRIBUTING.md`, and `docs/licensing.md` updated accordingly, `LICENSE-APACHE` removed. (#162)
+- **`.env` loading is debug-build only** (`src/main.rs`) — `#[cfg(debug_assertions)]` replaces the `dev-env` feature flag, so `.env` loads transparently in `cargo build` without extra flags; release builds rely on environment variables, OS keychain, or the interactive prompt only. (#163)
+- **Unified Symbol Detail / Position Detail modal layout** (`src/ui/modals.rs`) — both modals now share a single `render_detail_modal` implementation and layout, giving Position Detail feature parity with Symbol Detail (OHLCV row, crosshair, asset flags) and vice versa (position summary, open orders pane). (#171, closes #148)
+
+### Fixed
+- **Zero prices during closed-market hours** (`src/app.rs`, `src/ui/positions.rs`, `src/ui/modals.rs`) — watchlist, positions, equity chart, and symbol/position detail modals now filter out non-positive live quotes and fall back to the last known REST price instead of showing `$0.00` or a false equity cliff. (#178)
+- **Windows double-input on key release** (`src/main.rs`) — Crossterm key-release events are now ignored, fixing duplicate keystrokes on Windows terminals. (#178)
+- **Windows keychain prompt stdin hang** (`src/credentials.rs`) — `rpassword::read_password()` used uniformly (not split by `#[cfg(target_os = "windows")]`) for the non-echoed y/n keychain-save prompt. (#178)
+- **Proxy config no longer erased on exit** (`src/prefs.rs`) — `to_toml_string()` now round-trips `[proxy]` `http`/`socks5`/`no_proxy` fields instead of emitting a hardcoded comment template that a later unconditional `write_to` call would silently overwrite.
+
+[0.8.0]: https://github.com/arunkumar-mourougappane/alpaca-trader-rs/compare/v0.7.1...v0.8.0
+
+---
+
 ## [0.7.1] — 2026-05-22
 
 Patch release fixing TUI sluggishness during market hours. No new features or breaking changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpaca-trader-rs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "alpaca-trader-rs"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.88"
-authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]
+authors = [
+    "Arunkumar Mourougappane <amouroug.dev@gmail.com>",
+    "Samyak Gangwal <sam.gangwal97@gmail.com>",
+]
 license = "MIT"
 description = "Alpaca Markets trading toolkit — async REST client library and interactive TUI trading terminal"
 repository = "https://github.com/arunkumar-mourougappane/alpaca-trader-rs"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 | Watchlist panel — Volume, Change%, live search | ✅ |
 | Positions panel — totals footer, column sorting, position detail modal | ✅ |
 | Orders panel — Open/Filled/Cancelled sub-tabs, column sorting, symbol filter | ✅ |
-| Order Entry modal — Side, Type, TIF dropdowns | ✅ |
-| Symbol Detail modal — OHLCV, intraday chart, watchlist toggle | ✅ |
+| Order Entry modal — Side, Type (Market/Limit/Stop/Stop-Limit/Trailing Stop), TIF, Extended Hours | ✅ |
+| Bracket orders — take-profit and stop-loss legs on Market/Limit orders | ✅ |
+| Watchlist price alerts — above/below threshold, status flash + terminal bell, persisted to disk | ✅ |
+| Symbol Detail / Position Detail modal — OHLCV, intraday chart, crosshair, asset flags, watchlist toggle | ✅ |
 | Global symbol search (Ctrl-F / `/`) | ✅ |
+| In-app Preferences modal (`P`) — App, UI, Stream, Notifications, Safety, Proxy, and Credentials sections | ✅ |
+| Configurable chart marker style (braille / dot / block / bar / half-block) | ✅ |
+| Stream status indicator — loading / reconnecting (with attempt count) / offline per stream | ✅ |
 | Help and About overlays | ✅ |
 | Mouse — row selection, double-click to open detail, click outside to dismiss | ✅ |
 | Runtime colour theme switching (`T`) | ✅ |
@@ -57,8 +62,9 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 |---|---|
 | Typed async REST client (`AlpacaClient`) | ✅ |
 | WebSocket market data + account/trade streaming | ✅ |
-| Live order submission and cancellation | ✅ |
-| Watchlist add / remove | ✅ |
+| Live order submission and cancellation, single-order lookup | ✅ |
+| Multi-day historical OHLCV bars (paginated) | ✅ |
+| Watchlist add / remove / replace, asset lookup | ✅ |
 
 ### Infrastructure
 
@@ -68,10 +74,11 @@ An Alpaca Markets trading toolkit for Rust — ships as both an **integratable l
 | `--dry-run` mode — simulate orders without sending to Alpaca | ✅ |
 | OS-native keychain credential storage | ✅ |
 | Interactive first-run credential prompt | ✅ |
+| `.env` loading in debug builds; release builds use env vars / keychain / prompt only | ✅ |
 | Persistent user preferences (TOML config file) | ✅ |
 | Windows, macOS, and Linux support | ✅ |
 | GitHub Actions CI, security audit, Codecov, release builds | ✅ |
-| 800 tests (unit + integration) | ✅ |
+| 1254 tests (unit + integration) | ✅ |
 
 ---
 
@@ -163,8 +170,9 @@ alpaca-trader --reset live    # remove live keychain entries
 | `/` · `Ctrl-F` | Search (watchlist filter on Watchlist tab; global search on all others) |
 | `s` / `S` | Cycle sort column / toggle direction (Positions & Orders) |
 | `f` | Symbol filter (Orders panel) |
+| `A` / `Shift-C` | Set price alert · clear all alerts (Watchlist panel) |
 | `←`/`→` · `p` | Chart crosshair · cycle range 1D/1W/1M/YTD (Account panel) |
-| `r` · `T` · `?`/`A` | Refresh · theme · Help/About |
+| `r` · `T` · `P` · `?` / `A` | Refresh · theme · Preferences · Help/About (`A` outside Watchlist) |
 | `Esc` | Dismiss modal / clear filter |
 | `q` / `Ctrl-C` | Quit |
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,57 +1,115 @@
-# Release Notes — v0.7.1
+# Release Notes — v0.8.0
 
-**Release date:** 2026-05-22
+**Release date:** 2026-07-12
 **MSRV:** Rust 1.88+
-**Previous release:** [v0.7.0](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.7.0)
+**Previous release:** [v0.7.1](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/releases/tag/v0.7.1)
 
 ---
 
 ## Overview
 
-v0.7.1 is a patch release fixing a responsiveness regression during market hours.
-No new features or breaking changes.
+v0.8.0 is a major feature release focused on order flexibility, watchlist alerting, and in-app configuration. The headline changes are:
+
+1. **Bracket Orders** — submit entry + take-profit + stop-loss legs atomically from Order Entry
+2. **Extended Order Types** — Stop, Stop-Limit, and Trailing Stop join Market/Limit, plus an Extended Hours flag
+3. **Watchlist Price Alerts** — set an above/below threshold per symbol; crossing it flashes the status bar and rings the terminal bell, and alerts persist across restarts
+4. **In-App Preferences Modal** — edit every setting, including live/paper API credentials against the OS keychain, without leaving the app
+5. **Configurable Chart Marker** — choose braille, dot, block, bar, or half-block rendering for all charts
+6. **Dynamic Intraday Chart Labels** — x-axis end label reflects the last received bar; y-axis shows min/max price
+7. **Stream Reconnect Indicator** — header distinguishes loading, reconnecting (with attempt count), and permanently offline per stream
+8. **Unified Symbol/Position Detail Modal** — both detail modals now share one implementation and have full feature parity
+9. **License simplified to MIT-only**
+10. **`.env` loads automatically in debug builds only** — no feature flag needed; release builds are unaffected
+
+Test count grows from **800 → 1254 tests**.
+
+---
+
+## What's New
+
+### Bracket Orders
+
+Order Entry gains a **Bracket** checkbox, available for Market and Limit orders on BUY/SELL (not SellShort) sides.
+Enabling it reveals **Take Profit $** and **Stop Loss $** fields, plus an optional **Stop Loss Limit $** (leave blank for a market SL leg, or fill it in for a stop-limit SL leg).
+All three legs submit atomically via `order_class=bracket`. Directional validation catches an invalid TP/SL relative to the entry price before submission.
+
+### Extended Order Types
+
+The order Type field now cycles through **Market, Limit, Stop, Stop-Limit, and Trailing Stop** (by price or percent), replacing the old binary Market/Limit toggle. An **Extended Hours** flag is available for eligible Limit + Day orders.
+
+### Watchlist Price Alerts
+
+Press `A` on a Watchlist row to set an above/below price threshold. When a live quote crosses it, the status bar flashes and the terminal bell rings; a `🔔` marker appears next to symbols with an active alert.
+Alerts — including whether they've already fired — are saved to `config.toml`, so a restart won't replay an already-acknowledged crossing.
+`Shift-C` clears all configured alerts at once, gated behind a confirmation modal when `confirm_watchlist_remove` is enabled.
+
+### In-App Preferences Modal (`P`)
+
+A full-screen Preferences editor covers App, UI, Stream, Notifications, Safety, Proxy, and Credentials sections. Changes apply on `Ctrl-S`; `Esc` discards.
+The **Credentials** section manages live and paper Alpaca API key/secret pairs independently, writing to the OS-native keychain (macOS Keychain / Windows Credential Store / Linux keyutils) — values are never written to `config.toml`.
+
+### Configurable Chart Marker
+
+A new `chart_marker` preference (`braille` / `dot` / `block` / `bar` / `half_block`) controls the rendering style of every chart in the app, set from the Preferences UI section.
+
+### Dynamic Intraday Chart Labels
+
+The intraday chart's x-axis end label now reflects the timestamp of the last received bar (e.g. `11:47` mid-session) instead of always showing `16:00`. Y-axis min/max price labels were added so the visible price range is readable without opening the crosshair tooltip.
+
+### Stream Reconnect Indicator
+
+The dashboard header now differentiates three states per stream: initial loading, actively reconnecting (with attempt count), and permanently offline — replacing a single ambiguous warning badge.
+
+### Unified Symbol Detail / Position Detail Modal
+
+Both modals now render through a single shared implementation. Position Detail gained OHLCV, crosshair, and asset-flag rows it previously lacked; Symbol Detail gained the position-summary and open-orders panes when the symbol is held.
 
 ---
 
 ## Bug Fixes
 
-### TUI Sluggishness During Market Hours (Closes #143)
+- **Zero prices during closed-market hours** — watchlist, positions, the equity chart, and detail modals now filter out non-positive live quotes and fall back to the last known REST price instead of showing `$0.00` or a false equity cliff.
+- **Windows double-input on key release** — Crossterm key-release events are now ignored, fixing duplicate keystrokes on Windows terminals.
+- **Windows keychain prompt stdin hang** — the non-echoed y/n keychain-save prompt now uses `rpassword::read_password()` uniformly across platforms instead of a Windows-only code path that could hang.
+- **Proxy config erased on exit** — `config.toml`'s `[proxy]` section (`http`, `socks5`, `no_proxy`) now round-trips correctly instead of being silently overwritten with a blank template on clean exit.
+- **Dotted ticker symbols (e.g. `BRK.B`) dropped from alerts on reload** — the `[price_alerts]` TOML key is now quoted, avoiding a dotted-key misparse.
 
-**Problem:** The TUI became sluggish and unresponsive to keyboard input during market hours.
+---
 
-**Root cause:** The main loop called `terminal.draw()` on every event — including every
-`MarketQuote` arriving from the WebSocket stream. With many symbols subscribed, quote events
-arrive at high frequency, triggering continuous full re-renders that starved keyboard input.
+## Changed
 
-**Fix:** Added a non-blocking drain loop after processing the first event. All queued events
-are consumed in a single pass before the next `terminal.draw()`, decoupling render rate from
-quote arrival rate.
+- **License: MIT-only** — the Apache-2.0 dual-license option has been dropped. `Cargo.toml`, `LICENSE.md`, `README.md`, `CONTRIBUTING.md`, and `docs/licensing.md` are updated accordingly; `LICENSE-APACHE` has been removed. If you depended on the Apache-2.0 terms, only MIT applies going forward.
+- **`.env` loading is debug-build only** — `.env` now loads automatically in `cargo build` (debug) without any feature flag. Release builds — including installed/pre-compiled binaries — do **not** read `.env`; use environment variables, the OS keychain, or the interactive credential prompt instead.
 
-```rust
-// Before: one render per event (N quotes = N renders per frame)
-// After: drain all queued events, then render once
-while let Ok(event) = rx.try_recv() {
-    update(&mut app, event);
-    if app.should_quit { break; }
-}
-```
+---
 
-N quote events between frames now costs **1 render** instead of N renders. Keyboard input
-remains responsive regardless of quote volume or number of subscribed symbols.
+## Documentation
+
+- **`docs/architecture.md`** — directory tree now includes the previously undocumented `src/handlers/` module (REST polling, command dispatch, input event stream).
+- **`docs/ui-mockups.md`** — Order Entry mockup updated with bracket/extended-type fields; Symbol/Position Detail mockups merged and updated with dynamic axis labels; Preferences Credentials section mockup added; Watchlist alert UI documented.
+- **`docs/future-features.md`** — Price Alerts marked ✅ Implemented; related-issues table extended to cover all v0.8.0 issues.
+- **`docs/testing.md`** — test counts and binary breakdown updated to match the current suite.
 
 ---
 
 ## Tests
 
-**800 tests** (unchanged from v0.7.0) — this patch contains no new logic paths requiring
-additional test coverage.
+**1254 tests total** (up from 800 in v0.7.1):
+
+| Scope | Count |
+|---|---|
+| Library (`src/lib.rs`: `types`, `config`, `stream`, `prefs`, `logging`) | 134 |
+| App (`src/main.rs`: `app`, `update`, `input/*`, `ui/*`, `handlers/*`) | 1090 |
+| HTTP integration (`tests/client_tests.rs`) | 29 |
+| Doc-tests | 1 |
 
 ---
 
-## No Breaking Changes
+## Upgrade Notes
 
-v0.7.1 is fully backwards-compatible with v0.7.0. All CLI flags, credential resolution,
-environment variables, key bindings, and library API are unchanged.
+- If you rely on `.env` for credentials in a **release** build or installed binary, switch to environment variables, the OS keychain (`P` → Credentials, or the first-run prompt), or a `.env` loaded manually before launch — release builds no longer read `.env` automatically.
+- If your tooling references the Apache-2.0 license text, note the project is now MIT-only.
+- Existing `config.toml` files are read without modification; new keys (`chart_marker`, `[price_alerts]`, Preferences sections) default sensibly if absent.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,11 @@ alpaca-trader-rs/
 │   ├── credentials.rs      # 4-tier credential resolution (env → keychain → prompt)
 │   ├── clipboard.rs        # Cross-platform clipboard write helper
 │   ├── logging.rs          # File + syslog tracing subscriber setup
+│   ├── handlers/
+│   │   ├── mod.rs          # Re-exports commands, input, rest handlers
+│   │   ├── rest.rs         # Background REST polling loop → Event channel
+│   │   ├── commands.rs     # Command → REST/WS side-effect dispatch (order submission, cancels, etc.)
+│   │   └── input.rs        # Terminal input stream → Event channel (crossterm EventStream)
 │   ├── input/
 │   │   ├── mod.rs          # Shared nav helper (j/k/g/G) and key() / ctrl() factories
 │   │   ├── modal.rs        # Key handler for all modal states

--- a/docs/future-features.md
+++ b/docs/future-features.md
@@ -27,13 +27,8 @@ Add a new panel (tab `5`) showing all closed orders with per-trade P&L, filterab
 
 ---
 
-### Price Alerts / Triggers
-Allow the user to set a price threshold for any symbol. When the live quote crosses the threshold the TUI flashes a notification and rings the terminal bell.
-
-- **Storage**: in-memory `HashMap<Symbol, AlertThreshold>` (persisted to config file when #61 lands)
-- **Trigger**: evaluated in the market stream handler on each quote tick
-- **UI**: `A` key in Watchlist panel → "Set Alert" modal; active alerts shown with `🔔` marker in the watchlist row
-- **Files**: `src/app.rs`, `src/stream/`, `src/ui/watchlist.rs`, new `src/input/alerts.rs`
+### ~~Price Alerts / Triggers~~ — ✅ Implemented (v0.8.0, #156, #178, closes #101)
+Users can set an above/below price threshold for any watchlist symbol; a crossing quote flashes the status bar and rings the terminal bell. Alerts (including whether they've already fired) persist to `config.toml` across restarts, and `Shift-C` bulk-clears all alerts. See `docs/ui-mockups.md` (Panel 2 — Watchlist) for the current UI.
 
 ---
 
@@ -127,3 +122,15 @@ Filter the full universe of tradeable symbols by criteria (price range, volume, 
 | [#60](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/60) | `--dry-run` flag to simulate order submissions | ✅ Implemented |
 | [#61](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/61) | Persist user preferences to `~/.config/alpaca-trader/config.toml` | ✅ Implemented |
 | [#62](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/62) | Theme switching (default / dark / high-contrast) via `T` key | ✅ Implemented |
+| [#76](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/76) | Distinguish stream reconnecting from permanently offline in header | ✅ Implemented (v0.8.0, #149) |
+| [#94](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/94) | Extended order types: Stop, Stop-Limit, Trailing Stop, Extended Hours | ✅ Implemented (v0.8.0, #155) |
+| [#101](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/101) | Watchlist price alerts (threshold notification + bell) | ✅ Implemented (v0.8.0, #156, #178) |
+| [#102](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/102) | Bracket order support (take-profit + stop-loss legs) | ✅ Implemented (v0.8.0, #160) |
+| [#146](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/146) | Intraday chart: hardcoded `16:00` x-axis label misleading mid-session | ✅ Implemented (v0.8.0, #161) |
+| [#147](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/147) | Configurable chart marker style | ✅ Implemented (v0.8.0, #168) |
+| [#148](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/148) | Unify Symbol Detail / Position Detail modal layout | ✅ Implemented (v0.8.0, #171) |
+| [#162](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/162) | Switch from MIT OR Apache-2.0 dual license to MIT only | ✅ Implemented (v0.8.0) |
+| [#163](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/163) | `.env` loading should work in debug builds without a feature flag | ✅ Implemented (v0.8.0) |
+| [#169](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/169) | In-app Preferences modal with Credentials management | ✅ Implemented (v0.8.0, #170) |
+| [#172](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/172) | Library: multi-day historical OHLCV bars with pagination | ✅ Implemented (v0.8.0, #176) |
+| [#173](https://github.com/arunkumar-mourougappane/alpaca-trader-rs/issues/173) | Library: fetch a single order by ID | ✅ Implemented (v0.8.0, #177) |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,14 +2,14 @@
 
 Test coverage strategy, mock patterns, crate rationale, and test case inventory for `alpaca-trader-rs`.
 
-**Current state: 800 tests implemented and passing** (`cargo test`).
+**Current state: 1254 tests implemented and passing** (`cargo test`).
 
 | Binary | Count | Scope |
 |---|---|---|
-| `lib` (unit + UI) | 670 | `types`, `config`, `app`, `update`, `input/*`, `ui/*` — state logic, keyboard dispatch, render coverage |
-| `bin` (integration) | 100 | `AlpacaClient` — all HTTP methods via wiremock |
-| `bin` (doc tests) | 29 | Inline `# Example` blocks in public API docs |
-| `bin` (smoke) | 1 | Basic smoke test |
+| `lib` (`src/lib.rs`) | 134 | `types`, `config`, `stream`, `prefs`, `logging` — library-level unit and integration tests |
+| `bin` (`src/main.rs`) | 1090 | `app`, `update`, `input/*`, `ui/*`, `handlers/*` — app state logic, keyboard dispatch, render coverage |
+| `tests/client_tests.rs` (integration) | 29 | `AlpacaClient` — all HTTP methods via wiremock |
+| Doc tests | 1 | Inline `# Example` blocks in public API docs |
 
 ---
 

--- a/docs/ui-mockups.md
+++ b/docs/ui-mockups.md
@@ -77,8 +77,9 @@ Every screen shares this outer chrome:
 │  GLW     Corning Incorporated           $47.18    -0.18%       3.2M         │
 │  QCOM    QUALCOMM                      $168.40    +0.72%       6.8M         │
 │  TSM     Taiwan Semiconductor          $182.15    +1.15%       7.3M         │
+│▶ HOOD 🔔 Robinhood Markets              $28.63    +3.41%       8.9M         │
 │                                                                              │
-│ a:Add  d:Remove  Enter:Detail  /:Search                                     │
+│ a:Add  d:Remove  Enter:Detail  /:Search  A:Alert  Shift-C:Clear Alerts      │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -86,6 +87,10 @@ Every screen shares this outer chrome:
 - Price and Change: green if positive, red if negative
 - Prices update live from WebSocket `Event::MarketQuote`
 - `/` opens an inline search bar above the table header that filters rows by symbol as you type
+- `🔔` marker shown next to a symbol with an active price alert (above and/or below threshold configured)
+- `A` opens the **Set Alert** modal for the selected symbol (above / below price threshold); when an alert threshold is crossed, the status bar flashes and the terminal bell rings
+- `Shift-C` bulk-clears all configured alerts; gated behind a confirmation modal when `confirm_watchlist_remove` is enabled
+- Alerts (including whether they've already fired) persist to `config.toml` across restarts
 
 ---
 
@@ -150,8 +155,15 @@ Triggered by `o` from any panel. Pre-fills Symbol if a row is selected.
 ║  Symbol  [ AMD            ]              ║
 ║  Side    ( ● BUY )  ( ○ SELL )          ║
 ║  Type    [ LIMIT  ▾       ]              ║
+║          (Market/Limit/Stop/StopLimit/   ║
+║           TrailingStop)                  ║
 ║  Qty     [ 10             ]              ║
 ║  Price   [ 141.00         ]  (limit only)║
+║  Extended Hours  [ ]                     ║
+║  Bracket         [x]  (Market/Limit only)║
+║  Take Profit $   [ 150.00       ]        ║
+║  Stop Loss $     [ 135.00       ]        ║
+║  Stop Loss Limit $ [            ] (opt.) ║
 ║                                          ║
 ║  ─────────────────────────────────────   ║
 ║  Est. Total    $1,410.00                 ║
@@ -165,16 +177,20 @@ Triggered by `o` from any panel. Pre-fills Symbol if a row is selected.
 
 **Behavior:**
 - Price field is hidden / greyed when Type = MARKET
+- Stop Price / Trail Amount + Trail Mode (Price/Percent) rows appear for Stop, Stop-Limit, and Trailing Stop types respectively
+- Extended Hours toggle is only valid for Limit + Day TIF combinations; validation blocks submission otherwise
+- Bracket checkbox appears only for Market/Limit order types and BUY/SELL (not SellShort) side; toggling it reveals Take Profit $ and Stop Loss $ fields, plus an optional Stop Loss Limit $ (blank = market SL leg, filled = stop-limit SL leg)
+- Bracket validation enforces price direction (e.g. for a buy: TP above SL and above the limit entry price; SL below the limit entry price); a validation error keeps the modal open
 - Est. Total recalculates as Qty and Price change
 - Buying Power indicator: green `✓ sufficient` / red `✗ insufficient`
 - Submit button is disabled (dimmed) when buying power is insufficient or required fields are empty
-- `Tab` / `Shift-Tab` moves focus between fields; focused field has a highlighted border
+- `Tab` / `Shift-Tab` moves focus between fields (skipping hidden ones); focused field has a highlighted border
 
 ---
 
-## Modal — Symbol Detail
+## Modal — Symbol Detail / Position Detail
 
-Triggered by `Enter` on a **Watchlist** row.
+Both modals share a single unified layout (`render_detail_modal`, 60 × 92% of the terminal). **Symbol Detail** is triggered by `Enter` on a **Watchlist** row; **Position Detail** by `Enter` on a **Positions** row. Position Detail additionally shows a position-summary + open-orders section when the symbol is held; Symbol Detail shows it only if the searched symbol happens to be held too.
 
 ```
 ╔═ AMD — Advanced Micro Devices ═══════════╗
@@ -184,49 +200,32 @@ Triggered by `Enter` on a **Watchlist** row.
 ║  Low     $140.85    Volume  28.7M        ║
 ║                                          ║
 ║  ── Intraday ──────────────────────────  ║
+║  $143.20 ┐                               ║
 ║  ⠀⠀⠀⢀⣀⠤⠤⢄⡀⠀⠀⠀⣀⡠⠔⠒⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ║
 ║  ⡠⠒⠉⠀⠀⠀⠀⠀⠈⠑⠒⠊⠀⠀⠀⠀⠀⠀⠀⠙⠒⠤⣀⣀⡠⠔⠉⠁⠀  ║
-║  09:30                             16:00 ║
+║  $140.85 ┘                               ║
+║  09:30                             11:47 ║
 ║                                          ║
 ║  Exchange    NASDAQ   Class    us_equity ║
 ║  Tradable    ✓        Shortable ✓        ║
 ║  Fractionable ✓       ETB      ✓        ║
+║                                          ║
+║  ── Position (if held) ──────────────    ║
+║  Qty 50  Avg Cost $138.20  P&L +$232.50  ║
+║  ── Open Orders ──────────────────────   ║
+║  a3f2… BUY 10 LIMIT $141.00 PENDING      ║
 ║                                          ║
 ║  o:Buy  s:Sell  w:Toggle Watchlist  Esc  ║
 ╚══════════════════════════════════════════╝
 ```
 
 - Price and Change update live from WebSocket while modal is open
-- `w` adds/removes symbol from the watchlist (toggles)
+- `w` adds/removes symbol from the watchlist (toggles); `s` opens Order Entry pre-filled SELL (Position Detail and, since the layout unification, Symbol Detail too)
 - Asset flags (`Tradable`, `Shortable`, `ETB`, `Fractionable`) sourced from watchlist asset data
-- Intraday chart: rendered as a **no-fill line chart** using `ratatui::widgets::Chart` with `GraphType::Line` and `Marker::Braille`; x-axis bounds = `[0.0, total_bars]`, y-axis auto-scaled to data min/max
-
----
-
-## Modal — Position Detail
-
-Triggered by `Enter` on a **Positions** row.
-
-```
-╔═ AMD — Position Detail ══════════════════╗
-║                                          ║
-║  Qty       50       Avg Cost  $138.20    ║
-║  Cur Price $142.85  Mkt Value $7,142.50  ║
-║  Unrealized P&L     +$232.50  (+3.36%)   ║
-║                                          ║
-║  ── Intraday ──────────────────────────  ║
-║  ⠀⠀⠀⢀⣀⠤⠤⢄⡀⠀⠀⠀⣀⡠⠔⠒⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ║
-║  ⡠⠒⠉⠀⠀⠀⠀⠀⠈⠑⠒⠊⠀⠀⠀⠀⠀⠀⠀⠀⠙⠒⠤⣀⣀⡠⠔⠉⠁⠀  ║
-║  09:30                             16:00 ║
-║                                          ║
-║  o:New Order                        Esc  ║
-╚══════════════════════════════════════════╝
-```
-
-- Distinct from **Symbol Detail** — shows held-position metrics (Qty, Avg Cost, Unrealized P&L) rather than asset metadata
-- Intraday chart fetched via `Command::FetchIntradayBars` on open; same `Chart` widget as Symbol Detail
-- `o` opens Order Entry pre-filled with the position's symbol (SELL side)
-- `Esc` dismisses; no `s`, `w` actions (those belong to Symbol Detail only)
+- Intraday chart: rendered as a **no-fill line chart** using `ratatui::widgets::Chart` with `GraphType::Line` and a configurable marker (`chart_marker` preference; braille by default)
+- **X-axis end label is dynamic** — reflects the timestamp of the last received bar (e.g. `11:47` mid-session) rather than always showing `16:00`; a full day's bars still show `16:00`
+- **Y-axis min/max price labels** — the chart's low/high price for the visible range is printed directly on the axis, so the price scale is readable without needing the crosshair
+- `←`/`→` moves a crosshair over the chart with a tooltip showing the date/time and price at that point (both modals, since the unification in #171)
 
 ---
 
@@ -251,21 +250,24 @@ Triggered by `?` from any context.
 ║  c    Cancel selected order              ║
 ║  a    Add symbol to watchlist            ║
 ║  d    Remove symbol from watchlist       ║
+║  A    Set price alert (Watchlist)        ║
+║  Shift-C  Clear all price alerts         ║
 ║  r    Force refresh                      ║
 ║  s/S  Cycle / toggle sort column/dir     ║
 ║  f    Filter orders by symbol            ║
 ║  p    Toggle equity range (1D/1W/1M/YTD) ║
 ║  Ctrl-F / /  Global symbol search        ║
 ║                                          ║
-║  ACCOUNT CHART                           ║
+║  ACCOUNT / DETAIL CHART                  ║
 ║  ←/h / →/l  Move crosshair              ║
 ║  Esc         Clear crosshair             ║
 ║                                          ║
 ║  GLOBAL                                  ║
 ║  q / Ctrl-C   Quit                       ║
 ║  T            Cycle theme                ║
+║  P            Open Preferences           ║
 ║  ?            This help screen           ║
-║  A            About this app             ║
+║  A            About this app (non-Watchlist)║
 ║                                          ║
 ║             Press any key to close       ║
 ╚══════════════════════════════════════════╝
@@ -280,7 +282,7 @@ Triggered by `A` (uppercase) from any context. Displays app metadata, author inf
 ```
 ╔═ About alpaca-trader-rs ══════════════════╗
 ║                                           ║
-║   alpaca-trader-rs  v0.6.0                ║
+║   alpaca-trader-rs  v0.8.0                ║
 ║                                           ║
 ║   Alpaca Markets TUI trading terminal     ║
 ║   and async REST client library.          ║
@@ -339,8 +341,9 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `q` / `Ctrl-C` | Quit |
 | `r` | Force REST re-poll |
 | `T` | Cycle theme (default → dark → high-contrast) |
+| `P` | Open Preferences modal |
 | `?` | Toggle help overlay |
-| `A` | Open About modal |
+| `A` (non-Watchlist) | Open About modal |
 | `Ctrl-F` / `/` (non-Watchlist) | Open global symbol search modal |
 | `Esc` | Close any open modal |
 
@@ -361,6 +364,8 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `a` | Open Add Symbol text input |
 | `d` | Remove selected symbol (confirmation prompt) |
 | `/` | Focus inline search bar; filters rows as you type |
+| `A` | Open Set Alert modal for the selected symbol (above/below price threshold) |
+| `Shift-C` | Clear all configured price alerts (confirmation prompt if `confirm_watchlist_remove` is enabled) |
 
 ### Positions Panel
 
@@ -401,21 +406,17 @@ All values are baked in at `cargo build` time — no runtime file I/O needed.
 | `Enter` | Advance to next field; submit when Submit button is focused |
 | `Esc` | Close modal without submitting |
 
-### Symbol Detail Modal (Watchlist)
+### Symbol Detail Modal (Watchlist) & Position Detail Modal (Positions)
+
+Since the layout unification (#171), both modals accept the same key set:
 
 | Key | Action |
 |-----|--------|
 | `o` | Open Order Entry pre-filled with symbol (BUY) |
 | `s` | Open Order Entry pre-filled with symbol (SELL) |
 | `w` | Toggle symbol in/out of the active watchlist |
-| `Esc` | Close modal |
-
-### Position Detail Modal (Positions)
-
-| Key | Action |
-|-----|--------|
-| `o` | Open Order Entry pre-filled with symbol (SELL) |
-| `Esc` | Close modal |
+| `←`/`→` | Move intraday chart crosshair |
+| `Esc` | Close modal (also clears any active crosshair) |
 
 ---
 
@@ -456,6 +457,7 @@ explicit save (`Ctrl-S` or `Enter` on the Save button).
 ║  │  Notifications  │  │                                          │   ║
 ║  │  Safety         │  │                                          │   ║
 ║  │  Proxy          │  │                                          │   ║
+║  │  Credentials    │  │                                          │   ║
 ║  └─────────────────┘  └──────────────────────────────────────── ┘   ║
 ║                                                                      ║
 ║  Tab:Next Section  ↑/↓:Move Field  Enter:Edit  Ctrl-S:Save  Esc:Cancel ║
@@ -524,6 +526,32 @@ explicit save (`Ctrl-S` or `Enter` on the Save button).
 ║  Tab:Next Section  ↑/↓:Move Field  Enter:Edit  Ctrl-S:Save  Esc:Cancel ║
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
+
+### Credentials section
+
+```
+╔═ Preferences ════════════════════════════════════════════════════════╗
+║                                                                      ║
+║  ┌─ Sections ──────┐  ┌─ Credentials ──────────────────────────┐   ║
+║  │  App            │  │                                          │   ║
+║  │  UI             │  │  [LIVE]  APCA-API-KEY-ID    [ ●●●●●●●● ] │   ║
+║  │  Stream         │  │  [LIVE]  APCA-API-SECRET    [ ●●●●●●●● ] │   ║
+║  │  Notifications  │  │  [PAPER] APCA-API-KEY-ID    [ not set  ] │   ║
+║  │  Safety         │  │  [PAPER] APCA-API-SECRET    [ **‸       ] │   ║
+║  │  Proxy          │  │                                          │   ║
+║  │▶ Credentials    │  │                                          │   ║
+║  └─────────────────┘  └──────────────────────────────────────── ┘   ║
+║                                                                      ║
+║  Tab:Next Section  ↑/↓:Move Field  Enter:Edit  Ctrl-S:Save  Esc:Cancel ║
+╚══════════════════════════════════════════════════════════════════════╝
+```
+
+- Saved keychain values render as `●` (masked); a value being typed in the current edit session renders as `*`; an unset field shows `[ not set ]`
+- `[LIVE]` and `[PAPER]` key/secret pairs are validated independently on `Ctrl-S` — submitting a key without its matching secret (or vice versa) shows a red per-env error banner and keeps the modal open
+- Both env pairs can be updated in the same save; only the currently-active env's in-memory `AlpacaConfig` key/secret is synced immediately, the other is written to the keychain for use on next switch
+- Values are written via `credentials::save_to_keychain()` to the OS-native store (macOS Keychain / Windows Credential Store / Linux keyutils) — never persisted to `config.toml`
+
+---
 
 ### Unsaved changes indicator
 


### PR DESCRIPTION
## Summary

Full documentation and release-notes refresh for the v0.8.0 release, closing #164.

- `CHANGELOG.md` — new `[0.8.0]` entry covering every user-facing change since v0.7.1 (bracket orders #160, extended order types #155, watchlist price alerts #156/#178, Preferences modal + Credentials management #170, configurable chart marker #168, dynamic intraday chart labels #161, stream reconnect indicator #149, new client library methods #150/#176/#177, MIT-only license #162, debug-only `.env` loading #163, unified Symbol/Position Detail modal #171, and closed-market/Windows/proxy fixes from #178) — expanded beyond the issue's original 4-PR list since several more features landed before this refresh
- `RELEASE_NOTES.md` — rewritten for v0.8.0 following the repo's existing per-release format
- `Cargo.toml` — version bumped to `0.8.0`; added Samyak Gangwal as a contributor
- `README.md` — feature tables, key bindings, and test count (1254) updated
- `docs/architecture.md` — directory tree gained the previously undocumented `src/handlers/` module
- `docs/ui-mockups.md` — bracket order fields, extended order types, unified Symbol/Position Detail modal, dynamic chart axis labels, Preferences Credentials section, watchlist alert UI
- `docs/future-features.md` — Price Alerts marked implemented; related-issues table extended
- `docs/testing.md` — test breakdown updated to match the current suite
- `docs/licensing.md` — verified already correct, no changes needed

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 1254 passed, 0 failed

Closes #164